### PR TITLE
ci: move release actions off deprecated Node.js 20 (#41)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           Copy-Item README.md,LICENSE,NOTICE $dist -ErrorAction SilentlyContinue
           Compress-Archive -Path $dist -DestinationPath "$dist.zip"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
           path: |
@@ -119,7 +119,7 @@ jobs:
           mkdir -p pkgs
           cp target/debian/*.deb target/generate-rpm/*.rpm pkgs/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: linux-packages
           path: pkgs/*
@@ -130,7 +130,7 @@ jobs:
     needs: [build, packages]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -140,7 +140,7 @@ jobs:
         run: sha256sum sigil-* | tee SHA256SUMS
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: "dist/sigil-*"
 


### PR DESCRIPTION
Closes #41.

The `v0.1.x` release runs emitted Node.js 20 deprecation annotations (forced to Node 24 on **2026-06-02**, Node 20 removed **2026-09-16**). Bump the flagged JS actions in `release.yml` to their current Node 24-based majors:

| action | before | after |
|---|---|---|
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `actions/attest-build-provenance` | v2 | **v4** |

`actions/checkout@v5` and `Swatinem/rust-cache@v2` were not flagged and are already on their latest applicable majors — left as-is.

## Verification
These are **major** version jumps (upload v4→v7, download v4→v8), which risk API changes (e.g. `merge-multiple`, artifact naming). The workflow only runs on tags, so verified via a throwaway `v0.1.2-citest.1` prerelease dry-run: all jobs green and the release still publishes the full asset set (4 archives + server `.rpm`/`.deb` + SHA256SUMS) before merging.
