### PR TITLE
test: stabilize macOS FSEvents flake (#25)

### DIFF
--- a/crates/sigil-agent/tests/basic_events.rs
+++ b/crates/sigil-agent/tests/basic_events.rs
@@ -22,7 +22,7 @@ async fn it_emits_modified_event() {
                     && (v["evidence"]["change_kind"] == "modified"
                         || v["evidence"]["change_kind"] == "created")
             },
-            Duration::from_secs(5),
+            common::fs_event_timeout(),
         )
         .await
         .expect("expected file_change event");

--- a/crates/sigil-agent/tests/common/mod.rs
+++ b/crates/sigil-agent/tests/common/mod.rs
@@ -23,3 +23,11 @@ pub fn policy_for_paths(paths: &[&str], tier: &str) -> String {
     yaml.push_str("    follow_symlinks: false\n");
     yaml
 }
+
+/// Wait budget for OS-watcher-driven (`wait_for_event`) assertions. macOS
+/// FSEvents delivery can lag well past a few seconds under parallel test load
+/// (issue #25), so give it more headroom there; other platforms keep the tight
+/// 5s and fail fast.
+pub fn fs_event_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(if cfg!(target_os = "macos") { 15 } else { 5 })
+}

--- a/crates/sigil-agent/tests/critical_tier.rs
+++ b/crates/sigil-agent/tests/critical_tier.rs
@@ -18,7 +18,7 @@ async fn it_critical_tier_emits_recheck() {
     let event = agent
         .wait_for_event(
             |v| v["evidence"]["kind"] == "file_change" && v["evidence"]["recheck_hash"].is_string(),
-            Duration::from_secs(5),
+            common::fs_event_timeout(),
         )
         .await
         .expect("recheck_hash should be populated for critical tier");

--- a/crates/sigil-agent/tests/policy_reload_e2e.rs
+++ b/crates/sigil-agent/tests/policy_reload_e2e.rs
@@ -50,7 +50,7 @@ async fn apply_policy_reloads_live_watch_targets() {
     let ev = agent
         .wait_for_event(
             |v| v["evidence"]["kind"] == "file_change",
-            Duration::from_secs(5),
+            common::fs_event_timeout(),
         )
         .await
         .expect("policy A: file_change for X");

--- a/crates/sigil-agent/tests/show_events_e2e.rs
+++ b/crates/sigil-agent/tests/show_events_e2e.rs
@@ -6,7 +6,6 @@
 
 mod common;
 use common::{policy_for_paths, TestAgentBuilder};
-use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn snapshot_mode_reads_real_file_change_events() {
@@ -20,10 +19,10 @@ async fn snapshot_mode_reads_real_file_change_events() {
     let ev = agent
         .wait_for_event(
             |v| v["evidence"]["kind"] == "file_change",
-            Duration::from_secs(5),
+            common::fs_event_timeout(),
         )
         .await
-        .expect("agent emitted no file_change within 5s");
+        .expect("agent emitted no file_change in time");
     assert_eq!(ev["schema_version"], 1);
 
     // Snapshot-mode read from the same events_dir. Use the test-only entry


### PR DESCRIPTION
Closes #25.

`it_critical_tier_emits_recheck` and its companion `basic_events::it_emits_modified_event` flake on macOS: under parallel test load FSEvents delivery lags past the 5s `wait_for_event` budget (they pass in isolation). 

## Change
- Add a `fs_event_timeout()` test helper (`tests/common/mod.rs`): **15s on macOS, 5s elsewhere**.
- Use it for **all four** FSEvents-driven `wait_for_event` assertions (`critical_tier`, `basic_events`, `policy_reload_e2e`, `show_events_e2e`) — the two named in #25 plus two latent ones with the identical mechanism.
- Non-macOS behavior is unchanged (still 5s, fail-fast).

This matches the fix the issue recommends (bump the macOS wait). `wait_for_event` returns as soon as the event arrives, so the larger budget only matters when delivery is slow — no slowdown on the happy path.

## Verification
`cargo fmt --check` / `clippy --all-targets --all-features -D warnings` / `cargo test --workspace` all green; the three affected tests pass. (Flake fixes are inherently probabilistic — this triples the macOS budget to cover the reported root cause rather than claiming a deterministic proof.)