### PR TITLE
fix(hardening): codex follow-ups for #10 slice 1 — events-dir owner check + sender group (#60, #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
   `UnixStream::peer_cred`) before trusting its `DoctorAiGuardReport`, closing a
   local security-telemetry spoofing gap where another user could serve a
   fabricated "all-clear" posture. Returns a distinct `UntrustedPeer` error.
+- **`sigil doctor` events-dir check now validates the owner, not just the group**
+  (#60). `classify_events_dir_perms` previously checked only group + mode, so a
+  dir owned by a non-root user with group `sigil` and mode `0750` was falsely
+  reported as `root:sigil`-hardened while that owner could still mutate it. It
+  now warns on a non-root owner, mirroring the control-socket classifier.
+- **Standalone `sigil-sender` install no longer fails on `Group=sigil`** (#61).
+  The sender unit runs `root:sigil`, but the sender package neither created the
+  group nor depended on the agent package, so a sender-only install left
+  `systemctl enable --now sigil-sender` failing on group credential resolution.
+  The sender package now ships and applies the same idempotent
+  `sysusers.d`/`tmpfiles.d` `sigil.conf` as the agent package.
 
 ### Changed
 

--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -982,7 +982,7 @@ mod linux_tests {
 
     #[test]
     fn check_events_dir_perms_warns_when_world_writable() {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
         let dir = tempfile::tempdir().unwrap();
         let ev = dir.path().join("events");
         std::fs::create_dir(&ev).unwrap();
@@ -993,12 +993,19 @@ mod linux_tests {
         std::fs::write(&group_file, "sigil:x:996:\n").unwrap();
         let r = check_events_dir_perms(&ev, &group_file);
         assert_eq!(r.level, CheckLevel::Warn);
-        assert!(r.message.contains("777"), "{:?}", r);
+        // A non-root owner is flagged before the mode (#60), so only a
+        // root-owned tempdir (CI container jobs run as root) reaches the
+        // world-writable message; a non-root runner sees the owner warning.
+        if std::fs::metadata(&ev).unwrap().uid() == 0 {
+            assert!(r.message.contains("777"), "{:?}", r);
+        } else {
+            assert!(r.message.contains("uid="), "{:?}", r);
+        }
     }
 
     #[test]
     fn check_events_dir_perms_ok_for_0750() {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
         let dir = tempfile::tempdir().unwrap();
         let ev = dir.path().join("events");
         std::fs::create_dir(&ev).unwrap();
@@ -1008,12 +1015,18 @@ mod linux_tests {
         // Empty group file → `read_group_gid_from` returns None → the gid
         // ownership check inside `check_events_dir_perms` is skipped. We can't
         // chown the tempdir to a real `sigil` gid in a unit test, so this
-        // isolates the mode check.
+        // isolates the mode check — but only when the dir is root-owned.
         let group_file = dir.path().join("group");
         std::fs::write(&group_file, "").unwrap();
         let r = check_events_dir_perms(&ev, &group_file);
-        assert_eq!(r.level, CheckLevel::Ok);
-        assert!(r.message.contains("0750"), "{:?}", r);
+        if std::fs::metadata(&ev).unwrap().uid() == 0 {
+            assert_eq!(r.level, CheckLevel::Ok);
+            assert!(r.message.contains("0750"), "{:?}", r);
+        } else {
+            // A non-root runner owns the tempdir, so the owner check warns (#60).
+            assert_eq!(r.level, CheckLevel::Warn, "{r:?}");
+            assert!(r.message.contains("uid="), "{:?}", r);
+        }
     }
 }
 

--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -683,25 +683,34 @@ fn check_events_dir_perms(
     classify_events_dir_perms(
         &events_dir.display().to_string(),
         meta.is_dir(),
+        meta.uid(),
         meta.mode() & 0o777,
         meta.gid(),
         read_group_gid_from(group_file, "sigil"),
     )
 }
 
-/// Pure classifier for the events dir (testable without a real dir). Accepts
-/// 0750 (group-read for sigil) or 0755 (world-read); world-write is always Warn;
-/// if the sigil group exists, the dir gid must match it (#10).
+/// Pure classifier for the events dir (testable without a real dir). The dir must
+/// be root-owned (mirrors the control-socket check); accepts 0750 (group-read for
+/// sigil) or 0755 (world-read); world-write is always Warn; if the sigil group
+/// exists, the dir gid must match it (#10). A non-root owner is a Warn even with
+/// `root:sigil`-looking group/mode, since that owner can still mutate the dir (#60).
 #[cfg(target_os = "linux")]
 fn classify_events_dir_perms(
     path: &str,
     is_dir: bool,
+    uid: u32,
     mode: u32,
     gid: u32,
     sigil_gid: Option<u32>,
 ) -> CheckResult {
     if !is_dir {
         return CheckResult::warn(format!("events dir: {path} exists but is not a directory"));
+    }
+    if uid != 0 {
+        return CheckResult::warn(format!(
+            "events dir owner: uid={uid}, expected root (uid 0) at {path}"
+        ));
     }
     if mode & 0o002 != 0 {
         return CheckResult::warn(format!(
@@ -859,30 +868,39 @@ mod linux_tests {
 
     #[test]
     fn classify_events_dir_ok_root_sigil_0750() {
-        let r = classify_events_dir_perms("/var/log/sigil", true, 0o750, 996, Some(996));
+        let r = classify_events_dir_perms("/var/log/sigil", true, 0, 0o750, 996, Some(996));
         assert_eq!(r.level, CheckLevel::Ok, "{r:?}");
         assert!(r.message.contains("root:sigil(996)"), "{r:?}");
     }
     #[test]
     fn classify_events_dir_ok_without_group_0755() {
-        let r = classify_events_dir_perms("/var/log/sigil", true, 0o755, 0, None);
+        let r = classify_events_dir_perms("/var/log/sigil", true, 0, 0o755, 0, None);
         assert_eq!(r.level, CheckLevel::Ok, "{r:?}");
     }
     #[test]
+    fn classify_events_dir_warn_not_root_owned() {
+        // Owned by a non-root user but group=sigil mode=0750: must NOT pass as
+        // root:sigil — the owner can still mutate the dir (#60).
+        let r = classify_events_dir_perms("/var/log/sigil", true, 1000, 0o750, 996, Some(996));
+        assert_eq!(r.level, CheckLevel::Warn, "{r:?}");
+        assert!(r.message.contains("uid=1000"), "{r:?}");
+        assert!(!r.message.contains("root:sigil"), "{r:?}");
+    }
+    #[test]
     fn classify_events_dir_warn_world_writable() {
-        let r = classify_events_dir_perms("/var/log/sigil", true, 0o757, 0, None);
+        let r = classify_events_dir_perms("/var/log/sigil", true, 0, 0o757, 0, None);
         assert_eq!(r.level, CheckLevel::Warn, "{r:?}");
         assert!(r.message.contains("world-writable"), "{r:?}");
     }
     #[test]
     fn classify_events_dir_warn_group_mismatch() {
-        let r = classify_events_dir_perms("/var/log/sigil", true, 0o750, 0, Some(996));
+        let r = classify_events_dir_perms("/var/log/sigil", true, 0, 0o750, 0, Some(996));
         assert_eq!(r.level, CheckLevel::Warn, "{r:?}");
         assert!(r.message.contains("expected gid=996"), "{r:?}");
     }
     #[test]
     fn classify_events_dir_warn_not_a_dir() {
-        let r = classify_events_dir_perms("/var/log/sigil", false, 0o750, 0, None);
+        let r = classify_events_dir_perms("/var/log/sigil", false, 0, 0o750, 0, None);
         assert_eq!(r.level, CheckLevel::Warn, "{r:?}");
         assert!(r.message.contains("not a directory"), "{r:?}");
     }

--- a/crates/sigil-sender/Cargo.toml
+++ b/crates/sigil-sender/Cargo.toml
@@ -64,6 +64,11 @@ assets = [
     ["../../config/sender.example.yaml", "etc/sigil/sender.yaml.example", "644"],
     ["../../README.md", "usr/share/doc/sigil-sender/README.md", "644"],
     ["../../LICENSE", "usr/share/doc/sigil-sender/LICENSE", "644"],
+    # Ship the sigil group/user + dir declarations so a standalone sender install
+    # establishes Group=sigil before the unit starts (#61). Idempotent — a no-op
+    # when the agent package already created them.
+    ["../../packaging/sysusers.d/sigil.conf", "usr/lib/sysusers.d/sigil.conf", "644"],
+    ["../../packaging/tmpfiles.d/sigil.conf", "usr/lib/tmpfiles.d/sigil.conf", "644"],
 ]
 
 [package.metadata.deb.systemd-units]
@@ -82,9 +87,15 @@ assets = [
     { source = "../../config/sender.example.yaml", dest = "/etc/sigil/sender.yaml.example", mode = "0644" },
     { source = "../../README.md", dest = "/usr/share/doc/sigil-sender/README.md", mode = "0644", doc = true },
     { source = "../../LICENSE", dest = "/usr/share/doc/sigil-sender/LICENSE", mode = "0644", doc = true },
+    { source = "../../packaging/sysusers.d/sigil.conf", dest = "/usr/lib/sysusers.d/sigil.conf", mode = "0644" },
+    { source = "../../packaging/tmpfiles.d/sigil.conf", dest = "/usr/lib/tmpfiles.d/sigil.conf", mode = "0644" },
 ]
+# Apply sysusers/tmpfiles so a standalone sender install creates the sigil
+# group/user + dirs before the unit's Group=sigil resolves (#61). Idempotent.
 post_install_script = """\
 systemctl daemon-reload >/dev/null 2>&1 || :
+command -v systemd-sysusers >/dev/null 2>&1 && systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || :
+command -v systemd-tmpfiles >/dev/null 2>&1 && systemd-tmpfiles --create /usr/lib/tmpfiles.d/sigil.conf >/dev/null 2>&1 || :
 """
 pre_uninstall_script = """\
 if [ "$1" = 0 ] ; then

--- a/packaging/debian-sender/postinst
+++ b/packaging/debian-sender/postinst
@@ -3,4 +3,15 @@ set -e
 
 #DEBHELPER#
 
+# Sigil hardening (#61): a standalone sender install must create the sigil
+# group/user + own the dirs so the unit's Group=sigil resolves before start.
+# Guarded so non-systemd hosts no-op. Idempotent (sysusers/tmpfiles are
+# declarative; a no-op when the agent package already created them).
+if command -v systemd-sysusers >/dev/null 2>&1; then
+    systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || true
+fi
+if command -v systemd-tmpfiles >/dev/null 2>&1; then
+    systemd-tmpfiles --create /usr/lib/tmpfiles.d/sigil.conf >/dev/null 2>&1 || true
+fi
+
 exit 0


### PR DESCRIPTION
Follow-up fixes from the codex review of the #10 slice-1 hardening foundation (merged separately in #59). Branches on the merged foundation; carries only the two review findings + a CHANGELOG note.

## Fixes

- **#60 — `sigil doctor` events-dir check validates the owner, not just the group.** `classify_events_dir_perms` checked group (`gid == sigil`) + mode but never the owner uid, unlike the sibling control-socket classifier. A dir owned by a non-root user with group `sigil` and mode `0750` was falsely reported as `root:sigil`-hardened while that owner could still mutate it. Now warns on a non-root owner; adds a non-root-owner unit test. (`Fixes #60`)
- **#61 — standalone `sigil-sender` install no longer fails on `Group=sigil`.** The sender unit runs `root:sigil`, but the sender package neither created the `sigil` group nor depended on the agent package — so a sender-only install left `systemctl enable --now sigil-sender` failing on group credential resolution. The sender deb+rpm now ship and apply the same idempotent `sysusers.d`/`tmpfiles.d` `sigil.conf` as the agent package. (`Fixes #61`)

## Verification (Rocky Linux 9.7 aarch64, SELinux enforcing)

- **#60:** Linux `doctor` unit tests green, including the new non-root-owner case. (`doctor`'s classifier is `cfg(target_os="linux")`, so it runs on Linux/CI, not macOS — verified on the Rocky box.) Linux `clippy -D warnings` clean.
- **#61:** Built the sender rpm and installed it **standalone** on a clean host (no agent package). The sender postinst created the `sigil` group/user and `root:sigil 0750` dirs; the unit's `Group=sigil` resolved and `RuntimeDirectory=sigil` was set up; it reached `ExecStart` and failed only on missing app config (`host_id not configured`) — **zero `216/GROUP` / credential errors**, confirming the fix.

Fixes #60, #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)