### PR TITLE
ci(release): publish static sigil-server .rpm/.deb (#42)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,17 @@ jobs:
           cargo deb --no-build
           cargo generate-rpm --output ../../target/generate-rpm/
 
+      # Flatten into one dir so the artifact (and dist/) has the packages at the
+      # root — the release job globs dist/sigil-* non-recursively.
+      - name: Collect packages into a flat dir
+        run: |
+          mkdir -p pkgs
+          cp target/debian/*.deb target/generate-rpm/*.rpm pkgs/
+
       - uses: actions/upload-artifact@v4
         with:
           name: linux-packages
-          path: |
-            target/debian/*.deb
-            target/generate-rpm/*.rpm
+          path: pkgs/*
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,48 @@ jobs:
             sigil-*.zip
           if-no-files-found: error
 
+  packages:
+    name: linux packages (server, static)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl tools + packagers
+        run: |
+          sudo apt-get update && sudo apt-get install -y musl-tools
+          cargo install cargo-deb cargo-generate-rpm
+
+      # Static (musl) binary so the .rpm/.deb run on any glibc — incl. RHEL/Rocky 9.
+      - name: Build static sigil-server
+        run: cargo build --release --locked -p sigil-server --target x86_64-unknown-linux-musl
+
+      - name: Stage binary where the packagers expect it
+        run: |
+          mkdir -p target/release
+          cp target/x86_64-unknown-linux-musl/release/sigil-server target/release/sigil-server
+
+      - name: Build .deb + .rpm
+        working-directory: crates/sigil-server
+        run: |
+          mkdir -p ../../target/generate-rpm
+          cargo deb --no-build
+          cargo generate-rpm --output ../../target/generate-rpm/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-packages
+          path: |
+            target/debian/*.deb
+            target/generate-rpm/*.rpm
+          if-no-files-found: error
+
   release:
     name: publish release
-    needs: build
+    needs: [build, packages]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -126,6 +165,17 @@ jobs:
           `aarch64` for Arm devices such as Surface Pro X) and add it to your PATH.
 
           Every archive contains all four binaries: `sigil`, `sigil-sender`, `sigil-server`, `sigil-sign`.
+
+          ## Server (Linux)
+
+          Run the collector from a prebuilt package (static binary — works on RHEL/Rocky and Debian/Ubuntu). See [docs/install-server.md](https://github.com/Ju571nK/sigil/blob/main/docs/install-server.md).
+
+          ```sh
+          sudo dnf install ./sigil-server-*.x86_64.rpm     # RHEL / Rocky / Fedora
+          sudo apt  install ./sigil-server_*_amd64.deb     # Debian / Ubuntu
+          ```
+
+          Each package ships a hardened, disabled-by-default systemd unit + config example.
           EOF
           # Tags with a pre-release suffix (e.g. v0.1.0-rc.1) are marked
           # --prerelease so they don't become "latest" — install.sh won't pick

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -2316,11 +2316,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "sigil-sender"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -40,21 +40,27 @@ Debian/Ubuntu works via the `.deb` package; deltas are called out inline.
 Pick one. The `.rpm`/`.deb` path is recommended for servers — it ships a
 hardened, disabled-by-default systemd unit and a config example.
 
-### Option A — `.rpm` (RHEL / Rocky / Fedora), recommended
+### Option A — `.rpm` / `.deb` from Releases (RHEL / Rocky / Debian), recommended
+
+Download the package for your distro from the
+[latest release](https://github.com/Ju571nK/sigil/releases/latest). These are
+**static** builds, so they run on any glibc — including RHEL/Rocky 9:
 
 ```sh
-# Build the package on a build host (one-time tooling):
-cargo install cargo-deb cargo-generate-rpm
-packaging/build.sh server rpm
+# RHEL / Rocky / Fedora
+sudo dnf install ./sigil-server-*.x86_64.rpm
 
-# On the server:
-sudo dnf install ./target/generate-rpm/sigil-server-0.1.0-1.x86_64.rpm
+# Debian / Ubuntu
+sudo apt install ./sigil-server_*_amd64.deb
 ```
 
 This installs `/usr/bin/sigil-server`, the unit at
 `/usr/lib/systemd/system/sigil-server.service`, and
-`/etc/sigil/server.yaml.example`. Debian/Ubuntu: build with `packaging/build.sh
-server deb` and `sudo apt install ./...deb`.
+`/etc/sigil/server.yaml.example`.
+
+> Prefer to build the package yourself? `cargo install cargo-deb
+> cargo-generate-rpm && packaging/build.sh server` produces them under
+> `target/debian/` and `target/generate-rpm/`.
 
 You also need `sigil-sign` (operator CLI) on a trusted workstation to produce
 the signed policy bundle — install the `sigil-signer` package or use `install.sh`.


### PR DESCRIPTION
Closes #42.

Makes `sigil-server` installable from Releases without a build — addressing the gap where the *recommended* server install (`install-server.md` Option A) required building the `.rpm`/`.deb` from source.

## Changes
- **`release.yml`**: new `packages` job builds `sigil-server` as a **static (musl)** binary and packages it into `.rpm` + `.deb`, attached as release assets. The release job now `needs: [build, packages]`; the existing `sigil-*` glob + SHA256SUMS pick the packages up automatically.
  - **Static on purpose**: a glibc build on `ubuntu-22.04` (glibc 2.35) would *not* run on RHEL/Rocky 9 (glibc 2.34). musl-static runs on any glibc — same reason the tarball already uses musl.
- **`install-server.md`** Option A → "download `.rpm`/`.deb` from Releases" (`dnf`/`apt install`), build-from-source kept as a fallback note.
- **Release notes**: new `## Server (Linux)` section linking `install-server.md`.
- Version bump → `0.1.2`.

## Verification
- `release.yml` parses as valid YAML; `cargo check` clean at 0.1.2.
- Workflow only runs on tags → validated via a `v0.1.2-rc.1` prerelease dry-run (checking the `.rpm`/`.deb` assets attach and the ARM64 Windows + other legs stay green) before promoting to `v0.1.2`.
