### PR TITLE
fix(server,mcp): query_events host_id filter — comma-separated, not a Vec (#73)

### DIFF
--- a/crates/sigil-mcp/src/tools.rs
+++ b/crates/sigil-mcp/src/tools.rs
@@ -83,8 +83,11 @@ impl SigilFleet {
         Parameters(p): Parameters<QueryEventsParams>,
     ) -> Result<CallToolResult, McpError> {
         let mut q: Vec<(&str, String)> = Vec::new();
-        for h in &p.host_id {
-            q.push(("host_id", h.clone()));
+        // The server reads `host_id` as a comma-separated filter (like
+        // evidence_kind/severity/source), not repeated params — sending repeats
+        // tripped its serde_urlencoded deserializer with "expected a sequence" (#73).
+        if !p.host_id.is_empty() {
+            q.push(("host_id", p.host_id.join(",")));
         }
         if let Some(s) = &p.since {
             q.push(("since", s.clone()));
@@ -212,6 +215,35 @@ mod tests {
                 since: Some("2026-05-01T00:00:00Z".to_string()),
                 limit: Some(50),
                 cursor: Some("abc-cursor".to_string()),
+            }))
+            .await
+            .unwrap();
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn query_events_joins_multiple_host_ids_into_one_comma_param() {
+        // #73: multiple host_ids must go out as a single comma-separated value,
+        // not repeated params — the server reads it like its other multi-value
+        // filters, and repeated params broke its deserializer.
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/v1/events")
+                    .query_param("host_id", "H1,H2");
+                then.status(200)
+                    .json_body(json!({"events": [], "next_cursor": null}));
+            })
+            .await;
+
+        fleet(server.base_url())
+            .query_events(Parameters(QueryEventsParams {
+                host_id: vec!["H1".to_string(), "H2".to_string()],
+                since: None,
+                limit: None,
+                cursor: None,
             }))
             .await
             .unwrap();

--- a/crates/sigil-server/src/routes/events.rs
+++ b/crates/sigil-server/src/routes/events.rs
@@ -15,8 +15,11 @@ use uuid::Uuid;
 pub struct EventsQuery {
     pub cursor: Option<String>,
     pub limit: Option<u32>,
-    #[serde(default)]
-    pub host_id: Vec<String>,
+    // Comma-separated, like the other multi-value filters below (evidence_kind,
+    // severity, source). A `Vec<String>` here can't be deserialized by axum's
+    // serde_urlencoded `Query` extractor (it reports "expected a sequence" even
+    // for a single value), which is what broke the MCP `query_events` tool (#73).
+    pub host_id: Option<String>,
     pub since: Option<String>,
     pub until: Option<String>,
     pub evidence_kind: Option<String>,
@@ -81,11 +84,7 @@ pub async fn get_events(
 
     let filters = ScanFilters {
         cursor,
-        host_ids: if q.host_id.is_empty() {
-            None
-        } else {
-            Some(q.host_id.clone())
-        },
+        host_ids: comma_split(&q.host_id),
         since,
         until,
         evidence_kinds: comma_split(&q.evidence_kind),

--- a/crates/sigil-server/tests/read_api_e2e.rs
+++ b/crates/sigil-server/tests/read_api_e2e.rs
@@ -107,6 +107,36 @@ async fn events_empty_returns_empty_list() {
 }
 
 #[tokio::test]
+async fn events_host_id_filter_does_not_400() {
+    // #73: a host_id filter (single or comma-separated) must deserialize and
+    // return 200 — the old `Vec<String>` field made serde_urlencoded reject it
+    // with "expected a sequence" → HTTP 400, breaking the MCP query_events tool.
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state_with_token(dir.path(), "tok"));
+
+    let (status, body) = get(
+        &app,
+        "/v1/events?host_id=4376ef7a-4fac-4644-b4cf-128fc471f783&limit=100",
+        Some("tok"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "single host_id must not 400: {body}"
+    );
+    assert!(body["events"].as_array().unwrap().is_empty());
+
+    let (status, body) = get(&app, "/v1/events?host_id=h1,h2&limit=100", Some("tok")).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "comma-separated host_id must not 400: {body}"
+    );
+    assert!(body["events"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn fleet_host_by_id_404_when_unknown() {
     let dir = tempfile::tempdir().unwrap();
     let app = build_router(state_with_token(dir.path(), "tok"));


### PR DESCRIPTION
## Bug

The `query_events` MCP tool returned HTTP 400 whenever a client passed a `host_id`:

```
Mcp error: -32602: invalid query (HTTP 400): Failed to deserialize query string:
invalid type: string "4376ef7a-…", expected a sequence
```

## Root cause

`GET /v1/events` declared `host_id: Vec<String>`, but axum's `Query` extractor uses **serde_urlencoded**, which can't deserialize a query param into a sequence — it rejected even a single `host_id=X` with *"expected a sequence"*. The endpoint's other multi-value filters (`evidence_kind`, `severity`, `source`) all already use `Option<String>` + `comma_split`; `host_id` was the lone `Vec<String>`, so it was the only one that broke.

## Fix

- **Server** (`routes/events.rs`): `host_id: Option<String>` + `comma_split` — consistent with the sibling filters; no new dependency.
- **Client** (`sigil-mcp/tools.rs`): join the `host_id` array into one comma-separated param (`host_id=a,b`) instead of emitting repeated params.

Accepts a single host (`host_id=a`) and multiple (`host_id=a,b`).

## Tests

- `read_api_e2e::events_host_id_filter_does_not_400` — in-process GET with a single and a comma-separated `host_id` now returns **200** (was 400). Directly reproduces #73.
- `tools::query_events_joins_multiple_host_ids_into_one_comma_param` — multiple host_ids serialize to one comma value.
- `cargo fmt` / `clippy -D warnings` clean; full `sigil-server` + `sigil-mcp` suites green.

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)