### PR TITLE
ci: add Debian .deb build + install-test leg (#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,49 @@ jobs:
           	sigil-server|sigil-server|sigil-server.service|/etc/sigil/server.yaml.example
           	sigil-signer|sigil-sign||
           	TABLE
+
+  # Debian/Ubuntu validation of the .deb packages. The rocky9 leg covers the
+  # RPM path; this covers .deb end-to-end: build all four, install each, smoke
+  # `--help`, then purge and verify cleanup. (#11)
+  debian12:
+    name: debian:12 / .deb install-test
+    runs-on: ubuntu-latest
+    container: debian:12
+    steps:
+      - name: install build deps
+        run: |
+          apt-get update
+          apt-get install -y git gcc perl ca-certificates curl init-system-helpers
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: debian12
+      - name: build .deb (all 4 packages)
+        run: |
+          cargo install cargo-deb --locked
+          packaging/build.sh deb
+      - name: inspect & install-test .deb (all 4 packages)
+        shell: bash
+        run: |
+          set -eux
+          for entry in \
+            "sigil|sigil|sigil.service|/etc/sigil/policy.yaml.example" \
+            "sigil-sender|sigil-sender|sigil-sender.service|/etc/sigil/sender.yaml.example" \
+            "sigil-server|sigil-server|sigil-server.service|/etc/sigil/server.yaml.example" \
+            "sigil-signer|sigil-sign||"; do
+            IFS='|' read -r pkg bin unit example <<< "$entry"
+            # the `_` after the name keeps sigil_ from matching sigil-sender_ etc.
+            deb=$(echo target/debian/${pkg}_[0-9]*.deb)
+            echo "=== $pkg :: $deb ==="
+            dpkg --info "$deb"
+            dpkg --contents "$deb"
+            dpkg --contents "$deb" | grep -qE "/usr/bin/${bin}$"
+            [ -z "$unit" ]    || dpkg --contents "$deb" | grep -qE "/systemd/system/${unit}$"
+            [ -z "$example" ] || dpkg --contents "$deb" | grep -qE "${example}$"
+            dpkg -i "$deb"
+            "/usr/bin/${bin}" --help >/dev/null
+            [ -z "$example" ] || test -f "$example"
+            dpkg -P "$pkg"
+            test ! -e "/usr/bin/${bin}"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,14 @@ jobs:
             deb=$(echo target/debian/${pkg}_[0-9]*.deb)
             echo "=== $pkg :: $deb ==="
             dpkg --info "$deb"
-            dpkg --contents "$deb"
-            dpkg --contents "$deb" | grep -qE "/usr/bin/${bin}$"
-            [ -z "$unit" ]    || dpkg --contents "$deb" | grep -qE "/systemd/system/${unit}$"
-            [ -z "$example" ] || dpkg --contents "$deb" | grep -qE "${example}$"
+            # Capture once; grep via here-string. A `dpkg --contents | grep -q`
+            # pipe SIGPIPEs dpkg's tar subprocess (grep exits at first match),
+            # which fails the step under bash's default `set -o pipefail`.
+            contents=$(dpkg --contents "$deb")
+            printf '%s\n' "$contents"
+            grep -qE "/usr/bin/${bin}$" <<< "$contents"
+            [ -z "$unit" ]    || grep -qE "/systemd/system/${unit}$" <<< "$contents"
+            [ -z "$example" ] || grep -qE "${example}$" <<< "$contents"
             dpkg -i "$deb"
             "/usr/bin/${bin}" --help >/dev/null
             [ -z "$example" ] || test -f "$example"


### PR DESCRIPTION
Closes #11.

Adds a `debian12` CI job that validates the `.deb` packages end-to-end — the RPM path was covered by the `rocky9` leg, but `.deb` metadata was shipped (#5) and never install-tested in CI.

## What it does (mirrors the `rocky9` leg)
On a `debian:12` container:
1. `packaging/build.sh deb` builds all four packages (`sigil`, `sigil-sender`, `sigil-server`, `sigil-signer`).
2. For each: `dpkg --info` / `--contents`, assert the binary (+ systemd unit / config example where applicable) is present, `dpkg -i`, smoke-test `<bin> --help`, `dpkg -P`, and verify the binary is removed.
3. `set -e` → any single package failing fails the leg (fail-fast).

## Acceptance (#11)
- [x] New CI job builds 4 .debs on Debian 12
- [x] Each .deb installs, smoke-tests, and uninstalls cleanly
- [x] Failure of any single .deb fails the leg

## Verification
`ci.yml` runs on `pull_request`, so this PR's own CI run exercises the new leg — no separate dry-run needed.
