### PR TITLE
test: pin snapshot agent_version (fixes red CI since 0.1.1) (#46)

### DIFF
--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -855,7 +855,9 @@ mod tests {
             event_id: Uuid::parse_str("01910f5a-1234-7890-abcd-ef0123456789").unwrap(),
             ts: datetime!(2026-05-08 14:23:45.123 UTC),
             host_id: "5A7C3E91-FIXED-FOR-SNAPSHOT".into(),
-            agent_version: AGENT_VERSION.to_string(),
+            // Pinned (not AGENT_VERSION) so the snapshot stays stable across
+            // version bumps — this test asserts the JSONL shape, not the version.
+            agent_version: "0.1.0".into(),
             severity: Severity::Warn,
             source: SourceKind::FileSystem,
             subject: Subject::Path {


### PR DESCRIPTION
Closes #46. The `snapshot_file_change_event_jsonl` insta test used the live `AGENT_VERSION` in an otherwise-pinned fixture, so the stored `0.1.0` snapshot broke on the `0.1.1`/`0.1.2` bumps — `cargo test --workspace` has been red on main since the 0.1.1 bump (release.yml is build-only, so v0.1.1/v0.1.2 still shipped). Pinned `agent_version` to a fixed fixture value.

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` all green (was 184 passed / 1 failed → now all pass).