### PR TITLE
feat(systemd): run sigil-sender as the unprivileged sigil user (#10 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,23 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
   No code change — the server binds a non-privileged port (`:8443`) and writes
   only under its state dir. When mTLS is enabled, the operator must make
   `tls_key_path` readable by the `sigil` user.
+- **`sigil-sender` runs as the unprivileged `sigil` user** (#10 slice 2). The
+  sender unit switches from `User=root` to `User=sigil` (keeping `Group=sigil`)
+  and writes only its own state/log dirs — `StateDirectory=sigil-sender` /
+  `LogsDirectory=sigil-sender` (`/var/lib/sigil-sender`, `/var/log/sigil-sender`,
+  owned `sigil:sigil 0750`). It still *reads* the agent's `root:sigil` spool and
+  connects to the control socket via the `sigil` group, and no longer declares a
+  `RuntimeDirectory`. `offset_path` and `dead_letter_dir` now default to the
+  sender-owned dirs when omitted.
+
+  **Breaking (operator action on upgrade):** an existing `/etc/sigil/sender.yaml`
+  that sets `offset_path: /var/lib/sigil/sender-offset.json` and
+  `dead_letter_dir: /var/log/sigil/dead-letter` must move them to
+  `/var/lib/sigil-sender/sender-offset.json` and `/var/log/sigil-sender/dead-letter`
+  (or delete both lines to take the new defaults) — the non-root sender cannot
+  write the agent's `root:sigil` dirs. To preserve the read position (avoid
+  re-shipping the spool), move the offset file too:
+  `install -o sigil -g sigil -m700 -d /var/lib/sigil-sender && mv /var/lib/sigil/sender-offset.json /var/lib/sigil-sender/ && chown sigil:sigil /var/lib/sigil-sender/sender-offset.json`.
 
 ### Fixed
 

--- a/config/sender.example.yaml
+++ b/config/sender.example.yaml
@@ -9,20 +9,23 @@ client_cert_path: "/etc/sigil/client.crt"
 client_key_path: "/etc/sigil/client.key"
 server_ca_path: "/etc/sigil/server-ca.pem"
 
-# Where the agent writes its JSONL posture events. The sender tails this dir
-# and ships unsent records.
+# Where the agent writes its JSONL posture events. The sender only READS this
+# dir (the agent owns it root:sigil) and ships unsent records.
 events_dir: "/var/log/sigil/events"
 
-# The sender's durable read-offset checkpoint (atomic-rename writes).
-offset_path: "/var/lib/sigil/sender-offset.json"
+# The sender's durable read-offset checkpoint (atomic-rename writes). This is
+# sender-owned and writable — it lives in the sender's own state dir so the
+# non-root sender can write it. Defaults to this path if omitted.
+offset_path: "/var/lib/sigil-sender/sender-offset.json"
 
 # Agent control IPC. Used by the sender to forward apply_policy responses
 # pulled from /v1/policy.
 agent_control: "/var/run/sigil/control.sock"
 
 # Where the sender quarantines events the server permanently rejects (HTTP
-# 4xx that aren't transient). Operator audits these out-of-band.
-dead_letter_dir: "/var/log/sigil/dead-letter"
+# 4xx that aren't transient). Sender-owned/writable; defaults to this path if
+# omitted. Operator audits these out-of-band.
+dead_letter_dir: "/var/log/sigil-sender/dead-letter"
 
 # REQUIRED — this host's identifier. Must equal the agent's host_id (the UUID
 # stored in the agent's state.db, shown by `sigil show host-id`). The server

--- a/crates/sigil-sender/src/config.rs
+++ b/crates/sigil-sender/src/config.rs
@@ -17,13 +17,21 @@ pub struct SenderConfig {
     pub client_key_path: PathBuf,
     /// Path to CA bundle that signs the server cert (PEM).
     pub server_ca_path: PathBuf,
-    /// Path to the agent's events directory (where JSONL spool lives).
+    /// Path to the agent's events directory (where JSONL spool lives). The
+    /// sender only *reads* this (the agent owns it `root:sigil`), so it is
+    /// reachable by the `sigil` group.
     pub events_dir: PathBuf,
-    /// Path where `sender-offset.json` is persisted.
+    /// Path where `sender-offset.json` is persisted. Sender-owned and writable;
+    /// defaults to the sender's own state dir (`/var/lib/sigil-sender`) so the
+    /// non-root sender (#10 slice 2) can write it without touching the agent's
+    /// `root:sigil` `/var/lib/sigil`.
+    #[serde(default = "default_offset_path")]
     pub offset_path: PathBuf,
     /// Path to the agent's control IPC (Unix socket on unix; pipe name on Windows).
     pub agent_control: PathBuf,
-    /// Path to host-side dead-letter spool dir.
+    /// Path to host-side dead-letter spool dir. Sender-owned and writable;
+    /// defaults to the sender's own log dir (`/var/log/sigil-sender`).
+    #[serde(default = "default_dead_letter_dir")]
     pub dead_letter_dir: PathBuf,
     /// Maximum events per batch (spec default 256).
     #[serde(default = "default_max_batch_events")]
@@ -41,6 +49,12 @@ pub struct SenderConfig {
     pub host_id: Option<String>,
 }
 
+fn default_offset_path() -> PathBuf {
+    PathBuf::from("/var/lib/sigil-sender/sender-offset.json")
+}
+fn default_dead_letter_dir() -> PathBuf {
+    PathBuf::from("/var/log/sigil-sender/dead-letter")
+}
 fn default_max_batch_events() -> usize {
     256
 }
@@ -122,6 +136,35 @@ dead_letter_dir: "/var/log/sigil/dead-letter"
         assert_eq!(cfg.max_batch_events, 256);
         assert_eq!(cfg.max_batch_bytes, 1024 * 1024);
         assert_eq!(cfg.policy_poll_interval.as_secs(), 300);
+    }
+
+    #[test]
+    fn writable_paths_default_to_sender_owned_dirs_when_omitted() {
+        // #10 slice 2: when offset_path / dead_letter_dir are omitted, they
+        // default to the sender's own state/log dirs so the non-root sender can
+        // write them without touching the agent's root:sigil dirs.
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("sender.yaml");
+        write(
+            &p,
+            r#"
+server_base_url: "https://sigil.example.com"
+client_cert_path: "/etc/sigil/client.crt"
+client_key_path: "/etc/sigil/client.key"
+server_ca_path: "/etc/sigil/server-ca.pem"
+events_dir: "/var/log/sigil/events"
+agent_control: "/var/run/sigil/control.sock"
+"#,
+        );
+        let cfg = SenderConfig::load(&p).unwrap();
+        assert_eq!(
+            cfg.offset_path,
+            PathBuf::from("/var/lib/sigil-sender/sender-offset.json")
+        );
+        assert_eq!(
+            cfg.dead_letter_dir,
+            PathBuf::from("/var/log/sigil-sender/dead-letter")
+        );
     }
 
     #[test]

--- a/packaging/systemd/sigil-sender.service
+++ b/packaging/systemd/sigil-sender.service
@@ -17,17 +17,22 @@ Type=simple
 ExecStart=/usr/bin/sigil-sender --config /etc/sigil/sender.yaml start
 Restart=on-failure
 RestartSec=5
-User=root
+# Runs as the unprivileged sigil user (#10 slice 2). Group=sigil lets it READ
+# the agent's root:sigil spool (/var/log/sigil/events) and connect to the
+# agent's control socket (/run/sigil/control.sock, root:sigil 0660). It WRITES
+# only its own state/log dirs, which systemd owns as sigil:sigil 0750. The
+# sigil user is created by this package at install (sysusers.d). NOTE: existing
+# sender.yaml files must move offset_path/dead_letter_dir to the sender-owned
+# dirs below (see CHANGELOG); fresh configs that omit them get these defaults.
+User=sigil
 Group=sigil
-RuntimeDirectoryMode=0750
 StateDirectoryMode=0750
 LogsDirectoryMode=0750
-StateDirectory=sigil
-LogsDirectory=sigil
-RuntimeDirectory=sigil
+StateDirectory=sigil-sender
+LogsDirectory=sigil-sender
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/var/lib/sigil /var/log/sigil /var/run/sigil
+ReadWritePaths=/var/lib/sigil-sender /var/log/sigil-sender
 ProtectHome=read-only
 ProtectControlGroups=yes
 ProtectKernelTunables=yes


### PR DESCRIPTION
#10 slice 2 (second half): de-root the **sender**. Unlike the server, the sender shares `/var/lib/sigil` + `/var/log/sigil` with the root agent (it tails the agent's spool), so it needs its own writable dirs. Independent of the server PR (#65).

## Changes

- **`packaging/systemd/sigil-sender.service`** — `User=root` → `User=sigil` (keeps `Group=sigil`). Dedicated `StateDirectory=sigil-sender` / `LogsDirectory=sigil-sender` (systemd owns `/var/lib/sigil-sender`, `/var/log/sigil-sender` as `sigil:sigil 0750`). `ReadWritePaths` narrows to those two dirs; **`RuntimeDirectory` dropped** (the sender never writes to `/run`). It still *reads* the agent's `root:sigil` spool and connects to the control socket via the `sigil` group.
- **`crates/sigil-sender/src/config.rs`** — `offset_path` and `dead_letter_dir` now `#[serde(default)]` to the sender-owned dirs (`/var/lib/sigil-sender/sender-offset.json`, `/var/log/sigil-sender/dead-letter`), so a config that omits them lands in writable locations. New unit test.
- **`config/sender.example.yaml`** — updated to the new paths.

The sender package already creates the `sigil` user (sysusers.d, shipped since #61) — no packaging change needed.

## ⚠️ Breaking (operator action on upgrade)

An existing `/etc/sigil/sender.yaml` that pins `offset_path: /var/lib/sigil/sender-offset.json` and `dead_letter_dir: /var/log/sigil/dead-letter` must move them to the `sigil-sender` dirs (or delete both lines to take the new defaults) — the non-root sender can't write the agent's `root:sigil` dirs. CHANGELOG documents the exact `mv` to preserve the read offset (avoid re-shipping the spool).

## Verification (Rocky Linux 9.7 aarch64, SELinux enforcing)

Installed **agent + sender** together (realistic — sender tails the agent), started the agent, configured a sender.yaml that **omits** the writable paths (exercising the new defaults), started the sender:

- Sender unit resolves `User=sigil Group=sigil`; systemd created `/var/lib/sigil-sender` + `/var/log/sigil-sender` as **`sigil:sigil 0750`**; failure is cert-related (config), **zero `216/GROUP` / `217/USER`** errors.
- Direct `sudo -u sigil` probes (the full trust model):
  - **reads** the agent's spool — `/var/log/sigil/events` dir + a `root:sigil 0640` segment, both readable via the `sigil` group ✓
  - **writes** its own `/var/lib/sigil-sender` + `/var/log/sigil-sender` ✓
  - reaches the control socket (`root:sigil 0660`) r+w via group ✓
  - **cannot** write the agent's `/var/lib/sigil` — isolation holds ✓

`cargo fmt`/`clippy -D warnings` clean; new config-default test passes. (Two unrelated sigil-core tests flake under full-workspace parallelism on clean `main` — filed as #66 — not touched by this change.)

## Refs

Refs #10 (slice 2, sender). With #65 (server) this completes the non-root daemon work; the agent stays root for file-integrity monitoring. Follow-ups: SELinux `sigil_t` labeling; optionally pin the agent's JSONL segment mode (currently umask-dependent `0644`, group-readable) for determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)