### PR TITLE
feat(mcp): sigil-mcp --print-config + PATH troubleshooting docs (#72)

### DIFF
--- a/crates/sigil-mcp/README.md
+++ b/crates/sigil-mcp/README.md
@@ -23,13 +23,27 @@ Local mode: `my_risk`, `my_guard_detail`, `my_findings`.
 | `SIGIL_SERVER_READ_TOKEN` | bearer token |
 | `SIGIL_CLIENT_CERT` / `SIGIL_CLIENT_KEY` / `SIGIL_CA_CERT` | optional, for direct mTLS to `:8443` (omit when using a bearer-only reverse proxy) |
 
-## Claude Desktop / Code (stdio)
+## Register with an MCP client
+
+The fastest, paste-proof way — `--print-config` stamps the **absolute path** of
+the running binary, so it works even when the client doesn't see your shell PATH:
+
+```sh
+sigil-mcp --print-config codex     # Codex (~/.codex/config.toml)
+sigil-mcp --print-config claude    # Claude Code / Claude Desktop (mcpServers JSON)
+sigil-mcp --print-config           # both
+```
+
+Then fill in `SIGIL_SERVER_BASE_URL` / `SIGIL_SERVER_READ_TOKEN` (fleet mode), or
+delete the `env` for [local mode](#local-mode-individual-self-assessment-no-server).
+
+Claude Desktop / Code (stdio) looks like:
 
 ```json
 {
   "mcpServers": {
     "sigil-fleet": {
-      "command": "sigil-mcp",
+      "command": "/absolute/path/to/sigil-mcp",
       "env": {
         "SIGIL_SERVER_BASE_URL": "http://127.0.0.1:9090",
         "SIGIL_SERVER_READ_TOKEN": "..."
@@ -38,6 +52,15 @@ Local mode: `my_risk`, `my_guard_detail`, `my_findings`.
   }
 }
 ```
+
+> **`command` must be an absolute path** (or a name on the *client's* PATH). MCP
+> clients are usually GUI/login-launched and don't inherit your interactive shell
+> PATH, and a build-from-source binary lives at `target/release/sigil-mcp` —
+> never on PATH.
+>
+> **Troubleshooting — `MCP startup failed: No such file or directory (os error 2)`**:
+> the client can't find the binary. Use the absolute path (run
+> `sigil-mcp --print-config <client>` to get a correct block).
 
 ## Local mode (individual self-assessment, no server)
 

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod local;
 mod local_tools;
+mod print_config;
 mod tools;
 mod upstream;
 
@@ -13,8 +14,38 @@ use rmcp::transport::stdio;
 use rmcp::ServiceExt;
 use std::sync::Arc;
 
+/// Handle `--print-config [client]` before any async/server setup. Returns
+/// `Some(exit_code)` when the flag was handled (the caller then exits), else
+/// `None` to start the server as usual.
+fn handle_print_config() -> Option<i32> {
+    let mut args = std::env::args().skip(1);
+    if args.next().as_deref() != Some("--print-config") {
+        return None;
+    }
+    let client = args.next();
+    // Pin the absolute path of THIS binary so the emitted config works even when
+    // the MCP client doesn't see the user's interactive-shell PATH (#72).
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| "sigil-mcp".to_string());
+    match print_config::render_config(&exe, client.as_deref()) {
+        Ok(block) => {
+            print!("{block}");
+            Some(0)
+        }
+        Err(msg) => {
+            eprintln!("sigil-mcp --print-config: {msg}");
+            Some(2)
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    if let Some(code) = handle_print_config() {
+        std::process::exit(code);
+    }
     // MCP speaks JSON-RPC over stdout; ALL logs MUST go to stderr.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)

--- a/crates/sigil-mcp/src/print_config.rs
+++ b/crates/sigil-mcp/src/print_config.rs
@@ -1,0 +1,74 @@
+//! `sigil-mcp --print-config [codex|claude]` — emit a ready-to-paste MCP client
+//! config block that pins the **absolute** path of this binary
+//! (`std::env::current_exe()`), so registration works even when the client
+//! doesn't see the user's interactive-shell PATH (#72).
+
+/// Supported clients (and their aliases) for `render_config`.
+pub const CLIENTS: &str = "codex, claude";
+
+fn codex_block(exe: &str) -> String {
+    format!(
+        "# Codex — add to ~/.codex/config.toml\n\
+         [mcp_servers.sigil-fleet]\n\
+         command = \"{exe}\"\n\
+         # Fleet mode — point at your sigil-server's read API:\n\
+         env = {{ SIGIL_SERVER_BASE_URL = \"https://your-sigil-server:PORT\", SIGIL_SERVER_READ_TOKEN = \"your-read-token\" }}\n\
+         # Local mode (this host's own posture, no server): delete the env line.\n"
+    )
+}
+
+fn claude_block(exe: &str) -> String {
+    format!(
+        "// Claude Code / Claude Desktop — \"mcpServers\" entry\n\
+         {{\n  \"mcpServers\": {{\n    \"sigil-fleet\": {{\n      \"command\": \"{exe}\",\n      \"env\": {{\n        \"SIGIL_SERVER_BASE_URL\": \"https://your-sigil-server:PORT\",\n        \"SIGIL_SERVER_READ_TOKEN\": \"your-read-token\"\n      }}\n    }}\n  }}\n}}\n// Local mode (this host's own posture, no server): omit the \"env\" object.\n"
+    )
+}
+
+/// Render a config block for `client` (None = all clients) with `exe` as the
+/// command path. Returns Err with a usage hint for an unknown client.
+pub fn render_config(exe: &str, client: Option<&str>) -> Result<String, String> {
+    match client {
+        None => Ok(format!("{}\n{}", codex_block(exe), claude_block(exe))),
+        Some("codex") => Ok(codex_block(exe)),
+        Some("claude") | Some("claude-code") | Some("claude-desktop") => Ok(claude_block(exe)),
+        Some(other) => Err(format!(
+            "unknown client '{other}' — supported: {CLIENTS} (or omit for all)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_uses_absolute_exe_path_and_toml_table() {
+        let out = render_config("/opt/sigil/sigil-mcp", Some("codex")).unwrap();
+        assert!(out.contains("[mcp_servers.sigil-fleet]"));
+        assert!(out.contains("command = \"/opt/sigil/sigil-mcp\""));
+        assert!(out.contains("SIGIL_SERVER_BASE_URL"));
+    }
+
+    #[test]
+    fn claude_aliases_render_json_with_exe() {
+        for c in ["claude", "claude-code", "claude-desktop"] {
+            let out = render_config("/abs/sigil-mcp", Some(c)).unwrap();
+            assert!(out.contains("\"mcpServers\""), "{c}");
+            assert!(out.contains("\"command\": \"/abs/sigil-mcp\""), "{c}");
+        }
+    }
+
+    #[test]
+    fn no_client_renders_both() {
+        let out = render_config("/x/sigil-mcp", None).unwrap();
+        assert!(out.contains("[mcp_servers.sigil-fleet]"));
+        assert!(out.contains("\"mcpServers\""));
+    }
+
+    #[test]
+    fn unknown_client_is_error_with_hint() {
+        let err = render_config("/x/sigil-mcp", Some("nano")).unwrap_err();
+        assert!(err.contains("unknown client 'nano'"));
+        assert!(err.contains("codex"));
+    }
+}


### PR DESCRIPTION
## Bug

Registering `sigil-mcp` with an MCP client using `command = "sigil-mcp"` fails with the opaque:

```
⚠ MCP client for `sigil-fleet` failed to start: MCP startup failed: No such file or directory (os error 2)
```

MCP clients (Codex, Claude Code/Desktop) are GUI/login-launched and usually **don't inherit the user's interactive-shell PATH**; a build-from-source binary only lives at `target/release/sigil-mcp` (never on PATH). So the bare command resolves to ENOENT.

## Fix (issue option 3 + 1)

- **`sigil-mcp --print-config [codex|claude]`** — emits a ready-to-paste MCP config block with the **absolute path** of the running binary (`std::env::current_exe()`), so registration works regardless of the client's PATH:

  ```sh
  sigil-mcp --print-config codex     # ~/.codex/config.toml block
  sigil-mcp --print-config claude    # Claude Code / Desktop mcpServers JSON
  sigil-mcp --print-config           # both
  ```
  Unknown client → usage hint on stderr, exit 2. No new dependency (minimal `std::env::args` parse before server start).

- **Docs** — `crates/sigil-mcp/README.md` now leads the registration section with `--print-config`, requires an absolute `command` path, and adds an `os error 2` → "not on the client's PATH, use an absolute path" troubleshooting note. (The old example showed the PATH-fragile `command = "sigil-mcp"`.)

## Tests

- `print_config::tests` — `render_config` for codex / claude (+ `claude-code`/`claude-desktop` aliases) / no-client (both) / unknown-client error. Pure function, fully unit-tested.
- `cargo fmt` / `clippy -D warnings` clean; full `sigil-mcp` suite green (30 tests).

Verified locally: `sigil-mcp --print-config codex` prints a Codex block whose `command` is the resolved absolute path.

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)