### PR TITLE
feat(packaging): build.sh --target for cross-arch .deb/.rpm (#12)

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -11,34 +11,59 @@
 #   packaging/build.sh agent                    # sigil-agent, both formats
 #   packaging/build.sh sender rpm               # sigil-sender, .rpm only
 #   packaging/build.sh signer deb               # sigil-signer, .deb only
+#   packaging/build.sh agent rpm --target aarch64-unknown-linux-gnu
+#                                               # cross-build an ARM64 .rpm (#12)
 #
-# Args (any order, both optional):
-#   <what>:   agent|sender|server|signer|all   (default: all)
-#   <format>: deb|rpm|all                      (default: all)
+# Args (any order):
+#   <what>:   agent|sender|server|signer|all      (default: all)
+#   <format>: deb|rpm|all                         (default: all)
+#   --target <triple>:  Rust target triple        (default: host arch)
+#                       e.g. aarch64-unknown-linux-gnu,
+#                       aarch64-unknown-linux-musl, armv7-unknown-linux-gnueabihf.
+#                       Requires the target installed (`rustup target add <triple>`)
+#                       and, for cross-compiles, an appropriate linker/toolchain.
 #
-# Outputs:
+# Outputs (host build):
 #   target/debian/<pkg>_<version>_<arch>.deb
 #   target/generate-rpm/<pkg>-<version>-1.<arch>.rpm
+# Outputs (--target <triple>):
+#   target/<triple>/debian/<pkg>_<version>_<arch>.deb
+#   target/generate-rpm/<pkg>-<version>-1.<arch>.rpm
 #
-# The packagers are invoked from each crate's directory because the asset
-# paths in the per-crate [package.metadata.deb] / [package.metadata.generate-rpm]
-# blocks are written relative to that directory.
+# The packagers are invoked from each crate's directory because the asset paths
+# in the per-crate [package.metadata.deb] / [package.metadata.generate-rpm]
+# blocks are written relative to that directory (`../../target/release/...`).
+# Neither cargo-deb nor cargo-generate-rpm rewrites a `../../target/release`
+# asset path for a cross target, so for --target we cross-build into
+# `target/<triple>/release`, stage the binary into `target/release` (where the
+# asset paths point), and stamp the package architecture explicitly: cargo-deb
+# via `--target`, cargo-generate-rpm via `--arch`.
 set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
 WHAT=all
 FORMAT=all
-for arg in "$@"; do
+TARGET=""
+# Parse args. --target takes the following arg (or --target=<triple>).
+while [ $# -gt 0 ]; do
+    arg="$1"
     case "$arg" in
         agent|sender|server|signer|all) WHAT="$arg" ;;
         deb|rpm) FORMAT="$arg" ;;
+        --target)
+            shift
+            TARGET="${1:-}"
+            [ -n "$TARGET" ] || { echo "--target needs a triple" >&2; exit 2; }
+            ;;
+        --target=*) TARGET="${arg#--target=}" ;;
         *)
             echo "unknown arg: $arg" >&2
-            echo "usage: packaging/build.sh [agent|sender|server|signer|all] [deb|rpm]" >&2
+            echo "usage: packaging/build.sh [agent|sender|server|signer|all] [deb|rpm] [--target <triple>]" >&2
             exit 2
             ;;
     esac
+    shift
 done
 
 case "$WHAT" in
@@ -49,14 +74,47 @@ case "$WHAT" in
     signer) CRATES="sigil-signer" ;;
 esac
 
+# crate -> binary name (the agent ships `sigil`, the signer ships `sigil-sign`).
+bin_for() {
+    case "$1" in
+        sigil-agent)  echo sigil ;;
+        sigil-sender) echo sigil-sender ;;
+        sigil-server) echo sigil-server ;;
+        sigil-signer) echo sigil-sign ;;
+    esac
+}
+
+# cargo build gets --target directly; the packagers need an explicit arch.
+TARGET_ARG=""
+RPM_ARCH=""
+if [ -n "$TARGET" ]; then
+    TARGET_ARG="--target $TARGET"
+    case "$TARGET" in
+        aarch64*) RPM_ARCH=aarch64 ;;
+        armv7*)   RPM_ARCH=armv7hl ;;
+        x86_64*)  RPM_ARCH=x86_64 ;;
+        *) echo "warning: no rpm arch mapping for $TARGET; .rpm arch may be wrong" >&2 ;;
+    esac
+fi
+
 # Single release build for everything we'll package.
-echo ">> building release binaries for: $CRATES"
+echo ">> building release binaries for: $CRATES${TARGET:+ (target: $TARGET)}"
 BUILD_ARGS=""
 for c in $CRATES; do
     BUILD_ARGS="$BUILD_ARGS -p $c"
 done
 # shellcheck disable=SC2086
-cargo build --release $BUILD_ARGS --manifest-path "$ROOT/Cargo.toml"
+cargo build --release $BUILD_ARGS $TARGET_ARG --manifest-path "$ROOT/Cargo.toml"
+
+# For a cross target, stage each binary into target/release so the crate asset
+# paths (`../../target/release/<bin>`) resolve to the cross-built binary.
+if [ -n "$TARGET" ]; then
+    mkdir -p "$ROOT/target/release"
+    for c in $CRATES; do
+        b=$(bin_for "$c")
+        cp -f "$ROOT/target/$TARGET/release/$b" "$ROOT/target/release/$b"
+    done
+fi
 
 mkdir -p "$ROOT/target/generate-rpm"
 
@@ -64,19 +122,27 @@ for c in $CRATES; do
     cd "$ROOT/crates/$c"
     case "$FORMAT" in
         deb|all)
-            echo ">> cargo deb ($c)"
-            cargo deb --no-build
+            echo ">> cargo deb ($c)${TARGET:+ [$TARGET]}"
+            # --target stamps the Debian arch; the staged binary is read from
+            # the unrewritten ../../target/release path.
+            # shellcheck disable=SC2086
+            cargo deb --no-build $TARGET_ARG
             ;;
     esac
     case "$FORMAT" in
         rpm|all)
-            echo ">> cargo generate-rpm ($c)"
-            cargo generate-rpm --output "$ROOT/target/generate-rpm/"
+            echo ">> cargo generate-rpm ($c)${TARGET:+ [$TARGET]}"
+            RPM_ARCH_ARG=""
+            [ -n "$RPM_ARCH" ] && RPM_ARCH_ARG="--arch $RPM_ARCH"
+            # shellcheck disable=SC2086
+            cargo generate-rpm $RPM_ARCH_ARG --output "$ROOT/target/generate-rpm/"
             ;;
     esac
 done
 
 echo
 echo ">> built:"
+# Host build writes target/debian; --target writes target/<triple>/debian.
 ls -l "$ROOT"/target/debian/*.deb 2>/dev/null || true
+[ -n "$TARGET" ] && ls -l "$ROOT/target/$TARGET"/debian/*.deb 2>/dev/null || true
 ls -l "$ROOT"/target/generate-rpm/*.rpm 2>/dev/null || true


### PR DESCRIPTION
First slice of #12 (cross-arch packaging): teach `packaging/build.sh` to cross-build per-arch `.deb`/`.rpm`. This is the foundational, low-risk piece — the CI/release aarch64 matrix is a separate follow-up.

## Change

`packaging/build.sh` gains an optional **`--target <triple>`**:

```sh
packaging/build.sh agent rpm --target aarch64-unknown-linux-gnu
packaging/build.sh all --target aarch64-unknown-linux-gnu      # all 4, deb+rpm
```

The host-arch path is **unchanged** when `--target` is omitted (the new logic only runs when a target is set), so the existing CI `build.sh rpm` / `build.sh deb` steps behave exactly as before.

### Why the staging step

Neither cargo-deb nor cargo-generate-rpm rewrites a `../../target/release` asset path for a cross target — both only special-case paths starting *exactly* with `target/release/`, and the per-crate metadata uses `../../target/release/<bin>` (the packagers run from each crate dir). cargo-deb even warns: *"… '../../target/release/sigil' does not match the pattern, and will not be built."*

So for `--target`, build.sh:
1. cross-builds into `target/<triple>/release`,
2. stages each binary into `target/release` (where the asset paths point),
3. stamps the package arch explicitly — cargo-deb via `--target`, cargo-generate-rpm via `--arch` (triple→arch map: `aarch64` / `armv7hl` / `x86_64`).

## Verification (Rocky Linux 9.7 aarch64)

- `build.sh agent --target aarch64-unknown-linux-gnu` → `sigil_0.2.0-1_arm64.deb` + `sigil-0.2.0-1.aarch64.rpm`.
- The `.rpm` **installs** and the packaged binary is `ELF 64-bit … ARM aarch64` and **runs** (`sigil 0.2.0`); clean removal.
- Host-arch `build.sh agent rpm` (no `--target`) still produces a host `.rpm` unchanged.
- `sh -n` clean; the only shellcheck note is the pre-existing `CDPATH=` idiom (SC1007), not from this change.

## Scope

- ✅ Acceptance #1: `build.sh … --target aarch64-unknown-linux-gnu` produces a working ARM64 `.rpm`.
- ⏭️ Follow-up (separate PR): CI cross-build matrix producing aarch64 `.deb`/`.rpm` for all 4 packages in releases; optional armv7 path.

Refs #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)