### PR TITLE
feat(mcp): sigil-mcp — read-only fleet MCP server (stage 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +312,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -170,10 +359,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -202,8 +391,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -222,9 +411,9 @@ dependencies = [
  "arc-swap",
  "bytes",
  "fs-err",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "rustls",
@@ -254,13 +443,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -310,6 +525,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -365,6 +593,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,7 +637,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -420,6 +662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +692,12 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -485,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,7 +781,41 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -559,6 +856,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,7 +894,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -584,6 +902,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -610,6 +934,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +968,33 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -670,6 +1036,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -728,12 +1100,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -743,10 +1131,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -756,7 +1168,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -777,6 +1189,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -851,6 +1264,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,7 +1286,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -923,6 +1348,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,12 +1376,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -950,8 +1403,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -968,6 +1421,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,8 +1482,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -995,8 +1499,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "tokio",
@@ -1015,17 +1519,41 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1117,6 +1645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1739,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1796,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,10 +1848,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1307,6 +1905,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1398,6 +1999,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1664,6 +2271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +2300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,10 +2321,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -1722,6 +2383,20 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1748,13 +2423,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1772,8 +2453,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
  "rand",
@@ -1804,7 +2485,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1841,7 +2522,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1924,6 +2605,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,10 +2674,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -2005,6 +2717,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2129,6 +2876,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,7 +2940,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2192,6 +2976,16 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -2315,6 +3109,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sigil-mcp"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "httpmock",
+ "reqwest",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "urlencoding",
+]
+
+[[package]]
 name = "sigil-rules-basic"
 version = "0.1.2"
 
@@ -2325,7 +3136,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
- "http",
+ "http 1.4.0",
  "parking_lot",
  "reqwest",
  "rustls",
@@ -2357,7 +3168,7 @@ dependencies = [
  "clap",
  "data-encoding",
  "ed25519-dalek",
- "http",
+ "http 1.4.0",
  "parking_lot",
  "rand_core 0.6.4",
  "reqwest",
@@ -2443,6 +3254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +3270,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2481,6 +3308,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +3330,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2520,7 +3370,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2534,6 +3384,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -2562,7 +3423,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2573,7 +3434,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2617,6 +3478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,7 +3522,7 @@ dependencies = [
  "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2665,7 +3535,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2757,8 +3627,8 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -2797,7 +3667,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2930,6 +3800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,7 +3911,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3156,10 +4032,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3437,7 +4366,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3453,7 +4382,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3520,7 +4449,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3541,7 +4470,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3561,7 +4490,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3601,7 +4530,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "crates/sigil-rules-basic", "crates/sigil-sender", "crates/sigil-signer", "crates/sigil-server"]
+members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "crates/sigil-rules-basic", "crates/sigil-sender", "crates/sigil-signer", "crates/sigil-server", "crates/sigil-mcp"]
 resolver = "2"
 
 [workspace.package]
@@ -44,6 +44,8 @@ http = "1"
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio"] }
 tower = "0.5"
 urlencoding = "2"
+rmcp = { version = "0.16", features = ["server", "transport-io"] }
+httpmock = "0.7"
 
 [profile.release]
 panic = "unwind"

--- a/crates/sigil-mcp/Cargo.toml
+++ b/crates/sigil-mcp/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "sigil-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Read-only fleet MCP server: exposes a sigil-server's read API as Model Context Protocol tools."
+
+[[bin]]
+name = "sigil-mcp"
+path = "src/main.rs"
+
+[dependencies]
+rmcp = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+urlencoding = { workspace = true }
+
+[dev-dependencies]
+httpmock = { workspace = true }
+tokio = { workspace = true }

--- a/crates/sigil-mcp/README.md
+++ b/crates/sigil-mcp/README.md
@@ -1,0 +1,40 @@
+# sigil-mcp
+
+Read-only fleet MCP server. Exposes a `sigil-server`'s GET read API as
+Model Context Protocol tools so an MCP client (Claude Desktop/Code, etc.)
+can read and reason over fleet security posture. Read-only by construction:
+GET only, no write/remediation tools.
+
+## Tools
+`list_hosts`, `get_host`, `fleet_risk`, `fleet_compliance`, `query_events`,
+`get_event`, `get_policy`, `server_meta`, `healthz`.
+
+## Configuration (env)
+
+| Var | Meaning |
+|-----|---------|
+| `SIGIL_SERVER_BASE_URL` | read API base, e.g. `http://127.0.0.1:9090` (proxy) or `https://host:8443` |
+| `SIGIL_SERVER_READ_TOKEN` | bearer token |
+| `SIGIL_CLIENT_CERT` / `SIGIL_CLIENT_KEY` / `SIGIL_CA_CERT` | optional, for direct mTLS to `:8443` (omit when using a bearer-only reverse proxy) |
+
+## Claude Desktop / Code (stdio)
+
+```json
+{
+  "mcpServers": {
+    "sigil-fleet": {
+      "command": "sigil-mcp",
+      "env": {
+        "SIGIL_SERVER_BASE_URL": "http://127.0.0.1:9090",
+        "SIGIL_SERVER_READ_TOKEN": "..."
+      }
+    }
+  }
+}
+```
+
+## Note for operators
+Configuration is validated at startup, but connectivity is not probed — an
+unreachable `SIGIL_SERVER_BASE_URL` or bad token surfaces on the first tool
+call (with a clear error), not at launch. Logs go to stderr; stdout is the
+MCP JSON-RPC channel.

--- a/crates/sigil-mcp/src/config.rs
+++ b/crates/sigil-mcp/src/config.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+// fields consumed by HTTP client + main.rs in Tasks 3/4
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub base_url: String,
+    pub token: String,
+    pub mtls: Option<MtlsPaths>,
+}
+
+// client_key and ca_cert used by the HTTP client in Task 4
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct MtlsPaths {
+    pub client_cert: PathBuf,
+    pub client_key: PathBuf,
+    pub ca_cert: PathBuf,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("missing required env var {0}")]
+    Missing(&'static str),
+    #[error("incomplete mTLS config: set all of SIGIL_CLIENT_CERT, SIGIL_CLIENT_KEY, SIGIL_CA_CERT, or none")]
+    PartialMtls,
+}
+
+impl Config {
+    // used by main.rs in Task 4
+    #[allow(dead_code)]
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let map: HashMap<String, String> = std::env::vars().collect();
+        Self::from_map(&map)
+    }
+
+    pub fn from_map(map: &HashMap<String, String>) -> Result<Self, ConfigError> {
+        let base_url = map
+            .get("SIGIL_SERVER_BASE_URL")
+            .cloned()
+            .ok_or(ConfigError::Missing("SIGIL_SERVER_BASE_URL"))?;
+        let token = map
+            .get("SIGIL_SERVER_READ_TOKEN")
+            .cloned()
+            .ok_or(ConfigError::Missing("SIGIL_SERVER_READ_TOKEN"))?;
+        let mtls = match (
+            map.get("SIGIL_CLIENT_CERT"),
+            map.get("SIGIL_CLIENT_KEY"),
+            map.get("SIGIL_CA_CERT"),
+        ) {
+            (Some(c), Some(k), Some(a)) => Some(MtlsPaths {
+                client_cert: PathBuf::from(c),
+                client_key: PathBuf::from(k),
+                ca_cert: PathBuf::from(a),
+            }),
+            (None, None, None) => None,
+            _ => return Err(ConfigError::PartialMtls),
+        };
+        Ok(Config {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token,
+            mtls,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn missing_base_url_errs() {
+        let m = map(&[("SIGIL_SERVER_READ_TOKEN", "t")]);
+        assert!(matches!(
+            Config::from_map(&m),
+            Err(ConfigError::Missing("SIGIL_SERVER_BASE_URL"))
+        ));
+    }
+
+    #[test]
+    fn missing_token_errs() {
+        let m = map(&[("SIGIL_SERVER_BASE_URL", "http://x")]);
+        assert!(matches!(
+            Config::from_map(&m),
+            Err(ConfigError::Missing("SIGIL_SERVER_READ_TOKEN"))
+        ));
+    }
+
+    #[test]
+    fn bearer_only_ok_and_trailing_slash_trimmed() {
+        let m = map(&[
+            ("SIGIL_SERVER_BASE_URL", "http://127.0.0.1:9090/"),
+            ("SIGIL_SERVER_READ_TOKEN", "tok"),
+        ]);
+        let c = Config::from_map(&m).unwrap();
+        assert_eq!(c.base_url, "http://127.0.0.1:9090");
+        assert_eq!(c.token, "tok");
+        assert!(c.mtls.is_none());
+    }
+
+    #[test]
+    fn full_mtls_parsed() {
+        let m = map(&[
+            ("SIGIL_SERVER_BASE_URL", "https://h:8443"),
+            ("SIGIL_SERVER_READ_TOKEN", "tok"),
+            ("SIGIL_CLIENT_CERT", "/p/c.crt"),
+            ("SIGIL_CLIENT_KEY", "/p/c.key"),
+            ("SIGIL_CA_CERT", "/p/ca.crt"),
+        ]);
+        let c = Config::from_map(&m).unwrap();
+        let mtls = c.mtls.unwrap();
+        assert_eq!(mtls.client_cert.to_str().unwrap(), "/p/c.crt");
+        assert_eq!(mtls.client_key.to_str().unwrap(), "/p/c.key");
+        assert_eq!(mtls.ca_cert.to_str().unwrap(), "/p/ca.crt");
+    }
+
+    #[test]
+    fn partial_mtls_errs() {
+        let m = map(&[
+            ("SIGIL_SERVER_BASE_URL", "https://h:8443"),
+            ("SIGIL_SERVER_READ_TOKEN", "tok"),
+            ("SIGIL_CLIENT_CERT", "/p/c.crt"),
+        ]);
+        assert!(matches!(
+            Config::from_map(&m),
+            Err(ConfigError::PartialMtls)
+        ));
+    }
+}

--- a/crates/sigil-mcp/src/config.rs
+++ b/crates/sigil-mcp/src/config.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-// fields consumed by HTTP client + main.rs in Tasks 3/4
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Config {
     pub base_url: String,
@@ -10,8 +8,6 @@ pub struct Config {
     pub mtls: Option<MtlsPaths>,
 }
 
-// client_key and ca_cert used by the HTTP client in Task 4
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct MtlsPaths {
     pub client_cert: PathBuf,
@@ -28,8 +24,6 @@ pub enum ConfigError {
 }
 
 impl Config {
-    // used by main.rs in Task 4
-    #[allow(dead_code)]
     pub fn from_env() -> Result<Self, ConfigError> {
         let map: HashMap<String, String> = std::env::vars().collect();
         Self::from_map(&map)

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,68 +1,29 @@
 mod config;
+mod tools;
 mod upstream;
 
-use rmcp::{
-    handler::server::router::tool::ToolRouter,
-    model::{ServerCapabilities, ServerInfo},
-    tool, tool_handler, tool_router,
-    transport::stdio,
-    ServerHandler, ServiceExt,
-};
-
-#[derive(Clone)]
-pub struct SigilFleet {
-    tool_router: ToolRouter<Self>,
-}
-
-#[tool_router]
-impl SigilFleet {
-    pub fn new() -> Self {
-        Self {
-            tool_router: Self::tool_router(),
-        }
-    }
-
-    #[tool(description = "Liveness ping; returns \"pong\".")]
-    async fn ping(&self) -> String {
-        "pong".to_string()
-    }
-}
-
-impl Default for SigilFleet {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[tool_handler]
-impl ServerHandler for SigilFleet {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
-    }
-}
+use crate::config::Config;
+use crate::tools::SigilFleet;
+use crate::upstream::Upstream;
+use rmcp::transport::stdio;
+use rmcp::ServiceExt;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // MCP speaks JSON-RPC over stdout; ALL logs MUST go to stderr.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "sigil_mcp=info".into()),
+        )
         .init();
-    let service = SigilFleet::new().serve(stdio()).await?;
+
+    let cfg = Config::from_env()?;
+    tracing::info!(base_url = %cfg.base_url, mtls = cfg.mtls.is_some(), "starting sigil-mcp");
+    let upstream = Arc::new(Upstream::new(&cfg)?);
+    let service = SigilFleet::new(upstream).serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn ping_returns_pong() {
-        let fleet = SigilFleet::new();
-        let result = fleet.ping().await;
-        assert_eq!(result, "pong");
-    }
 }

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod upstream;
 
 use rmcp::{
     handler::server::router::tool::ToolRouter,

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,3 +1,5 @@
+mod config;
+
 use rmcp::{
     handler::server::router::tool::ToolRouter,
     model::{ServerCapabilities, ServerInfo},

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,0 +1,65 @@
+use rmcp::{
+    handler::server::router::tool::ToolRouter,
+    model::{ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::stdio,
+    ServerHandler, ServiceExt,
+};
+
+#[derive(Clone)]
+pub struct SigilFleet {
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl SigilFleet {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(description = "Liveness ping; returns \"pong\".")]
+    async fn ping(&self) -> String {
+        "pong".to_string()
+    }
+}
+
+impl Default for SigilFleet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for SigilFleet {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // MCP speaks JSON-RPC over stdout; ALL logs MUST go to stderr.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+    let service = SigilFleet::new().serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn ping_returns_pong() {
+        let fleet = SigilFleet::new();
+        let result = fleet.ping().await;
+        assert_eq!(result, "pong");
+    }
+}

--- a/crates/sigil-mcp/src/tools.rs
+++ b/crates/sigil-mcp/src/tools.rs
@@ -1,0 +1,235 @@
+use crate::upstream::Upstream;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::schemars;
+use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SigilFleet {
+    upstream: Arc<Upstream>,
+    tool_router: ToolRouter<Self>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct HostIdParams {
+    /// Stable host UUID (from list_hosts / fleet_risk).
+    pub host_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct EventIdParams {
+    /// Event UUID (from query_events).
+    pub event_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct QueryEventsParams {
+    /// Filter to these host UUIDs (repeatable). Empty = all hosts.
+    #[serde(default)]
+    pub host_id: Vec<String>,
+    /// Only events at/after this RFC 3339 timestamp.
+    pub since: Option<String>,
+    /// Max events, 1..1000 (server default 100).
+    pub limit: Option<u32>,
+    /// Opaque pagination cursor (UUID) from a prior next_cursor.
+    pub cursor: Option<String>,
+}
+
+fn ok(v: serde_json::Value) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(v.to_string())]))
+}
+
+#[tool_router]
+impl SigilFleet {
+    pub fn new(upstream: Arc<Upstream>) -> Self {
+        Self {
+            upstream,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(description = "List all hosts known to the fleet (id, hostname, last-seen).")]
+    async fn list_hosts(&self) -> Result<CallToolResult, McpError> {
+        ok(self.upstream.get("/v1/fleet/hosts", &[]).await?)
+    }
+
+    #[tool(description = "Get full posture detail for one host by its UUID.")]
+    async fn get_host(
+        &self,
+        Parameters(p): Parameters<HostIdParams>,
+    ) -> Result<CallToolResult, McpError> {
+        ok(self
+            .upstream
+            .get(&format!("/v1/fleet/hosts/{}", p.host_id), &[])
+            .await?)
+    }
+
+    #[tool(description = "Fleet-wide AI Guard risk index: per-host risk band and score.")]
+    async fn fleet_risk(&self) -> Result<CallToolResult, McpError> {
+        ok(self.upstream.get("/v1/fleet/risk", &[]).await?)
+    }
+
+    #[tool(description = "Fleet-wide policy compliance per host.")]
+    async fn fleet_compliance(&self) -> Result<CallToolResult, McpError> {
+        ok(self.upstream.get("/v1/fleet/compliance", &[]).await?)
+    }
+
+    #[tool(description = "Query posture events with optional host/time filters and pagination.")]
+    async fn query_events(
+        &self,
+        Parameters(p): Parameters<QueryEventsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut q: Vec<(&str, String)> = Vec::new();
+        for h in &p.host_id {
+            q.push(("host_id", h.clone()));
+        }
+        if let Some(s) = &p.since {
+            q.push(("since", s.clone()));
+        }
+        if let Some(l) = p.limit {
+            q.push(("limit", l.to_string()));
+        }
+        if let Some(c) = &p.cursor {
+            q.push(("cursor", c.clone()));
+        }
+        ok(self.upstream.get("/v1/events", &q).await?)
+    }
+
+    #[tool(description = "Get one posture event by its UUID.")]
+    async fn get_event(
+        &self,
+        Parameters(p): Parameters<EventIdParams>,
+    ) -> Result<CallToolResult, McpError> {
+        ok(self
+            .upstream
+            .get(&format!("/v1/events/{}", p.event_id), &[])
+            .await?)
+    }
+
+    #[tool(description = "Get the active signed policy bundle the server serves to agents.")]
+    async fn get_policy(&self) -> Result<CallToolResult, McpError> {
+        ok(self.upstream.get("/v1/policy", &[]).await?)
+    }
+
+    #[tool(description = "Server metadata (version, build, capabilities).")]
+    async fn server_meta(&self) -> Result<CallToolResult, McpError> {
+        ok(self.upstream.get("/v1/meta", &[]).await?)
+    }
+
+    #[tool(description = "Server liveness check.")]
+    async fn healthz(&self) -> Result<CallToolResult, McpError> {
+        ok(self.upstream.get("/v1/healthz", &[]).await?)
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for SigilFleet {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            instructions: Some(
+                "Read-only access to a Sigil fleet's security posture. \
+                 Survey with fleet_risk/list_hosts, drill in with get_host, \
+                 investigate over time with query_events. There are no write \
+                 or remediation tools — this server cannot change anything."
+                    .to_string(),
+            ),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::{Method::GET, MockServer};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn fleet(base_url: String) -> SigilFleet {
+        SigilFleet::new(Arc::new(crate::upstream::Upstream::for_test(base_url)))
+    }
+
+    #[tokio::test]
+    async fn list_hosts_hits_endpoint_and_returns_text() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/fleet/hosts");
+                then.status(200)
+                    .json_body(json!([{"host_id": "abc", "hostname": "ju571n"}]));
+            })
+            .await;
+
+        let res = fleet(server.base_url()).list_hosts().await.unwrap();
+
+        m.assert_async().await;
+        assert_eq!(res.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn get_host_interpolates_id() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/fleet/hosts/abc-123");
+                then.status(200).json_body(json!({"host_id": "abc-123"}));
+            })
+            .await;
+
+        fleet(server.base_url())
+            .get_host(Parameters(HostIdParams {
+                host_id: "abc-123".to_string(),
+            }))
+            .await
+            .unwrap();
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn query_events_builds_filters() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/v1/events")
+                    .query_param("host_id", "H1")
+                    .query_param("since", "2026-05-01T00:00:00Z")
+                    .query_param("limit", "50")
+                    .query_param("cursor", "abc-cursor");
+                then.status(200)
+                    .json_body(json!({"events": [], "next_cursor": null}));
+            })
+            .await;
+
+        fleet(server.base_url())
+            .query_events(Parameters(QueryEventsParams {
+                host_id: vec!["H1".to_string()],
+                since: Some("2026-05-01T00:00:00Z".to_string()),
+                limit: Some(50),
+                cursor: Some("abc-cursor".to_string()),
+            }))
+            .await
+            .unwrap();
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn auth_failure_surfaces_as_mcp_error() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/fleet/risk");
+                then.status(401);
+            })
+            .await;
+        let err = fleet(server.base_url()).fleet_risk().await.unwrap_err();
+        // Auth maps to internal_error; the Display string contains "authentication".
+        assert!(format!("{err:?}").to_lowercase().contains("auth"));
+    }
+}

--- a/crates/sigil-mcp/src/upstream.rs
+++ b/crates/sigil-mcp/src/upstream.rs
@@ -35,8 +35,6 @@ impl From<UpstreamError> for McpError {
     }
 }
 
-// fields and methods used by tool layer in Task 4
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct Upstream {
     client: Client,
@@ -45,8 +43,6 @@ pub struct Upstream {
 }
 
 impl Upstream {
-    // used by main.rs in Task 4
-    #[allow(dead_code)]
     pub fn new(cfg: &Config) -> Result<Self, UpstreamError> {
         let client = match &cfg.mtls {
             Some(m) => build_mtls_client(&m.client_cert, &m.client_key, &m.ca_cert)?,
@@ -69,8 +65,6 @@ impl Upstream {
     }
 
     /// GET `path` (+optional query), return parsed JSON. Only verb used: GET.
-    // used by tool layer in Task 4
-    #[allow(dead_code)]
     pub async fn get(&self, path: &str, query: &[(&str, String)]) -> Result<Value, UpstreamError> {
         debug_assert!(path.starts_with('/'), "path must start with '/': {path}");
         let url = format!("{}{}", self.base_url, path);

--- a/crates/sigil-mcp/src/upstream.rs
+++ b/crates/sigil-mcp/src/upstream.rs
@@ -1,0 +1,275 @@
+use crate::config::Config;
+use reqwest::{Client, ClientBuilder, Identity, StatusCode};
+use rmcp::ErrorData as McpError;
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, thiserror::Error)]
+pub enum UpstreamError {
+    #[error("authentication failed (HTTP {0}); check SIGIL_SERVER_READ_TOKEN")]
+    Auth(u16),
+    #[error(
+        "not found (HTTP 404): read API may be disabled (no server read token) or the id is unknown"
+    )]
+    NotFound,
+    #[error("invalid query (HTTP 400): {0}")]
+    BadQuery(String),
+    #[error("upstream sigil-server error (HTTP {0}): {1}")]
+    Server(u16, String),
+    #[error("cannot reach sigil-server at {0}: {1}")]
+    Connection(String, String),
+    #[error("client build failed: {0}")]
+    Build(String),
+    #[error("unexpected response: {0}")]
+    Protocol(String),
+}
+
+impl From<UpstreamError> for McpError {
+    fn from(e: UpstreamError) -> Self {
+        match &e {
+            // A 400 means the tool built a bad query param — caller-facing.
+            UpstreamError::BadQuery(_) => McpError::invalid_params(e.to_string(), None),
+            // Auth/connection/server/etc. are server-side/config issues, not bad tool args.
+            _ => McpError::internal_error(e.to_string(), None),
+        }
+    }
+}
+
+// fields and methods used by tool layer in Task 4
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct Upstream {
+    client: Client,
+    base_url: String,
+    token: String,
+}
+
+impl Upstream {
+    // used by main.rs in Task 4
+    #[allow(dead_code)]
+    pub fn new(cfg: &Config) -> Result<Self, UpstreamError> {
+        let client = match &cfg.mtls {
+            Some(m) => build_mtls_client(&m.client_cert, &m.client_key, &m.ca_cert)?,
+            None => Client::new(),
+        };
+        Ok(Upstream {
+            client,
+            base_url: cfg.base_url.clone(),
+            token: cfg.token.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn for_test(base_url: String) -> Self {
+        Upstream {
+            client: Client::new(),
+            base_url,
+            token: "testtoken".to_string(),
+        }
+    }
+
+    /// GET `path` (+optional query), return parsed JSON. Only verb used: GET.
+    // used by tool layer in Task 4
+    #[allow(dead_code)]
+    pub async fn get(&self, path: &str, query: &[(&str, String)]) -> Result<Value, UpstreamError> {
+        debug_assert!(path.starts_with('/'), "path must start with '/': {path}");
+        let url = format!("{}{}", self.base_url, path);
+        let mut req = self.client.get(&url).bearer_auth(&self.token);
+        if !query.is_empty() {
+            req = req.query(query);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|err| UpstreamError::Connection(self.base_url.clone(), err.to_string()))?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        match status {
+            s if s.is_success() => serde_json::from_str(&body)
+                .map_err(|e| UpstreamError::Protocol(format!("non-JSON 2xx body: {e}"))),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                Err(UpstreamError::Auth(status.as_u16()))
+            }
+            StatusCode::NOT_FOUND => Err(UpstreamError::NotFound),
+            StatusCode::BAD_REQUEST => Err(UpstreamError::BadQuery(body)),
+            s if s.is_server_error() => Err(UpstreamError::Server(s.as_u16(), body)),
+            s => Err(UpstreamError::Protocol(format!(
+                "unexpected HTTP {s}: {body}"
+            ))),
+        }
+    }
+}
+
+fn build_mtls_client(cert: &Path, key: &Path, ca: &Path) -> Result<Client, UpstreamError> {
+    let cert_pem = std::fs::read(cert).map_err(|e| UpstreamError::Build(e.to_string()))?;
+    let key_pem = std::fs::read(key).map_err(|e| UpstreamError::Build(e.to_string()))?;
+    let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
+    combined.extend_from_slice(&cert_pem);
+    combined.push(b'\n');
+    combined.extend_from_slice(&key_pem);
+    let identity =
+        Identity::from_pem(&combined).map_err(|e| UpstreamError::Build(e.to_string()))?;
+    let ca_pem = std::fs::read(ca).map_err(|e| UpstreamError::Build(e.to_string()))?;
+    let ca_cert =
+        reqwest::Certificate::from_pem(&ca_pem).map_err(|e| UpstreamError::Build(e.to_string()))?;
+    ClientBuilder::new()
+        .use_rustls_tls()
+        .identity(identity)
+        .add_root_certificate(ca_cert)
+        .tls_built_in_root_certs(false)
+        .build()
+        .map_err(|e| UpstreamError::Build(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::{Method::GET, MockServer};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn get_200_returns_json_and_sends_bearer() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/v1/fleet/risk")
+                    .header("authorization", "Bearer testtoken");
+                then.status(200).json_body(json!({"hosts": []}));
+            })
+            .await;
+
+        let up = Upstream::for_test(server.base_url());
+        let v = up.get("/v1/fleet/risk", &[]).await.unwrap();
+
+        m.assert_async().await;
+        assert_eq!(v, json!({"hosts": []}));
+    }
+
+    #[tokio::test]
+    async fn query_params_are_sent() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/v1/events")
+                    .query_param("limit", "100")
+                    .query_param("host_id", "H1");
+                then.status(200)
+                    .json_body(json!({"events": [], "next_cursor": null}));
+            })
+            .await;
+
+        let up = Upstream::for_test(server.base_url());
+        let q = vec![("host_id", "H1".to_string()), ("limit", "100".to_string())];
+        up.get("/v1/events", &q).await.unwrap();
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn status_401_maps_to_auth() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/meta");
+                then.status(401);
+            })
+            .await;
+        let up = Upstream::for_test(server.base_url());
+        assert!(matches!(
+            up.get("/v1/meta", &[]).await,
+            Err(UpstreamError::Auth(401))
+        ));
+    }
+
+    #[tokio::test]
+    async fn status_403_maps_to_auth() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/meta");
+                then.status(403);
+            })
+            .await;
+        let up = Upstream::for_test(server.base_url());
+        assert!(matches!(
+            up.get("/v1/meta", &[]).await,
+            Err(UpstreamError::Auth(403))
+        ));
+    }
+
+    #[tokio::test]
+    async fn status_404_maps_to_not_found() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/fleet/hosts/x");
+                then.status(404);
+            })
+            .await;
+        let up = Upstream::for_test(server.base_url());
+        assert!(matches!(
+            up.get("/v1/fleet/hosts/x", &[]).await,
+            Err(UpstreamError::NotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn status_400_carries_body() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/events");
+                then.status(400).body("cursor must be a UUID");
+            })
+            .await;
+        let up = Upstream::for_test(server.base_url());
+        match up.get("/v1/events", &[]).await {
+            Err(UpstreamError::BadQuery(b)) => assert!(b.contains("UUID")),
+            other => panic!("expected BadQuery, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn status_503_maps_to_server() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/fleet/risk");
+                then.status(503).body("busy");
+            })
+            .await;
+        let up = Upstream::for_test(server.base_url());
+        assert!(matches!(
+            up.get("/v1/fleet/risk", &[]).await,
+            Err(UpstreamError::Server(503, _))
+        ));
+    }
+
+    #[tokio::test]
+    async fn success_with_non_json_body_maps_to_protocol() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/healthz");
+                then.status(200).body("ok");
+            })
+            .await;
+        let up = Upstream::for_test(server.base_url());
+        assert!(matches!(
+            up.get("/v1/healthz", &[]).await,
+            Err(UpstreamError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn connection_refused_maps_to_connection() {
+        // Nothing listening on this port.
+        let up = Upstream::for_test("http://127.0.0.1:1".to_string());
+        assert!(matches!(
+            up.get("/v1/healthz", &[]).await,
+            Err(UpstreamError::Connection(_, _))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- New `crates/sigil-mcp`: a read-only fleet MCP server (rmcp 0.16, stdio) exposing a `sigil-server`'s GET read API as **9 Model Context Protocol tools** (`list_hosts`, `get_host`, `fleet_risk`, `fleet_compliance`, `query_events`, `get_event`, `get_policy`, `server_meta`, `healthz`).
- **Read-only by construction:** the only HTTP verb is GET (single chokepoint in `Upstream::get`); `POST /v1/events` ingest is unreachable. This is the seam where stage-2/3 *paid* action tools attach later (OSS-excluded).
- `Upstream` client: bearer auth + optional mTLS (cert/key/ca), status→MCP error mapping (400→invalid_params; auth/5xx/connection→internal_error). Env-based `Config` (`SIGIL_SERVER_BASE_URL`, `SIGIL_SERVER_READ_TOKEN`, optional mTLS triple). `ServerHandler` advertises tools + an instructions string stating it is read-only.
- Producer-side, OSS. The in-product copilot UI is informed-input to sigil-manager (Ju571nK/sigil-manager#9), not part of this PR.

## Test Plan
- [x] `cargo test --workspace` green (incl. sigil-mcp's 18 tests: 5 config / 9 upstream / 4 tools)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual smoke vs live demo server: register in Claude Desktop/Code (stdio) → `fleet_risk` returns host `ju571n` high

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)