### PR TITLE
feat(agent): add `sigil show host-id` (#35)

### DIFF
--- a/config/sender.example.yaml
+++ b/config/sender.example.yaml
@@ -25,7 +25,7 @@ agent_control: "/var/run/sigil/control.sock"
 dead_letter_dir: "/var/log/sigil/dead-letter"
 
 # REQUIRED — this host's identifier. Must equal the agent's host_id (the UUID
-# stored in the agent's state.db, shown by `sigil-agent status`). The server
+# stored in the agent's state.db, shown by `sigil show host-id`). The server
 # validates that every event's host_id matches the batch envelope host_id and
 # rejects the entire batch if they differ. Overridable by the SIGIL_HOST_ID
 # env var (env takes precedence over this field). Leaving both unset causes

--- a/crates/sigil-agent/src/cli.rs
+++ b/crates/sigil-agent/src/cli.rs
@@ -79,6 +79,9 @@ pub enum ShowWhat {
     Paths,
     /// Query the running daemon for stats via control IPC.
     Stats,
+    /// Print this host's stable host_id — the UUID persisted in state.db on the
+    /// agent's first run, and the value the sender's `host_id` must match.
+    HostId,
     /// Query the running daemon for the active policy version + envelope expiry.
     #[cfg(feature = "operator-cli")]
     PolicyStatus,

--- a/crates/sigil-agent/src/main.rs
+++ b/crates/sigil-agent/src/main.rs
@@ -40,7 +40,12 @@ fn main() -> anyhow::Result<()> {
             std::process::exit(code);
         }
         cli::Command::Show { what } => {
-            let code = show::run(what, cli.policy.clone(), cli.events_dir.clone())?;
+            let code = show::run(
+                what,
+                cli.policy.clone(),
+                cli.events_dir.clone(),
+                cli.state_db.clone().unwrap_or_else(default_state_db_path),
+            )?;
             std::process::exit(code);
         }
         cli::Command::Version => {

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -12,17 +12,21 @@ use sigil_core::policy::expand::{expand_per_user, EnvLookup};
 use sigil_core::policy::{current_platform, defaults, merge};
 use sigil_core::stats::StatsSnapshot;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn run(
     what: ShowWhat,
     policy_override: Option<PathBuf>,
     events_dir_override: Option<PathBuf>,
+    state_db_path: PathBuf,
 ) -> anyhow::Result<i32> {
     // `stats` talks to the running daemon over the control socket; it doesn't
     // touch the policy file, so handle it before the merge below.
     if let ShowWhat::Stats = what {
         return show_stats();
+    }
+    if let ShowWhat::HostId = what {
+        return show_host_id(&state_db_path);
     }
     #[cfg(feature = "operator-cli")]
     if let ShowWhat::PolicyStatus = what {
@@ -76,6 +80,7 @@ pub fn run(
             }
         }
         ShowWhat::Stats => unreachable!("handled above"),
+        ShowWhat::HostId => unreachable!("handled above"),
         #[cfg(feature = "operator-cli")]
         ShowWhat::PolicyStatus => unreachable!("handled above"),
         #[cfg(feature = "operator-cli")]
@@ -86,6 +91,27 @@ pub fn run(
         ShowWhat::Risk { .. } => unreachable!("handled above"),
     }
     Ok(0)
+}
+
+/// Print this host's persisted host_id (read-only — the agent assigns it on its
+/// first `sigil run`). Bare UUID on stdout so it's scriptable; exit 1 with a
+/// hint on stderr if none is persisted yet.
+fn show_host_id(state_db_path: &Path) -> anyhow::Result<i32> {
+    let cache = sigil_core::state::HashCache::open(state_db_path)?;
+    match cache.host_meta_get()?.host_id {
+        Some(id) => {
+            println!("{id}");
+            Ok(0)
+        }
+        None => {
+            eprintln!(
+                "sigil show host-id: no host_id yet — the agent assigns one on its \
+                 first `sigil run` (state.db: {})",
+                state_db_path.display()
+            );
+            Ok(1)
+        }
+    }
 }
 
 /// Connect to the running daemon's control socket, ask for `{"cmd":"stats"}`,


### PR DESCRIPTION
Closes #35.

`config/sender.example.yaml` told operators to find the agent's `host_id` via `sigil-agent status` — but there's no `sigil-agent` binary and no `status` subcommand, so that instruction is dead. Since `host_id` is a **required** sender field (a mismatch makes the server reject every batch), this is real setup friction.

## Change
- New **`sigil show host-id`** subcommand: reads the persisted host_id from `state.db` (read-only, same path as `doctor`), prints the **bare UUID** on stdout (scriptable); exits 1 with a hint on stderr if the agent hasn't generated one yet (`sigil run` assigns it on first run).
- Non-gated (like `show config/paths/stats`), so it compiles in the hardened `--no-default-features` build.
- Fix the `sender.example.yaml` comment to reference `sigil show host-id`.

## Verification (local)
`cargo fmt --check` / `clippy -D warnings` / `cargo build -p sigil-agent --no-default-features` / `cargo test --workspace` all green. Functional: ran the agent to persist a host_id, then `sigil show host-id` printed the bare UUID (exit 0); a fresh db printed the hint (exit 1).