### PR TITLE
ci(release): build ARM64 Windows (aarch64-pc-windows-msvc) artifact (#39)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
             os: macos-14
           - target: x86_64-pc-windows-msvc
             os: windows-2022
+          - target: aarch64-pc-windows-msvc     # Arm Windows (Surface Pro X, Arm laptops)
+            os: windows-11-arm                   # GitHub-hosted ARM64 runner
     steps:
       - uses: actions/checkout@v5
 
@@ -120,7 +122,8 @@ jobs:
 
           ## Windows
 
-          Download the `.zip` below and add it to your PATH.
+          Download the `.zip` for your architecture (`x86_64` for most PCs,
+          `aarch64` for Arm devices such as Surface Pro X) and add it to your PATH.
 
           Every archive contains all four binaries: `sigil`, `sigil-sender`, `sigil-server`, `sigil-sign`.
           EOF


### PR DESCRIPTION
Adds an ARM64 Windows artifact to the release matrix so the binary validated in #38 (and promised by `docs/install-windows-agent.md`) actually ships.

## Change
- `release.yml`: new matrix entry `aarch64-pc-windows-msvc` on the GitHub-hosted `windows-11-arm` runner — same native-build pattern as `aarch64-apple-darwin` / `macos-14`. The OS-based `Package (Windows)` step already produces the `.zip`; upload/release jobs need no change.
- Release notes: mention per-architecture downloads (`x86_64` for most PCs, `aarch64` for Arm devices).

## Verification
- `release.yml` parses as valid YAML.
- Full verification runs on the next `v*` tag push (this workflow only runs on tags). The native ARM64 build + run of `sigil` is already validated locally on Windows 11 ARM64 (#38).

## Note
Release binaries are not built with `+crt-static` today (pre-existing); a fully self-contained Windows `.exe` (no VC++ redist) is a possible follow-up if desired.

Closes #39
