### PR TITLE
feat(mcp): sigil-mcp local mode — individual self-assessment, no server (#55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,10 +3114,13 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "httpmock",
+ "libc",
  "reqwest",
  "rmcp",
  "serde",
  "serde_json",
+ "sigil-core",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -184,10 +184,13 @@ one operator CLI, one read-only MCP server, and three shared libraries.
 
 **MCP server**
 
-- `sigil-mcp` — read-only fleet MCP server (`sigil-mcp` binary). Exposes a
-  `sigil-server`'s bearer-gated read API as Model Context Protocol tools so an
-  MCP client (Claude Desktop/Code) can read and reason over fleet posture.
-  Read-only by construction: GET only, no write or remediation tools.
+- `sigil-mcp` — read-only MCP server (`sigil-mcp` binary), two auto-detected
+  modes. **Fleet mode** exposes a `sigil-server`'s bearer-gated read API as
+  Model Context Protocol tools so an MCP client (Claude Desktop/Code) can read
+  and reason over fleet posture. **Local mode** (no server URL) reads the local
+  `sigil-agent` control socket to surface *this machine's* AI Guard posture —
+  no server, no fleet. Read-only by construction: no write or remediation tools.
+  See [`crates/sigil-mcp/README.md`](crates/sigil-mcp/README.md).
 
 **Libraries**
 

--- a/crates/sigil-agent/src/control.rs
+++ b/crates/sigil-agent/src/control.rs
@@ -4,16 +4,23 @@
 //! Heartbeat-equivalent payload as JSON.
 
 use parking_lot::RwLock;
-use serde::{Deserialize, Serialize};
-use sigil_core::policy::signed_envelope::SignedPolicyResponse;
-use sigil_core::stats::{Stats, StatsSnapshot};
-use sigil_core::PolicySignatureInvalidReason;
+use sigil_core::stats::Stats;
 #[cfg(unix)]
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::policy_apply::{apply, ApplyContext, ApplyOutcome};
+
+// The control-socket wire protocol now lives in `sigil-core::control_proto`, so
+// `sigil-mcp` (local-mode client) can share the contract without depending on
+// this crate. Re-exported here so existing `crate::control::{...}` paths keep
+// working.
+pub use sigil_core::control_proto::{
+    ApplyPolicyResult, DoctorAiGuardReport, ExtScriptSummary, ParserInfo, PerRepoSummary,
+    PolicyStatusPayload, Request, Response, RiskPayload, RiskSummary, RubricEntry, RulePackInfo,
+    TargetSummary, TargetsPayload,
+};
 
 /// Default control-socket path. As root, the system path `/var/run/sigil`
 /// (matches the systemd unit's `RuntimeDirectory=`). A non-root agent (macOS,
@@ -22,8 +29,11 @@ use crate::policy_apply::{apply, ApplyContext, ApplyOutcome};
 /// control plane usable without elevation. Override with `--control-socket`.
 /// `sigil run` binds it; `sigil show stats` and `sigil-sender` connect to it.
 /// On Windows the named pipe is used instead and this value is ignored.
+///
+/// The pure branch logic lives in `sigil_core::control_proto::resolve_control_socket`;
+/// this wrapper supplies the euid/root/XDG/TMPDIR inputs.
 pub fn default_control_socket() -> PathBuf {
-    resolve_control_socket(
+    sigil_core::control_proto::resolve_control_socket(
         is_root(),
         std::env::var("XDG_RUNTIME_DIR")
             .ok()
@@ -31,27 +41,6 @@ pub fn default_control_socket() -> PathBuf {
         std::env::var("TMPDIR").ok().filter(|s| !s.is_empty()),
         current_uid(),
     )
-}
-
-/// Pure resolver for [`default_control_socket`] — split out so the
-/// root/non-root/XDG/TMPDIR branches can be unit-tested without touching the
-/// process euid or environment.
-fn resolve_control_socket(
-    is_root: bool,
-    xdg_runtime: Option<String>,
-    tmpdir: Option<String>,
-    uid: u32,
-) -> PathBuf {
-    if is_root {
-        return PathBuf::from("/var/run/sigil/control.sock");
-    }
-    if let Some(dir) = xdg_runtime {
-        return PathBuf::from(dir).join("sigil").join("control.sock");
-    }
-    let base = tmpdir.unwrap_or_else(|| "/tmp".to_string());
-    PathBuf::from(base)
-        .join(format!("sigil-{uid}"))
-        .join("control.sock")
 }
 
 /// True when the process effective uid is 0 (root). Non-Unix: always false.
@@ -81,186 +70,6 @@ fn current_uid() -> u32 {
 /// Default control named-pipe name on Windows.
 pub fn default_control_pipe_name() -> String {
     r"\\.\pipe\sigil-control".to_string()
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "cmd", rename_all = "snake_case")]
-pub enum Request {
-    /// Existing Phase 1 command — unchanged on the wire.
-    #[serde(rename = "stats")]
-    Stats,
-    /// Plan B `sigil-sender` hands a verified envelope here for application.
-    ApplyPolicy {
-        /// The full server response — agent re-verifies independently.
-        response: SignedPolicyResponse,
-    },
-    /// Operator + sender introspection: returns the agent's current
-    /// `last_applied_policy_version`, the active `valid_until`, and whether
-    /// the active policy is currently expired.
-    PolicyStatus,
-    /// Operator introspection: returns the agent's currently-active watch
-    /// targets and their compiled glob patterns.
-    #[cfg(feature = "operator-cli")]
-    Targets,
-    /// Operator action: re-read the policy file (after a hand-edit) without
-    /// verifying a signed envelope. Re-uses the existing live-reload pipeline
-    /// by nudging the policy-version watch channel.
-    #[cfg(feature = "operator-cli")]
-    ReloadPolicy,
-    /// Operator introspection: returns the latest AI Guard risk assessment
-    /// for each tool (or a single tool if `tool` is set).
-    #[cfg(feature = "operator-cli")]
-    Risk {
-        tool: Option<sigil_core::event::AiTool>,
-    },
-    /// Operator introspection: returns a snapshot of the AI Guard
-    /// subsystem state for `sigil doctor`. Phase 3b.5.
-    #[cfg(feature = "operator-cli")]
-    DoctorAiGuardReport,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Response {
-    pub ok: bool,
-    pub stats: Option<StatsSnapshot>,
-    /// Present iff the request was `ApplyPolicy`.
-    pub apply_policy: Option<ApplyPolicyResult>,
-    /// Present iff the request was `PolicyStatus`.
-    pub policy_status: Option<PolicyStatusPayload>,
-    /// Present iff the request was `Targets` (Phase 2 operator introspection).
-    pub targets: Option<TargetsPayload>,
-    /// Present iff the request was `Risk`.
-    pub risk: Option<RiskPayload>,
-    /// Present iff the request was `DoctorAiGuardReport`. Phase 3b.5.
-    #[cfg(feature = "operator-cli")]
-    pub doctor_ai_guard: Option<DoctorAiGuardReport>,
-    pub error: Option<String>,
-}
-
-/// Outcome of an `apply_policy` request.
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "outcome", rename_all = "snake_case")]
-pub enum ApplyPolicyResult {
-    /// Verifier accepted; policy.yaml written; version advanced.
-    Accepted {
-        /// The new `last_applied_policy_version`.
-        applied_policy_version: i64,
-    },
-    /// Verifier rejected. The wire-stable `reason` matches the
-    /// `PolicySignatureInvalid` event variant emitted in parallel.
-    Rejected {
-        /// Which check failed.
-        reason: PolicySignatureInvalidReason,
-    },
-}
-
-/// Snapshot of the agent's current policy state.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PolicyStatusPayload {
-    pub last_applied_policy_version: i64,
-    /// RFC 3339; `None` if no envelope has ever been applied.
-    pub active_envelope_valid_until: Option<String>,
-    /// `true` iff `now >= active_envelope_valid_until`.
-    pub policy_expired_active: bool,
-}
-
-/// Summary of one active watch target — what the agent is currently watching
-/// post-policy-merge + post-canonicalization.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct TargetSummary {
-    pub id: String,
-    pub tier: sigil_core::policy::Tier,
-    pub globs: Vec<String>,
-}
-
-/// Payload for the `targets` control-IPC response: the agent's currently-active
-/// compiled targets.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct TargetsPayload {
-    pub targets: Vec<TargetSummary>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RiskPayload {
-    pub assessments: Vec<RiskSummary>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RiskSummary {
-    pub tool: sigil_core::event::AiTool,
-    pub scope: sigil_core::event::AiGuardScope,
-    pub score: f32,
-    pub bucket: sigil_core::event::AiGuardBucket,
-    pub reasons_count: usize,
-    /// RFC 3339.
-    pub last_assessed_ts: String,
-}
-
-/// Phase 3b.5 — serializable snapshot of the agent's AI Guard subsystem
-/// state, returned by `Request::DoctorAiGuardReport` for `sigil doctor`.
-#[derive(Serialize, Deserialize, Debug)]
-#[cfg(feature = "operator-cli")]
-pub struct DoctorAiGuardReport {
-    /// Active parser instances. One entry per (tool, scope) pair.
-    pub parsers: Vec<ParserInfo>,
-    /// Discovered per-repo workspaces, count per tool.
-    pub per_repo: PerRepoSummary,
-    /// Loaded rule packs (3b.7). Skipped packs are not currently retained;
-    /// only loaded ones are reported. Future enhancement may surface skip
-    /// reasons from the loader.
-    pub rule_packs: Vec<RulePackInfo>,
-    /// External hook scripts (3b.3) currently being watched.
-    pub ext_scripts: ExtScriptSummary,
-    /// Latest risk assessment per (tool, scope) from ai_guard_state cache.
-    pub latest_risk: Vec<RiskSummary>,
-    /// Effective rubric — every kind_key with current weight + whether it
-    /// came from an operator override.
-    pub effective_rubric: Vec<RubricEntry>,
-    /// Snake_case override keys the envelope referenced but didn't match
-    /// any known kind. Surfaced by doctor as `[WARN]`.
-    pub unknown_override_keys: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[cfg(feature = "operator-cli")]
-pub struct ParserInfo {
-    pub tool: sigil_core::event::AiTool,
-    pub scope: sigil_core::event::AiGuardScope,
-    pub watched_path_count: usize,
-}
-
-#[derive(Serialize, Deserialize, Debug, Default)]
-#[cfg(feature = "operator-cli")]
-pub struct PerRepoSummary {
-    pub continue_dev: usize,
-    pub claude_code: usize,
-    pub codex: usize,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[cfg(feature = "operator-cli")]
-pub struct RulePackInfo {
-    pub id: String,
-    pub loaded: bool,
-    /// `None` when loaded. Reserved for future surfacing of skip reasons.
-    pub skip_reason: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Default)]
-#[cfg(feature = "operator-cli")]
-pub struct ExtScriptSummary {
-    /// Total unique canonical script paths across all parsers.
-    pub unique_paths: usize,
-    /// Number of (tool, scope) entries that have at least one ext-script.
-    pub parser_entries: usize,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[cfg(feature = "operator-cli")]
-pub struct RubricEntry {
-    pub kind_key: String,
-    pub weight: f32,
-    pub overridden: bool,
 }
 
 /// Shared context bundle passed to both platform `serve` functions.
@@ -299,7 +108,6 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
             policy_status: None,
             targets: None,
             risk: None,
-            #[cfg(feature = "operator-cli")]
             doctor_ai_guard: None,
             error: None,
         },
@@ -317,7 +125,6 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
                     policy_status: None,
                     targets: None,
                     risk: None,
-                    #[cfg(feature = "operator-cli")]
                     doctor_ai_guard: None,
                     error: None,
                 },
@@ -328,7 +135,6 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
                     policy_status: None,
                     targets: None,
                     risk: None,
-                    #[cfg(feature = "operator-cli")]
                     doctor_ai_guard: None,
                     error: None,
                 },
@@ -339,7 +145,6 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
                     policy_status: None,
                     targets: None,
                     risk: None,
-                    #[cfg(feature = "operator-cli")]
                     doctor_ai_guard: None,
                     error: Some(format!("internal: {detail}")),
                 },
@@ -372,7 +177,6 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
                 }),
                 targets: None,
                 risk: None,
-                #[cfg(feature = "operator-cli")]
                 doctor_ai_guard: None,
                 error: None,
             }
@@ -582,6 +386,23 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
                 error: None,
             }
         }
+        // The operator-cli request variants always exist on the wire (they live
+        // in sigil-core::control_proto), but their handlers compile only with
+        // the `operator-cli` feature. In a hardened build without it, reject.
+        #[cfg(not(feature = "operator-cli"))]
+        Request::Targets
+        | Request::ReloadPolicy
+        | Request::Risk { .. }
+        | Request::DoctorAiGuardReport => Response {
+            ok: false,
+            stats: None,
+            apply_policy: None,
+            policy_status: None,
+            targets: None,
+            risk: None,
+            doctor_ai_guard: None,
+            error: Some("operator-cli feature not enabled in this build".into()),
+        },
     }
 }
 
@@ -631,7 +452,6 @@ pub async fn serve(socket_path: &Path, ctx: Arc<ControlContext>) -> std::io::Res
                     policy_status: None,
                     targets: None,
                     risk: None,
-                    #[cfg(feature = "operator-cli")]
                     doctor_ai_guard: None,
                     error: Some(e.to_string()),
                 },
@@ -673,7 +493,6 @@ pub async fn serve(pipe_name: &str, ctx: Arc<ControlContext>) -> std::io::Result
                     policy_status: None,
                     targets: None,
                     risk: None,
-                    #[cfg(feature = "operator-cli")]
                     doctor_ai_guard: None,
                     error: Some(e.to_string()),
                 },
@@ -683,250 +502,5 @@ pub async fn serve(pipe_name: &str, ctx: Arc<ControlContext>) -> std::io::Result
                 let _ = wr.write_all(b"\n").await;
             }
         });
-    }
-}
-
-#[cfg(test)]
-mod socket_path_tests {
-    use super::resolve_control_socket;
-    use std::path::PathBuf;
-
-    #[test]
-    fn root_uses_system_run_path() {
-        assert_eq!(
-            resolve_control_socket(
-                true,
-                Some("/run/user/1000".into()),
-                Some("/tmp".into()),
-                1000
-            ),
-            PathBuf::from("/var/run/sigil/control.sock")
-        );
-    }
-
-    #[test]
-    fn nonroot_prefers_xdg_runtime_dir() {
-        assert_eq!(
-            resolve_control_socket(
-                false,
-                Some("/run/user/501".into()),
-                Some("/tmp".into()),
-                501
-            ),
-            PathBuf::from("/run/user/501/sigil/control.sock")
-        );
-    }
-
-    #[test]
-    fn nonroot_without_xdg_uses_tmpdir_namespaced_by_uid() {
-        assert_eq!(
-            resolve_control_socket(false, None, Some("/custom/tmp".into()), 501),
-            PathBuf::from("/custom/tmp/sigil-501/control.sock")
-        );
-    }
-
-    #[test]
-    fn nonroot_without_xdg_or_tmpdir_falls_back_to_slash_tmp() {
-        assert_eq!(
-            resolve_control_socket(false, None, None, 42),
-            PathBuf::from("/tmp/sigil-42/control.sock")
-        );
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use sigil_core::policy::signed_envelope::{SignedEnvelope, SignedPolicyResponse};
-    use time::macros::datetime;
-
-    fn sample_response() -> SignedPolicyResponse {
-        SignedPolicyResponse {
-            etag: "abc".into(),
-            signed_envelope: SignedEnvelope {
-                policy_version: 7,
-                policy_bytes_b64: "AAA=".into(),
-                valid_until: datetime!(2026-06-15 0:00 UTC),
-                issued_at: datetime!(2026-05-15 8:00 UTC),
-            },
-            signature: "sig".into(),
-            signing_pubkey_id: "k1".into(),
-            applied_at: datetime!(2026-05-15 8:01 UTC),
-        }
-    }
-
-    #[test]
-    fn apply_policy_request_round_trips() {
-        let req = Request::ApplyPolicy {
-            response: sample_response(),
-        };
-        let s = serde_json::to_string(&req).unwrap();
-        // The cmd discriminator MUST be exactly "apply_policy" (snake_case is
-        // wrong here — the existing Phase 1 control protocol uses lowercase).
-        assert!(s.contains("\"cmd\":\"apply_policy\""));
-        let back: Request = serde_json::from_str(&s).unwrap();
-        match back {
-            Request::ApplyPolicy { response } => {
-                assert_eq!(response.signed_envelope.policy_version, 7);
-            }
-            _ => panic!("expected ApplyPolicy, got {back:?}"),
-        }
-    }
-
-    #[test]
-    fn policy_status_request_round_trips() {
-        let req = Request::PolicyStatus;
-        let s = serde_json::to_string(&req).unwrap();
-        assert!(s.contains("\"cmd\":\"policy_status\""));
-        let _: Request = serde_json::from_str(&s).unwrap();
-    }
-
-    #[test]
-    fn response_includes_optional_apply_policy_payload() {
-        let r = Response {
-            ok: true,
-            stats: None,
-            apply_policy: Some(ApplyPolicyResult::Accepted {
-                applied_policy_version: 9,
-            }),
-            policy_status: None,
-            targets: None,
-            risk: None,
-            #[cfg(feature = "operator-cli")]
-            doctor_ai_guard: None,
-            error: None,
-        };
-        let s = serde_json::to_string(&r).unwrap();
-        assert!(s.contains("\"apply_policy\""));
-        assert!(s.contains("\"applied_policy_version\":9"));
-    }
-
-    #[test]
-    fn response_apply_policy_rejected_carries_reason() {
-        let r = Response {
-            ok: false,
-            stats: None,
-            apply_policy: Some(ApplyPolicyResult::Rejected {
-                reason: sigil_core::PolicySignatureInvalidReason::Expired,
-            }),
-            policy_status: None,
-            targets: None,
-            risk: None,
-            #[cfg(feature = "operator-cli")]
-            doctor_ai_guard: None,
-            error: None,
-        };
-        let s = serde_json::to_string(&r).unwrap();
-        assert!(s.contains("\"reason\":\"expired\""));
-    }
-
-    #[test]
-    fn response_with_targets_round_trips() {
-        let resp = Response {
-            ok: true,
-            stats: None,
-            apply_policy: None,
-            policy_status: None,
-            targets: Some(TargetsPayload {
-                targets: vec![TargetSummary {
-                    id: "tgt-1".into(),
-                    tier: sigil_core::policy::Tier::Critical,
-                    globs: vec!["/etc/foo.yaml".into(), "/var/log/bar/*.log".into()],
-                }],
-            }),
-            risk: None,
-            #[cfg(feature = "operator-cli")]
-            doctor_ai_guard: None,
-            error: None,
-        };
-        let s = serde_json::to_string(&resp).unwrap();
-        assert!(s.contains("\"targets\""));
-        assert!(s.contains("\"tgt-1\""));
-        assert!(
-            s.contains("\"critical\""),
-            "Tier::Critical serializes lowercase, got: {s}"
-        );
-        let back: Response = serde_json::from_str(&s).unwrap();
-        assert!(back.targets.is_some());
-        assert_eq!(back.targets.as_ref().unwrap().targets[0].id, "tgt-1");
-    }
-
-    #[cfg(feature = "operator-cli")]
-    #[test]
-    fn request_targets_round_trips() {
-        let req = Request::Targets;
-        let s = serde_json::to_string(&req).unwrap();
-        assert_eq!(s, r#"{"cmd":"targets"}"#);
-        let back: Request = serde_json::from_str(&s).unwrap();
-        assert!(matches!(back, Request::Targets));
-    }
-
-    #[cfg(feature = "operator-cli")]
-    #[test]
-    fn request_reload_policy_round_trips() {
-        let req = Request::ReloadPolicy;
-        let s = serde_json::to_string(&req).unwrap();
-        assert_eq!(s, r#"{"cmd":"reload_policy"}"#);
-        let back: Request = serde_json::from_str(&s).unwrap();
-        assert!(matches!(back, Request::ReloadPolicy));
-    }
-
-    #[cfg(feature = "operator-cli")]
-    #[test]
-    fn request_risk_round_trips_no_filter() {
-        let req = Request::Risk { tool: None };
-        let s = serde_json::to_string(&req).unwrap();
-        assert!(s.contains("\"cmd\":\"risk\""), "got: {s}");
-        let back: Request = serde_json::from_str(&s).unwrap();
-        assert!(matches!(back, Request::Risk { tool: None }));
-    }
-
-    #[cfg(feature = "operator-cli")]
-    #[test]
-    fn request_risk_round_trips_with_tool_filter() {
-        let req = Request::Risk {
-            tool: Some(sigil_core::event::AiTool::ClaudeCode),
-        };
-        let s = serde_json::to_string(&req).unwrap();
-        assert!(s.contains("\"tool\":\"claude_code\""), "got: {s}");
-        let back: Request = serde_json::from_str(&s).unwrap();
-        assert!(matches!(
-            back,
-            Request::Risk {
-                tool: Some(sigil_core::event::AiTool::ClaudeCode)
-            }
-        ));
-    }
-
-    #[cfg(feature = "operator-cli")]
-    #[test]
-    fn response_with_risk_payload_round_trips() {
-        use sigil_core::event::{AiGuardBucket, AiGuardScope, AiTool};
-        let resp = Response {
-            ok: true,
-            stats: None,
-            apply_policy: None,
-            policy_status: None,
-            targets: None,
-            risk: Some(RiskPayload {
-                assessments: vec![RiskSummary {
-                    tool: AiTool::Codex,
-                    scope: AiGuardScope::UserGlobal,
-                    score: 2.0,
-                    bucket: AiGuardBucket::Medium,
-                    reasons_count: 1,
-                    last_assessed_ts: "2026-05-16T06:00:00Z".into(),
-                }],
-            }),
-            doctor_ai_guard: None,
-            error: None,
-        };
-        let s = serde_json::to_string(&resp).unwrap();
-        assert!(s.contains("\"risk\""));
-        assert!(s.contains("\"tool\":\"codex\""));
-        assert!(s.contains("\"bucket\":\"medium\""));
-        let back: Response = serde_json::from_str(&s).unwrap();
-        assert!(back.risk.is_some());
-        assert_eq!(back.risk.as_ref().unwrap().assessments.len(), 1);
     }
 }

--- a/crates/sigil-agent/src/control_client.rs
+++ b/crates/sigil-agent/src/control_client.rs
@@ -100,7 +100,6 @@ mod tests {
                 policy_status: None,
                 targets: None,
                 risk: None,
-                #[cfg(feature = "operator-cli")]
                 doctor_ai_guard: None,
                 error: None,
             };

--- a/crates/sigil-core/src/control_proto.rs
+++ b/crates/sigil-core/src/control_proto.rs
@@ -1,0 +1,473 @@
+//! Wire protocol for the agent control socket (IPC). Shared by `sigil-agent`
+//! (server/handlers) and `sigil-mcp` (local-mode client) so the two can never
+//! drift. Types only — no handler/dispatch logic lives here.
+use crate::event::{AiGuardBucket, AiGuardScope, AiTool, PolicySignatureInvalidReason};
+use crate::policy::signed_envelope::SignedPolicyResponse;
+use crate::policy::Tier;
+use crate::stats::StatsSnapshot;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Pure resolver for the agent's default control-socket path — split out so the
+/// root/non-root/XDG/TMPDIR branches can be unit-tested without touching the
+/// process euid or environment. The agent's `default_control_socket()` wrapper
+/// reads euid/root/XDG/TMPDIR then delegates here.
+///
+/// As root, the system path `/var/run/sigil` (matches the systemd unit's
+/// `RuntimeDirectory=`). A non-root agent (macOS, non-root Linux) can't write
+/// there, so fall back to `$XDG_RUNTIME_DIR/sigil` (else `$TMPDIR`/`/tmp`
+/// namespaced by uid), keeping the control plane usable without elevation.
+pub fn resolve_control_socket(
+    is_root: bool,
+    xdg_runtime: Option<String>,
+    tmpdir: Option<String>,
+    uid: u32,
+) -> PathBuf {
+    if is_root {
+        return PathBuf::from("/var/run/sigil/control.sock");
+    }
+    if let Some(dir) = xdg_runtime {
+        return PathBuf::from(dir).join("sigil").join("control.sock");
+    }
+    let base = tmpdir.unwrap_or_else(|| "/tmp".to_string());
+    PathBuf::from(base)
+        .join(format!("sigil-{uid}"))
+        .join("control.sock")
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum Request {
+    /// Existing Phase 1 command — unchanged on the wire.
+    #[serde(rename = "stats")]
+    Stats,
+    /// Plan B `sigil-sender` hands a verified envelope here for application.
+    ApplyPolicy {
+        /// The full server response — agent re-verifies independently.
+        response: SignedPolicyResponse,
+    },
+    /// Operator + sender introspection: returns the agent's current
+    /// `last_applied_policy_version`, the active `valid_until`, and whether
+    /// the active policy is currently expired.
+    PolicyStatus,
+    /// Operator introspection: returns the agent's currently-active watch
+    /// targets and their compiled glob patterns.
+    Targets,
+    /// Operator action: re-read the policy file (after a hand-edit) without
+    /// verifying a signed envelope. Re-uses the existing live-reload pipeline
+    /// by nudging the policy-version watch channel.
+    ReloadPolicy,
+    /// Operator introspection: returns the latest AI Guard risk assessment
+    /// for each tool (or a single tool if `tool` is set).
+    Risk { tool: Option<AiTool> },
+    /// Operator introspection: returns a snapshot of the AI Guard
+    /// subsystem state for `sigil doctor`. Phase 3b.5.
+    DoctorAiGuardReport,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Response {
+    pub ok: bool,
+    pub stats: Option<StatsSnapshot>,
+    /// Present iff the request was `ApplyPolicy`.
+    pub apply_policy: Option<ApplyPolicyResult>,
+    /// Present iff the request was `PolicyStatus`.
+    pub policy_status: Option<PolicyStatusPayload>,
+    /// Present iff the request was `Targets` (Phase 2 operator introspection).
+    pub targets: Option<TargetsPayload>,
+    /// Present iff the request was `Risk`.
+    pub risk: Option<RiskPayload>,
+    /// Present iff the request was `DoctorAiGuardReport`. Phase 3b.5.
+    pub doctor_ai_guard: Option<DoctorAiGuardReport>,
+    pub error: Option<String>,
+}
+
+/// Outcome of an `apply_policy` request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ApplyPolicyResult {
+    /// Verifier accepted; policy.yaml written; version advanced.
+    Accepted {
+        /// The new `last_applied_policy_version`.
+        applied_policy_version: i64,
+    },
+    /// Verifier rejected. The wire-stable `reason` matches the
+    /// `PolicySignatureInvalid` event variant emitted in parallel.
+    Rejected {
+        /// Which check failed.
+        reason: PolicySignatureInvalidReason,
+    },
+}
+
+/// Snapshot of the agent's current policy state.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PolicyStatusPayload {
+    pub last_applied_policy_version: i64,
+    /// RFC 3339; `None` if no envelope has ever been applied.
+    pub active_envelope_valid_until: Option<String>,
+    /// `true` iff `now >= active_envelope_valid_until`.
+    pub policy_expired_active: bool,
+}
+
+/// Summary of one active watch target — what the agent is currently watching
+/// post-policy-merge + post-canonicalization.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TargetSummary {
+    pub id: String,
+    pub tier: Tier,
+    pub globs: Vec<String>,
+}
+
+/// Payload for the `targets` control-IPC response: the agent's currently-active
+/// compiled targets.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TargetsPayload {
+    pub targets: Vec<TargetSummary>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RiskPayload {
+    pub assessments: Vec<RiskSummary>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RiskSummary {
+    pub tool: AiTool,
+    pub scope: AiGuardScope,
+    pub score: f32,
+    pub bucket: AiGuardBucket,
+    pub reasons_count: usize,
+    /// RFC 3339.
+    pub last_assessed_ts: String,
+}
+
+/// Phase 3b.5 — serializable snapshot of the agent's AI Guard subsystem
+/// state, returned by `Request::DoctorAiGuardReport` for `sigil doctor`.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DoctorAiGuardReport {
+    /// Active parser instances. One entry per (tool, scope) pair.
+    pub parsers: Vec<ParserInfo>,
+    /// Discovered per-repo workspaces, count per tool.
+    pub per_repo: PerRepoSummary,
+    /// Loaded rule packs (3b.7). Skipped packs are not currently retained;
+    /// only loaded ones are reported. Future enhancement may surface skip
+    /// reasons from the loader.
+    pub rule_packs: Vec<RulePackInfo>,
+    /// External hook scripts (3b.3) currently being watched.
+    pub ext_scripts: ExtScriptSummary,
+    /// Latest risk assessment per (tool, scope) from ai_guard_state cache.
+    pub latest_risk: Vec<RiskSummary>,
+    /// Effective rubric — every kind_key with current weight + whether it
+    /// came from an operator override.
+    pub effective_rubric: Vec<RubricEntry>,
+    /// Snake_case override keys the envelope referenced but didn't match
+    /// any known kind. Surfaced by doctor as `[WARN]`.
+    pub unknown_override_keys: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ParserInfo {
+    pub tool: AiTool,
+    pub scope: AiGuardScope,
+    pub watched_path_count: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct PerRepoSummary {
+    pub continue_dev: usize,
+    pub claude_code: usize,
+    pub codex: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RulePackInfo {
+    pub id: String,
+    pub loaded: bool,
+    /// `None` when loaded. Reserved for future surfacing of skip reasons.
+    pub skip_reason: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct ExtScriptSummary {
+    /// Total unique canonical script paths across all parsers.
+    pub unique_paths: usize,
+    /// Number of (tool, scope) entries that have at least one ext-script.
+    pub parser_entries: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RubricEntry {
+    pub kind_key: String,
+    pub weight: f32,
+    pub overridden: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::signed_envelope::{SignedEnvelope, SignedPolicyResponse};
+    use time::macros::datetime;
+
+    fn sample_response() -> SignedPolicyResponse {
+        SignedPolicyResponse {
+            etag: "abc".into(),
+            signed_envelope: SignedEnvelope {
+                policy_version: 7,
+                policy_bytes_b64: "AAA=".into(),
+                valid_until: datetime!(2026-06-15 0:00 UTC),
+                issued_at: datetime!(2026-05-15 8:00 UTC),
+            },
+            signature: "sig".into(),
+            signing_pubkey_id: "k1".into(),
+            applied_at: datetime!(2026-05-15 8:01 UTC),
+        }
+    }
+
+    #[test]
+    fn apply_policy_request_round_trips() {
+        let req = Request::ApplyPolicy {
+            response: sample_response(),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        // The cmd discriminator MUST be exactly "apply_policy" (snake_case is
+        // wrong here — the existing Phase 1 control protocol uses lowercase).
+        assert!(s.contains("\"cmd\":\"apply_policy\""));
+        let back: Request = serde_json::from_str(&s).unwrap();
+        match back {
+            Request::ApplyPolicy { response } => {
+                assert_eq!(response.signed_envelope.policy_version, 7);
+            }
+            _ => panic!("expected ApplyPolicy, got {back:?}"),
+        }
+    }
+
+    #[test]
+    fn policy_status_request_round_trips() {
+        let req = Request::PolicyStatus;
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"cmd\":\"policy_status\""));
+        let _: Request = serde_json::from_str(&s).unwrap();
+    }
+
+    #[test]
+    fn response_includes_optional_apply_policy_payload() {
+        let r = Response {
+            ok: true,
+            stats: None,
+            apply_policy: Some(ApplyPolicyResult::Accepted {
+                applied_policy_version: 9,
+            }),
+            policy_status: None,
+            targets: None,
+            risk: None,
+            doctor_ai_guard: None,
+            error: None,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"apply_policy\""));
+        assert!(s.contains("\"applied_policy_version\":9"));
+    }
+
+    #[test]
+    fn response_apply_policy_rejected_carries_reason() {
+        let r = Response {
+            ok: false,
+            stats: None,
+            apply_policy: Some(ApplyPolicyResult::Rejected {
+                reason: PolicySignatureInvalidReason::Expired,
+            }),
+            policy_status: None,
+            targets: None,
+            risk: None,
+            doctor_ai_guard: None,
+            error: None,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"reason\":\"expired\""));
+    }
+
+    #[test]
+    fn response_with_targets_round_trips() {
+        let resp = Response {
+            ok: true,
+            stats: None,
+            apply_policy: None,
+            policy_status: None,
+            targets: Some(TargetsPayload {
+                targets: vec![TargetSummary {
+                    id: "tgt-1".into(),
+                    tier: Tier::Critical,
+                    globs: vec!["/etc/foo.yaml".into(), "/var/log/bar/*.log".into()],
+                }],
+            }),
+            risk: None,
+            doctor_ai_guard: None,
+            error: None,
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"targets\""));
+        assert!(s.contains("\"tgt-1\""));
+        assert!(
+            s.contains("\"critical\""),
+            "Tier::Critical serializes lowercase, got: {s}"
+        );
+        let back: Response = serde_json::from_str(&s).unwrap();
+        assert!(back.targets.is_some());
+        assert_eq!(back.targets.as_ref().unwrap().targets[0].id, "tgt-1");
+    }
+
+    #[test]
+    fn request_targets_round_trips() {
+        let req = Request::Targets;
+        let s = serde_json::to_string(&req).unwrap();
+        assert_eq!(s, r#"{"cmd":"targets"}"#);
+        let back: Request = serde_json::from_str(&s).unwrap();
+        assert!(matches!(back, Request::Targets));
+    }
+
+    #[test]
+    fn request_reload_policy_round_trips() {
+        let req = Request::ReloadPolicy;
+        let s = serde_json::to_string(&req).unwrap();
+        assert_eq!(s, r#"{"cmd":"reload_policy"}"#);
+        let back: Request = serde_json::from_str(&s).unwrap();
+        assert!(matches!(back, Request::ReloadPolicy));
+    }
+
+    #[test]
+    fn request_risk_round_trips_no_filter() {
+        let req = Request::Risk { tool: None };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"cmd\":\"risk\""), "got: {s}");
+        let back: Request = serde_json::from_str(&s).unwrap();
+        assert!(matches!(back, Request::Risk { tool: None }));
+    }
+
+    #[test]
+    fn request_risk_round_trips_with_tool_filter() {
+        let req = Request::Risk {
+            tool: Some(AiTool::ClaudeCode),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"tool\":\"claude_code\""), "got: {s}");
+        let back: Request = serde_json::from_str(&s).unwrap();
+        assert!(matches!(
+            back,
+            Request::Risk {
+                tool: Some(AiTool::ClaudeCode)
+            }
+        ));
+    }
+
+    #[test]
+    fn response_with_risk_payload_round_trips() {
+        let resp = Response {
+            ok: true,
+            stats: None,
+            apply_policy: None,
+            policy_status: None,
+            targets: None,
+            risk: Some(RiskPayload {
+                assessments: vec![RiskSummary {
+                    tool: AiTool::Codex,
+                    scope: AiGuardScope::UserGlobal,
+                    score: 2.0,
+                    bucket: AiGuardBucket::Medium,
+                    reasons_count: 1,
+                    last_assessed_ts: "2026-05-16T06:00:00Z".into(),
+                }],
+            }),
+            doctor_ai_guard: None,
+            error: None,
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"risk\""));
+        assert!(s.contains("\"tool\":\"codex\""));
+        assert!(s.contains("\"bucket\":\"medium\""));
+        let back: Response = serde_json::from_str(&s).unwrap();
+        assert!(back.risk.is_some());
+        assert_eq!(back.risk.as_ref().unwrap().assessments.len(), 1);
+    }
+
+    #[test]
+    fn root_uses_system_run_path() {
+        assert_eq!(
+            resolve_control_socket(
+                true,
+                Some("/run/user/1000".into()),
+                Some("/tmp".into()),
+                1000
+            ),
+            PathBuf::from("/var/run/sigil/control.sock")
+        );
+    }
+
+    #[test]
+    fn nonroot_prefers_xdg_runtime_dir() {
+        assert_eq!(
+            resolve_control_socket(
+                false,
+                Some("/run/user/501".into()),
+                Some("/tmp".into()),
+                501
+            ),
+            PathBuf::from("/run/user/501/sigil/control.sock")
+        );
+    }
+
+    #[test]
+    fn nonroot_without_xdg_uses_tmpdir_namespaced_by_uid() {
+        assert_eq!(
+            resolve_control_socket(false, None, Some("/custom/tmp".into()), 501),
+            PathBuf::from("/custom/tmp/sigil-501/control.sock")
+        );
+    }
+
+    #[test]
+    fn nonroot_without_xdg_or_tmpdir_falls_back_to_slash_tmp() {
+        assert_eq!(
+            resolve_control_socket(false, None, None, 42),
+            PathBuf::from("/tmp/sigil-42/control.sock")
+        );
+    }
+
+    #[test]
+    fn doctor_report_round_trips() {
+        let r = Response {
+            ok: true,
+            stats: None,
+            apply_policy: None,
+            policy_status: None,
+            targets: None,
+            risk: None,
+            error: None,
+            doctor_ai_guard: Some(DoctorAiGuardReport {
+                parsers: vec![],
+                rule_packs: vec![],
+                ext_scripts: Default::default(),
+                per_repo: PerRepoSummary {
+                    continue_dev: 0,
+                    claude_code: 2,
+                    codex: 1,
+                },
+                latest_risk: vec![RiskSummary {
+                    tool: AiTool::ClaudeCode,
+                    scope: AiGuardScope::UserGlobal,
+                    score: 8.0,
+                    bucket: AiGuardBucket::High,
+                    reasons_count: 3,
+                    last_assessed_ts: "2026-05-29T00:00:00Z".into(),
+                }],
+                effective_rubric: vec![RubricEntry {
+                    kind_key: "no_sandbox".into(),
+                    weight: 2.0,
+                    overridden: false,
+                }],
+                unknown_override_keys: vec![],
+            }),
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        let back: Response = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.doctor_ai_guard.unwrap().per_repo.claude_code, 2);
+    }
+}

--- a/crates/sigil-core/src/lib.rs
+++ b/crates/sigil-core/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(rust_2018_idioms)]
 
 pub mod audit;
+pub mod control_proto;
 pub mod debounce;
 pub mod event;
 pub mod hashing;

--- a/crates/sigil-mcp/Cargo.toml
+++ b/crates/sigil-mcp/Cargo.toml
@@ -13,6 +13,7 @@ name = "sigil-mcp"
 path = "src/main.rs"
 
 [dependencies]
+sigil-core = { path = "../sigil-core" }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }
@@ -24,6 +25,12 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 urlencoding = { workspace = true }
 
+# euid/uid reads for default_control_socket() in local mode — mirrors
+# sigil-agent's libc usage (sigil-agent declares `libc = "0.2"` directly).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 httpmock = { workspace = true }
 tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/sigil-mcp/README.md
+++ b/crates/sigil-mcp/README.md
@@ -1,13 +1,19 @@
 # sigil-mcp
 
-Read-only fleet MCP server. Exposes a `sigil-server`'s GET read API as
-Model Context Protocol tools so an MCP client (Claude Desktop/Code, etc.)
-can read and reason over fleet security posture. Read-only by construction:
-GET only, no write/remediation tools.
+Read-only MCP server for Sigil security posture. Two modes, auto-detected from
+the environment — both read-only by construction (no write/remediation tools):
+
+- **Fleet mode** (`SIGIL_SERVER_BASE_URL` set): exposes a `sigil-server`'s GET
+  read API as MCP tools so an MCP client (Claude Desktop/Code, etc.) can read
+  and reason over **fleet** security posture.
+- **Local mode** (no server URL): reads the local `sigil-agent`'s control socket
+  and exposes **this machine's** AI Guard posture — no server, no fleet. See
+  [Local mode](#local-mode-individual-self-assessment-no-server) below.
 
 ## Tools
-`list_hosts`, `get_host`, `fleet_risk`, `fleet_compliance`, `query_events`,
-`get_event`, `get_policy`, `server_meta`, `healthz`.
+Fleet mode: `list_hosts`, `get_host`, `fleet_risk`, `fleet_compliance`,
+`query_events`, `get_event`, `get_policy`, `server_meta`, `healthz`.
+Local mode: `my_risk`, `my_guard_detail`, `my_findings`.
 
 ## Configuration (env)
 
@@ -32,6 +38,27 @@ GET only, no write/remediation tools.
   }
 }
 ```
+
+## Local mode (individual self-assessment, no server)
+
+With `SIGIL_SERVER_BASE_URL` unset, `sigil-mcp` reads the running local
+`sigil-agent`'s control socket and exposes this machine's AI Guard posture as
+`my_risk` (per-tool risk band/score), `my_guard_detail` (rubric, parsers, rule
+packs), and `my_findings` (per-repo discovery + watched hook scripts).
+
+```json
+{
+  "mcpServers": {
+    "sigil-local": { "command": "sigil-mcp" }
+  }
+}
+```
+
+The socket path defaults to the same location `sigil-agent` uses
+(`$XDG_RUNTIME_DIR/sigil/control.sock`, `/var/run/sigil/control.sock` as root,
+or `/tmp/sigil-<uid>/control.sock`); override with `SIGIL_AGENT_CONTROL_SOCKET`.
+v1 expects the agent and `sigil-mcp` to run as the **same user** (the control
+socket is `0660`); root-daemon + group access is tracked in #10.
 
 ## Note for operators
 Configuration is validated at startup, but connectivity is not probed — an

--- a/crates/sigil-mcp/src/config.rs
+++ b/crates/sigil-mcp/src/config.rs
@@ -24,11 +24,6 @@ pub enum ConfigError {
 }
 
 impl Config {
-    pub fn from_env() -> Result<Self, ConfigError> {
-        let map: HashMap<String, String> = std::env::vars().collect();
-        Self::from_map(&map)
-    }
-
     pub fn from_map(map: &HashMap<String, String>) -> Result<Self, ConfigError> {
         let base_url = map
             .get("SIGIL_SERVER_BASE_URL")
@@ -62,11 +57,6 @@ impl Config {
 /// Operating mode, selected from the environment. `SIGIL_SERVER_BASE_URL`
 /// present -> [`Mode::Fleet`] (the existing read-API client config); absent ->
 /// [`Mode::Local`], which talks to a local sigil-agent over its control socket.
-///
-/// `dead_code` is allowed because `sigil-mcp` is a binary crate and `Mode` is
-/// not yet wired into `main` — the local transport + tools that consume it land
-/// in later tasks of #55. Remove the allow once `main` calls `Mode::from_env`.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum Mode {
     Fleet(Config),
@@ -74,13 +64,11 @@ pub enum Mode {
 }
 
 /// Local-mode config: the path to the local agent's control socket.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct LocalConfig {
     pub socket: PathBuf,
 }
 
-#[allow(dead_code)]
 impl Mode {
     pub fn from_env() -> Result<Self, ConfigError> {
         Self::from_map(&std::env::vars().collect())
@@ -105,7 +93,6 @@ impl Mode {
 /// branch logic is shared via `sigil_core::control_proto::resolve_control_socket`;
 /// this wrapper supplies the euid/root/XDG/TMPDIR inputs. Override with
 /// `SIGIL_AGENT_CONTROL_SOCKET`.
-#[allow(dead_code)]
 fn default_control_socket() -> PathBuf {
     sigil_core::control_proto::resolve_control_socket(
         is_root(),
@@ -118,13 +105,11 @@ fn default_control_socket() -> PathBuf {
 }
 
 /// True when the process effective uid is 0 (root). Non-Unix: always false.
-#[allow(dead_code)]
 #[cfg(unix)]
 fn is_root() -> bool {
     // SAFETY: `geteuid` has no preconditions and cannot fail.
     unsafe { libc::geteuid() == 0 }
 }
-#[allow(dead_code)]
 #[cfg(not(unix))]
 fn is_root() -> bool {
     false
@@ -132,13 +117,11 @@ fn is_root() -> bool {
 
 /// Process real uid — namespaces the fallback socket dir in shared `/tmp`.
 /// Non-Unix: 0 (unused; Windows uses the named pipe).
-#[allow(dead_code)]
 #[cfg(unix)]
 fn current_uid() -> u32 {
     // SAFETY: `getuid` has no preconditions and cannot fail.
     unsafe { libc::getuid() }
 }
-#[allow(dead_code)]
 #[cfg(not(unix))]
 fn current_uid() -> u32 {
     0

--- a/crates/sigil-mcp/src/config.rs
+++ b/crates/sigil-mcp/src/config.rs
@@ -59,6 +59,91 @@ impl Config {
     }
 }
 
+/// Operating mode, selected from the environment. `SIGIL_SERVER_BASE_URL`
+/// present -> [`Mode::Fleet`] (the existing read-API client config); absent ->
+/// [`Mode::Local`], which talks to a local sigil-agent over its control socket.
+///
+/// `dead_code` is allowed because `sigil-mcp` is a binary crate and `Mode` is
+/// not yet wired into `main` — the local transport + tools that consume it land
+/// in later tasks of #55. Remove the allow once `main` calls `Mode::from_env`.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum Mode {
+    Fleet(Config),
+    Local(LocalConfig),
+}
+
+/// Local-mode config: the path to the local agent's control socket.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct LocalConfig {
+    pub socket: PathBuf,
+}
+
+#[allow(dead_code)]
+impl Mode {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Self::from_map(&std::env::vars().collect())
+    }
+
+    pub fn from_map(map: &HashMap<String, String>) -> Result<Self, ConfigError> {
+        if map.contains_key("SIGIL_SERVER_BASE_URL") {
+            Ok(Mode::Fleet(Config::from_map(map)?))
+        } else {
+            let socket = map
+                .get("SIGIL_AGENT_CONTROL_SOCKET")
+                .map(PathBuf::from)
+                .unwrap_or_else(default_control_socket);
+            Ok(Mode::Local(LocalConfig { socket }))
+        }
+    }
+}
+
+/// Default agent control-socket path, mirroring sigil-agent's
+/// `default_control_socket()`: as root, the system path `/var/run/sigil`;
+/// else `$XDG_RUNTIME_DIR/sigil`; else `$TMPDIR`/`/tmp/sigil-<uid>`. The pure
+/// branch logic is shared via `sigil_core::control_proto::resolve_control_socket`;
+/// this wrapper supplies the euid/root/XDG/TMPDIR inputs. Override with
+/// `SIGIL_AGENT_CONTROL_SOCKET`.
+#[allow(dead_code)]
+fn default_control_socket() -> PathBuf {
+    sigil_core::control_proto::resolve_control_socket(
+        is_root(),
+        std::env::var("XDG_RUNTIME_DIR")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        std::env::var("TMPDIR").ok().filter(|s| !s.is_empty()),
+        current_uid(),
+    )
+}
+
+/// True when the process effective uid is 0 (root). Non-Unix: always false.
+#[allow(dead_code)]
+#[cfg(unix)]
+fn is_root() -> bool {
+    // SAFETY: `geteuid` has no preconditions and cannot fail.
+    unsafe { libc::geteuid() == 0 }
+}
+#[allow(dead_code)]
+#[cfg(not(unix))]
+fn is_root() -> bool {
+    false
+}
+
+/// Process real uid — namespaces the fallback socket dir in shared `/tmp`.
+/// Non-Unix: 0 (unused; Windows uses the named pipe).
+#[allow(dead_code)]
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // SAFETY: `getuid` has no preconditions and cannot fail.
+    unsafe { libc::getuid() }
+}
+#[allow(dead_code)]
+#[cfg(not(unix))]
+fn current_uid() -> u32 {
+    0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,5 +213,29 @@ mod tests {
             Config::from_map(&m),
             Err(ConfigError::PartialMtls)
         ));
+    }
+
+    #[test]
+    fn server_url_present_selects_fleet() {
+        let m = map(&[
+            ("SIGIL_SERVER_BASE_URL", "http://h:8443"),
+            ("SIGIL_SERVER_READ_TOKEN", "t"),
+        ]);
+        assert!(matches!(Mode::from_map(&m).unwrap(), Mode::Fleet(_)));
+    }
+
+    #[test]
+    fn no_server_url_selects_local() {
+        let m = map(&[]);
+        assert!(matches!(Mode::from_map(&m).unwrap(), Mode::Local(_)));
+    }
+
+    #[test]
+    fn explicit_socket_env_honored() {
+        let m = map(&[("SIGIL_AGENT_CONTROL_SOCKET", "/tmp/x/control.sock")]);
+        match Mode::from_map(&m).unwrap() {
+            Mode::Local(c) => assert_eq!(c.socket.to_str().unwrap(), "/tmp/x/control.sock"),
+            _ => panic!("expected local"),
+        }
     }
 }

--- a/crates/sigil-mcp/src/local.rs
+++ b/crates/sigil-mcp/src/local.rs
@@ -63,6 +63,7 @@ impl LocalUpstream {
         resp.doctor_ai_guard.ok_or(LocalError::Empty)
     }
 
+    #[cfg(unix)]
     async fn query(&self, req: &Request) -> anyhow::Result<Response> {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
         use tokio::net::UnixStream;
@@ -75,6 +76,19 @@ impl LocalUpstream {
         let mut line = String::new();
         BufReader::new(rd).read_line(&mut line).await?;
         Ok(serde_json::from_str(line.trim())?)
+    }
+
+    // Local mode reads the agent's Unix control socket. Windows uses a named
+    // pipe for that socket; wiring sigil-mcp to it is tracked separately (the
+    // spec scopes local mode to Unix for v1). On Windows, use fleet mode
+    // (SIGIL_SERVER_BASE_URL). This stub keeps the crate compiling there.
+    #[cfg(not(unix))]
+    async fn query(&self, req: &Request) -> anyhow::Result<Response> {
+        let _ = req;
+        anyhow::bail!(
+            "local mode (agent control socket) is only supported on Unix in v1; \
+             set SIGIL_SERVER_BASE_URL to use fleet mode on this platform"
+        )
     }
 }
 

--- a/crates/sigil-mcp/src/local.rs
+++ b/crates/sigil-mcp/src/local.rs
@@ -1,0 +1,137 @@
+//! Local-mode upstream: talks to a co-located `sigil-agent` over its control
+//! socket instead of the fleet read API. Read-only — fetches the AI Guard
+//! report via [`Request::DoctorAiGuardReport`]. The transport mirrors
+//! `sigil-agent`'s `control_client::query_unix`: connect, write one
+//! newline-terminated JSON request, shut down the write half so the agent sees
+//! EOF, then read one newline-terminated JSON `Response`.
+//!
+//! MCP tools that consume this land in the next task of #55; until then
+//! `from_cfg`/`query` are not yet called from `main`.
+
+use crate::config::LocalConfig;
+use rmcp::ErrorData as McpError;
+use sigil_core::control_proto::{DoctorAiGuardReport, Request, Response};
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LocalError {
+    #[error(
+        "local mode: no sigil-agent control socket at {0}: {1}. \
+         Start a local agent, set SIGIL_AGENT_CONTROL_SOCKET, or set SIGIL_SERVER_BASE_URL for fleet mode."
+    )]
+    Connect(String, String),
+    #[error("agent error: {0}")]
+    Agent(String),
+    #[error("agent returned no AI Guard report (built without operator-cli?)")]
+    Empty,
+}
+
+impl From<LocalError> for McpError {
+    fn from(e: LocalError) -> Self {
+        McpError::internal_error(e.to_string(), None)
+    }
+}
+
+#[derive(Clone)]
+pub struct LocalUpstream {
+    socket: PathBuf,
+}
+
+// `dead_code` is allowed because `sigil-mcp` is a binary crate and `LocalUpstream`
+// is not yet wired into `main` — the MCP tools that consume it land in Task 4 of
+// #55. The methods ARE exercised by this module's tests; the allow only silences
+// the non-test binary build. Remove it once `main` constructs `LocalUpstream`.
+#[allow(dead_code)]
+impl LocalUpstream {
+    pub fn new(socket: PathBuf) -> Self {
+        Self { socket }
+    }
+
+    pub fn from_cfg(cfg: &LocalConfig) -> Self {
+        Self {
+            socket: cfg.socket.clone(),
+        }
+    }
+
+    pub async fn doctor_report(&self) -> Result<DoctorAiGuardReport, LocalError> {
+        let resp = self
+            .query(&Request::DoctorAiGuardReport)
+            .await
+            .map_err(|e| LocalError::Connect(self.socket.display().to_string(), e.to_string()))?;
+        if let Some(err) = resp.error {
+            return Err(LocalError::Agent(err));
+        }
+        resp.doctor_ai_guard.ok_or(LocalError::Empty)
+    }
+
+    async fn query(&self, req: &Request) -> anyhow::Result<Response> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        use tokio::net::UnixStream;
+        let stream = UnixStream::connect(&self.socket).await?;
+        let (rd, mut wr) = stream.into_split();
+        let mut bytes = serde_json::to_vec(req)?;
+        bytes.push(b'\n');
+        wr.write_all(&bytes).await?;
+        wr.shutdown().await.ok();
+        let mut line = String::new();
+        BufReader::new(rd).read_line(&mut line).await?;
+        Ok(serde_json::from_str(line.trim())?)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use sigil_core::control_proto::{DoctorAiGuardReport, PerRepoSummary, Response};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    #[tokio::test]
+    async fn doctor_report_round_trips_against_canned_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("control.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let srv = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (rd, mut wr) = stream.into_split();
+            let mut line = String::new();
+            BufReader::new(rd).read_line(&mut line).await.unwrap();
+            assert_eq!(line.trim(), r#"{"cmd":"doctor_ai_guard_report"}"#);
+            let resp = Response {
+                ok: true,
+                stats: None,
+                apply_policy: None,
+                policy_status: None,
+                targets: None,
+                risk: None,
+                error: None,
+                doctor_ai_guard: Some(DoctorAiGuardReport {
+                    parsers: vec![],
+                    rule_packs: vec![],
+                    ext_scripts: Default::default(),
+                    per_repo: PerRepoSummary {
+                        continue_dev: 0,
+                        claude_code: 2,
+                        codex: 0,
+                    },
+                    latest_risk: vec![],
+                    effective_rubric: vec![],
+                    unknown_override_keys: vec![],
+                }),
+            };
+            let mut bytes = serde_json::to_vec(&resp).unwrap();
+            bytes.push(b'\n');
+            wr.write_all(&bytes).await.unwrap();
+        });
+        let up = LocalUpstream::new(socket);
+        let rep = up.doctor_report().await.unwrap();
+        assert_eq!(rep.per_repo.claude_code, 2);
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn errors_when_socket_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let up = LocalUpstream::new(dir.path().join("nope.sock"));
+        assert!(up.doctor_report().await.is_err());
+    }
+}

--- a/crates/sigil-mcp/src/local.rs
+++ b/crates/sigil-mcp/src/local.rs
@@ -5,8 +5,8 @@
 //! newline-terminated JSON request, shut down the write half so the agent sees
 //! EOF, then read one newline-terminated JSON `Response`.
 //!
-//! MCP tools that consume this land in the next task of #55; until then
-//! `from_cfg`/`query` are not yet called from `main`.
+//! Consumed by [`crate::local_tools::SigilLocal`]; `main` builds it via
+//! [`LocalUpstream::from_cfg`] in local mode.
 
 use crate::config::LocalConfig;
 use rmcp::ErrorData as McpError;
@@ -37,12 +37,11 @@ pub struct LocalUpstream {
     socket: PathBuf,
 }
 
-// `dead_code` is allowed because `sigil-mcp` is a binary crate and `LocalUpstream`
-// is not yet wired into `main` — the MCP tools that consume it land in Task 4 of
-// #55. The methods ARE exercised by this module's tests; the allow only silences
-// the non-test binary build. Remove it once `main` constructs `LocalUpstream`.
-#[allow(dead_code)]
 impl LocalUpstream {
+    /// Construct directly from a socket path. Test-only: `main` builds via
+    /// [`LocalUpstream::from_cfg`]; this is exercised by the canned-agent tests
+    /// here and in `local_tools`.
+    #[cfg(test)]
     pub fn new(socket: PathBuf) -> Self {
         Self { socket }
     }

--- a/crates/sigil-mcp/src/local.rs
+++ b/crates/sigil-mcp/src/local.rs
@@ -41,7 +41,7 @@ impl LocalUpstream {
     /// Construct directly from a socket path. Test-only: `main` builds via
     /// [`LocalUpstream::from_cfg`]; this is exercised by the canned-agent tests
     /// here and in `local_tools`.
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub fn new(socket: PathBuf) -> Self {
         Self { socket }
     }

--- a/crates/sigil-mcp/src/local_tools.rs
+++ b/crates/sigil-mcp/src/local_tools.rs
@@ -1,0 +1,149 @@
+use crate::local::LocalUpstream;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
+use std::sync::Arc;
+
+fn ok(v: serde_json::Value) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(v.to_string())]))
+}
+
+#[derive(Clone)]
+pub struct SigilLocal {
+    upstream: Arc<LocalUpstream>,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl SigilLocal {
+    pub fn new(upstream: Arc<LocalUpstream>) -> Self {
+        Self {
+            upstream,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        description = "This machine's AI-tool risk headline: per (tool, scope) risk band + score, \
+                          plus reasons_count and last-assessed time. Use for 'what's my AI risk?'."
+    )]
+    async fn my_risk(&self) -> Result<CallToolResult, McpError> {
+        let r = self.upstream.doctor_report().await?;
+        ok(serde_json::json!({ "latest_risk": r.latest_risk }))
+    }
+
+    #[tool(
+        description = "Why this machine is rated the way it is: effective rubric (weights/overrides), \
+                          active parsers per (tool, scope), loaded rule packs, unknown override keys."
+    )]
+    async fn my_guard_detail(&self) -> Result<CallToolResult, McpError> {
+        let r = self.upstream.doctor_report().await?;
+        ok(serde_json::json!({
+            "effective_rubric": r.effective_rubric,
+            "parsers": r.parsers,
+            "rule_packs": r.rule_packs,
+            "unknown_override_keys": r.unknown_override_keys,
+        }))
+    }
+
+    #[tool(
+        description = "Concrete surface Sigil found on this machine: per-repo workspace discovery \
+                          counts per tool, and external hook-script watch summary."
+    )]
+    async fn my_findings(&self) -> Result<CallToolResult, McpError> {
+        let r = self.upstream.doctor_report().await?;
+        ok(serde_json::json!({ "per_repo": r.per_repo, "ext_scripts": r.ext_scripts }))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for SigilLocal {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            instructions: Some(
+                "Read-only view of THIS machine's Sigil AI Guard posture (no fleet, no server). \
+                 Start with my_risk, explain with my_guard_detail, list findings with my_findings. \
+                 There are no write or remediation tools."
+                    .to_string(),
+            ),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use sigil_core::control_proto::{DoctorAiGuardReport, PerRepoSummary, Response};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    /// Stands up a canned UnixListener that replies to a single
+    /// `DoctorAiGuardReport` request, mirroring `local.rs`'s test harness.
+    fn canned_agent(socket: std::path::PathBuf) -> tokio::task::JoinHandle<()> {
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (rd, mut wr) = stream.into_split();
+            let mut line = String::new();
+            BufReader::new(rd).read_line(&mut line).await.unwrap();
+            let resp = Response {
+                ok: true,
+                stats: None,
+                apply_policy: None,
+                policy_status: None,
+                targets: None,
+                risk: None,
+                error: None,
+                doctor_ai_guard: Some(DoctorAiGuardReport {
+                    parsers: vec![],
+                    rule_packs: vec![],
+                    ext_scripts: Default::default(),
+                    per_repo: PerRepoSummary {
+                        continue_dev: 0,
+                        claude_code: 2,
+                        codex: 0,
+                    },
+                    latest_risk: vec![],
+                    effective_rubric: vec![],
+                    unknown_override_keys: vec![],
+                }),
+            };
+            let mut bytes = serde_json::to_vec(&resp).unwrap();
+            bytes.push(b'\n');
+            wr.write_all(&bytes).await.unwrap();
+        })
+    }
+
+    fn text(res: &CallToolResult) -> String {
+        res.content
+            .iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    #[tokio::test]
+    async fn my_risk_returns_latest_risk() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("control.sock");
+        let srv = canned_agent(socket.clone());
+        let local = SigilLocal::new(Arc::new(LocalUpstream::new(socket)));
+        let res = local.my_risk().await.unwrap();
+        assert_eq!(res.is_error, Some(false));
+        assert!(text(&res).contains("latest_risk"));
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn my_findings_returns_per_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("control.sock");
+        let srv = canned_agent(socket.clone());
+        let local = SigilLocal::new(Arc::new(LocalUpstream::new(socket)));
+        let res = local.my_findings().await.unwrap();
+        assert_eq!(res.is_error, Some(false));
+        assert!(text(&res).contains("per_repo"));
+        srv.await.unwrap();
+    }
+}

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod local;
 mod tools;
 mod upstream;
 

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,9 +1,12 @@
 mod config;
 mod local;
+mod local_tools;
 mod tools;
 mod upstream;
 
-use crate::config::Config;
+use crate::config::Mode;
+use crate::local::LocalUpstream;
+use crate::local_tools::SigilLocal;
 use crate::tools::SigilFleet;
 use crate::upstream::Upstream;
 use rmcp::transport::stdio;
@@ -21,10 +24,17 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let cfg = Config::from_env()?;
-    tracing::info!(base_url = %cfg.base_url, mtls = cfg.mtls.is_some(), "starting sigil-mcp");
-    let upstream = Arc::new(Upstream::new(&cfg)?);
-    let service = SigilFleet::new(upstream).serve(stdio()).await?;
-    service.waiting().await?;
+    match Mode::from_env()? {
+        Mode::Fleet(cfg) => {
+            tracing::info!(mode = "fleet", base_url = %cfg.base_url, mtls = cfg.mtls.is_some(), "starting sigil-mcp");
+            let up = Arc::new(Upstream::new(&cfg)?);
+            SigilFleet::new(up).serve(stdio()).await?.waiting().await?;
+        }
+        Mode::Local(cfg) => {
+            tracing::info!(mode = "local", socket = %cfg.socket.display(), "starting sigil-mcp");
+            let up = Arc::new(LocalUpstream::from_cfg(&cfg));
+            SigilLocal::new(up).serve(stdio()).await?.waiting().await?;
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
## What

Adds a **local mode** to `sigil-mcp`: install `sigil` → register `sigil-mcp` in Claude Code **with no server URL** → ask "what's my AI risk?" and get *this machine's* AI Guard posture conversationally. No `sigil-server`, no fleet.

Mode is auto-detected from the environment: `SIGIL_SERVER_BASE_URL` present → fleet (unchanged); absent → local, reading the local `sigil-agent` control socket.

## How

Daemon-backed, **zero new assessment logic** — reuses the existing `Request::DoctorAiGuardReport` IPC that powers `sigil doctor`. `sigil-mcp` gains a second upstream transport (Unix socket) alongside the existing HTTP client.

| Commit | Change |
|--------|--------|
| `refactor(core)` | Extract control wire types (`Request`/`Response`/`DoctorAiGuardReport`/…) + pure socket-path resolver from `sigil-agent` into `sigil-core::control_proto`, so `sigil-mcp` shares the contract without depending on the agent crate. `cfg(operator-cli)` dropped in core (types always exist); agent keeps a `not(operator-cli)` fallback arm + re-exports. No behavior change. |
| `feat(mcp)` Mode | `Mode::{Fleet,Local}` + env auto-detect; `SIGIL_AGENT_CONTROL_SOCKET` override, else the same default-path resolution as `sigil-agent`. |
| `feat(mcp)` local upstream | `LocalUpstream` connects the control socket and fetches a `DoctorAiGuardReport` (mirrors `control_client::query_unix`). Read-only. |
| `feat(mcp)` tools | `my_risk` / `my_guard_detail` / `my_findings` — three read-only tools, each from one `DoctorAiGuardReport` call. `main()` dispatches on mode. Fleet tools are not exposed in local mode. |
| `docs(mcp)` | Local-mode registration recipe + same-user note in the crate and top READMEs. |

## Tool surface (local mode)

- `my_risk` — per (tool, scope) risk band + score, headline.
- `my_guard_detail` — effective rubric, active parsers, loaded rule packs.
- `my_findings` — per-repo workspace discovery + watched hook scripts.

## Security (v1)

Same-user: the control socket is `0660`, so v1 expects the agent and `sigil-mcp` to run as the same user (the individual-developer case). Root-daemon + group access is deferred to #10 (hardening).

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo build -p sigil-agent --no-default-features`: green (exercises the `not(operator-cli)` fallback arm).
- `sigil-core` (201) + `sigil-mcp` (25+6) tests pass — deterministic feature code.
- New tests use a canned `UnixListener` mock agent (mirrors `control_client` test pattern).

Spec & plan: `docs/superpowers/specs/2026-05-29-sigil-mcp-local-mode-design.html`, `docs/superpowers/plans/2026-05-29-sigil-mcp-local-mode.html`.

Closes #55.