### PR TITLE
feat(systemd): run sigil-server as the unprivileged sigil user (#10 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
   package applies both at install (deb postinst + rpm scriptlet, guarded and
   idempotent). Foundation for de-rooting the sender/server daemons in later
   slices; the agent stays root for file-integrity monitoring.
+- **`sigil-server` runs as the unprivileged `sigil` user** (#10 slice 2). The
+  server unit switches from `User=root` to `User=sigil` + `Group=sigil`; systemd
+  owns its `StateDirectory`/`LogsDirectory` (`/var/lib/sigil-server`,
+  `/var/log/sigil-server`) as `sigil:sigil 0750`. The server package now creates
+  the `sigil` user at install (sysusers.d via deb postinst + rpm scriptlet,
+  idempotent), so a standalone server install resolves `User=sigil` before start.
+  No code change — the server binds a non-privileged port (`:8443`) and writes
+  only under its state dir. When mTLS is enabled, the operator must make
+  `tls_key_path` readable by the `sigil` user.
 
 ### Fixed
 

--- a/crates/sigil-server/Cargo.toml
+++ b/crates/sigil-server/Cargo.toml
@@ -63,6 +63,11 @@ assets = [
     ["../../config/server.example.yaml", "etc/sigil/server.yaml.example", "644"],
     ["../../README.md", "usr/share/doc/sigil-server/README.md", "644"],
     ["../../LICENSE", "usr/share/doc/sigil-server/LICENSE", "644"],
+    # Create the sigil group/user so the unit's User=sigil resolves at start
+    # (#10 slice 2). Idempotent. No tmpfiles here: systemd StateDirectory=
+    # sigil-server owns /var/lib/sigil-server as sigil:sigil; the agent's
+    # /var/lib/sigil is not used on a server-only host.
+    ["../../packaging/sysusers.d/sigil.conf", "usr/lib/sysusers.d/sigil.conf", "644"],
 ]
 
 [package.metadata.deb.systemd-units]
@@ -80,9 +85,13 @@ assets = [
     { source = "../../config/server.example.yaml", dest = "/etc/sigil/server.yaml.example", mode = "0644" },
     { source = "../../README.md", dest = "/usr/share/doc/sigil-server/README.md", mode = "0644", doc = true },
     { source = "../../LICENSE", dest = "/usr/share/doc/sigil-server/LICENSE", mode = "0644", doc = true },
+    { source = "../../packaging/sysusers.d/sigil.conf", dest = "/usr/lib/sysusers.d/sigil.conf", mode = "0644" },
 ]
+# Create the sigil user/group so the unit's User=sigil resolves before start
+# (#10 slice 2). Idempotent; no-op when the agent package already created it.
 post_install_script = """\
 systemctl daemon-reload >/dev/null 2>&1 || :
+command -v systemd-sysusers >/dev/null 2>&1 && systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || :
 """
 pre_uninstall_script = """\
 if [ "$1" = 0 ] ; then

--- a/packaging/debian-server/postinst
+++ b/packaging/debian-server/postinst
@@ -3,4 +3,11 @@ set -e
 
 #DEBHELPER#
 
+# Sigil hardening (#10 slice 2): create the sigil group/user so the server
+# unit's User=sigil resolves before start. Guarded so non-systemd hosts no-op.
+# Idempotent (sysusers is declarative; a no-op if the group/user already exist).
+if command -v systemd-sysusers >/dev/null 2>&1; then
+    systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || true
+fi
+
 exit 0

--- a/packaging/systemd/sigil-server.service
+++ b/packaging/systemd/sigil-server.service
@@ -19,9 +19,18 @@ Type=simple
 ExecStart=/usr/bin/sigil-server serve --config /etc/sigil/server.yaml
 Restart=on-failure
 RestartSec=5
-User=root
+# Runs as the unprivileged sigil user (#10 slice 2). systemd creates
+# StateDirectory/LogsDirectory owned sigil:sigil. The sigil user/group is
+# created by this package at install (sysusers.d). NOTE: when mTLS is enabled,
+# the operator must make tls_key_path readable by the sigil user (e.g.
+# `chown root:sigil server.key && chmod 0640 server.key`) — the private key is
+# operator-provided, not packaged.
+User=sigil
+Group=sigil
 StateDirectory=sigil-server
 LogsDirectory=sigil-server
+StateDirectoryMode=0750
+LogsDirectoryMode=0750
 NoNewPrivileges=yes
 ProtectSystem=strict
 ReadWritePaths=/var/lib/sigil-server /var/log/sigil-server


### PR DESCRIPTION
#10 slice 2 (first half): de-root the **server** daemon. The server has its own `StateDirectory`/`LogsDirectory` and shares nothing with the agent, so it de-roots cleanly — no code change, packaging + unit only. (The sender de-root, which shares dirs with the agent and needs its own state dir + migration, is a separate follow-up PR.)

## Changes

- **`packaging/systemd/sigil-server.service`** — `User=root` → `User=sigil` + `Group=sigil`; add `StateDirectoryMode=0750` / `LogsDirectoryMode=0750`. systemd owns `/var/lib/sigil-server` + `/var/log/sigil-server` as `sigil:sigil 0750`.
- **`crates/sigil-server/Cargo.toml`** — ship + apply `sysusers.d/sigil.conf` (deb postinst + rpm `post_install_script`, idempotent) so a standalone server install creates the `sigil` user before the unit's `User=sigil` resolves (same pattern as the sender fix #61). **No tmpfiles**: `StateDirectory` creates the server dirs, and the agent's `/var/lib/sigil` isn't used on a server-only host.
- **`packaging/debian-server/postinst`** — apply sysusers on `.deb`.
- mTLS note in the unit: the operator must make `tls_key_path` readable by the `sigil` user (the private key is operator-provided, not packaged).

No server code change: it binds a non-privileged port (`:8443`) and writes only under its state dir; no `chown`/`setuid`/privileged ops.

## Verification (Rocky Linux 9.7 aarch64, SELinux enforcing)

Built the server rpm and installed it **standalone** on a clean host (no agent):

- `sigil` group/user created by the server postinst; unit shows `User=sigil Group=sigil`.
- systemd created `/var/lib/sigil-server` + `/var/log/sigil-server` as **`sigil:sigil 0750`**.
- Started with a minimal config on a test port: the process runs as **`sigil`**, **listens on `127.0.0.1:18443`** (non-root bind), and **writes under its state dir** (`/var/lib/sigil-server/events/` with `audit-signing.key`, `license-audit.jsonl`).
- With no config, it fails only on `load config … No such file` — **zero `216/GROUP` / `217/USER` credential errors**, confirming `User=sigil` resolves and `StateDirectory` is set up before `ExecStart`.

`cargo metadata` (manifest parse) + `cargo fmt --check` clean; no Rust changed.

## Refs

Refs #10 (slice 2, server). Follow-ups: sender de-root (dedicated `/var/lib/sigil-sender` + migration), SELinux `sigil_t` labeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)