### PR TITLE
fix(agent): run the agent-runtime integration tests on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,24 +39,9 @@ fingerprint. Several refinements are deliberately left open and marked
   whether the agent service is running. A check that handles systemd /
   OpenRC / runit would be useful (systemd unit ships in
   `packaging/systemd/sigil.service`).
-- **Packaging.** `.deb` / `.rpm` build recipes (only the systemd unit ships
-  today).
 
 Linux runtime tests run in CI on `ubuntu-22.04`, so platform-specific test
 gaps in the existing agent integration suite are also fair game.
-
-## Good first contributions — agent
-
-- **Run the agent-runtime tests on Windows CI.** The integration tests that
-  boot the whole agent via `TestAgentBuilder` (`basic_events`, `critical_tier`,
-  `large_file`, `shutdown`) run on macOS and Linux but are
-  `#[cfg_attr(target_os = "windows", ignore)]`: on Windows, `runtime::run`
-  stops right after the hardware-fingerprint step, before the control listener
-  comes up. The tolerant `spawn_watcher` (a single bad watch root no longer
-  kills the agent) didn't change it, so it isn't a per-root error — suspect
-  `RecommendedWatcher::new` (the `ReadDirectoryChangesW` backend) or a hang in
-  it. Reproduce with `SIGIL_LOG=debug cargo test -p sigil-agent --test
-  basic_events` on Windows, fix, and drop the `cfg_attr`.
 
 ## License of Contributions
 

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -266,6 +266,10 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     } else {
         None
     };
+    tracing::info!(
+        roots = watch_roots.len(),
+        "runtime: spawning filesystem watcher"
+    );
     let watcher_handle = watcher::spawn_watcher(
         watch_roots.clone(),
         runtime_handle.clone(),
@@ -274,10 +278,15 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     )?;
     let backend_name = watcher_handle.backend_name;
     let raw_rx = watcher_handle.rx;
+    tracing::info!(
+        backend = backend_name,
+        "runtime: filesystem watcher started"
+    );
 
     let targets = Arc::new(normalizer::compile_targets(&effective, &expanded_paths));
     let mut sup = Supervisor::new();
     let cancel = sup.shutdown.clone();
+    tracing::info!("runtime: spawning pipeline tasks");
 
     sup.track(
         "normalizer",
@@ -471,6 +480,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         );
     }
 
+    tracing::info!("runtime: all tasks spawned; running");
     // Wait for shutdown.
     let exit_code = sup.run(host_id.clone(), tx_sink.clone()).await?;
     Ok(exit_code)

--- a/crates/sigil-agent/tests/basic_events.rs
+++ b/crates/sigil-agent/tests/basic_events.rs
@@ -3,14 +3,6 @@ use common::{policy_for_paths, TestAgentBuilder};
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// macOS + Linux: passes. Windows: `runtime::run` stops right after the
-// hardware-fingerprint step (the tolerant `spawn_watcher` didn't change it, so
-// it's not a per-root error — likely `RecommendedWatcher::new` or a hang in the
-// ReadDirectoryChangesW backend). Tracked follow-up — see CONTRIBUTING.
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "agent-runtime test: not yet hardened for Windows"
-)]
 async fn it_emits_modified_event() {
     let dir = tempfile::tempdir().unwrap();
     let p = dir

--- a/crates/sigil-agent/tests/critical_tier.rs
+++ b/crates/sigil-agent/tests/critical_tier.rs
@@ -3,10 +3,6 @@ use common::{policy_for_paths, TestAgentBuilder};
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "agent-runtime test: not yet hardened for Windows"
-)]
 async fn it_critical_tier_emits_recheck() {
     let dir = tempfile::tempdir().unwrap();
     let target = dir.path().join("config.json");

--- a/crates/sigil-agent/tests/large_file.rs
+++ b/crates/sigil-agent/tests/large_file.rs
@@ -3,10 +3,6 @@ use common::{policy_for_paths, TestAgentBuilder};
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "agent-runtime test: not yet hardened for Windows"
-)]
 async fn it_large_file_emits_incomplete() {
     let dir = tempfile::tempdir().unwrap();
     let target = dir.path().join("big.bin");

--- a/crates/sigil-agent/tests/shutdown.rs
+++ b/crates/sigil-agent/tests/shutdown.rs
@@ -3,10 +3,6 @@ use common::{policy_for_paths, TestAgentBuilder};
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "agent-runtime test: not yet hardened for Windows"
-)]
 async fn it_graceful_shutdown_drains_queue() {
     let dir = tempfile::tempdir().unwrap();
     let target = dir.path().join("x.json");


### PR DESCRIPTION
The four `TestAgentBuilder`-based agent-runtime tests were
`#[cfg_attr(target_os = "windows", ignore)]`. The old "runtime::run stops
after the hardware-fingerprint step" diagnosis was wrong — the agent ran
fine; the globs (compiled from raw policy paths) just never matched the
canonicalized event paths on Windows. The watch-path-prefix canonicalization
fixed that, so these already pass on `windows-2022` CI; drop the `cfg_attr`s.

Closes #1