### PR TITLE
test(agent): generous, env-tunable FS-event wait budget to de-flake the suite (#66)

### DIFF
--- a/crates/sigil-agent/tests/ai_guard_e2e.rs
+++ b/crates/sigil-agent/tests/ai_guard_e2e.rs
@@ -7,7 +7,7 @@
 #![cfg(all(unix, feature = "operator-cli"))]
 
 mod common;
-use common::TestAgentBuilder;
+use common::{fs_event_timeout, TestAgentBuilder};
 use std::time::Duration;
 use tokio::sync::Mutex;
 
@@ -84,7 +84,7 @@ targets:
                     && v["evidence"]["tool"] == "claude_code"
                     && v["evidence"]["bucket"] == "critical"
             },
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected an AiGuardRiskAssessed event with bucket=critical");
@@ -115,7 +115,7 @@ targets:
     // ── Second emission: low bucket ──────────────────────────────────────────
     // Poll until we see an AiGuardRiskAssessed event for claude_code that is
     // NOT the original boot event and carries score < 1.0 (bucket = low).
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + fs_event_timeout();
     let mut clean_seen = false;
     while std::time::Instant::now() < deadline {
         let found = agent
@@ -198,7 +198,7 @@ targets:
                     && v["evidence"]["scope"]["kind"] == "application"
                     && v["evidence"]["scope"]["app"] == "claude_desktop"
             },
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected an AiGuardRiskAssessed event for claude_desktop");
@@ -257,7 +257,7 @@ targets:
                     && v["evidence"]["scope"]["kind"] == "application"
                     && v["evidence"]["scope"]["app"] == "continue"
             },
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected an AiGuardRiskAssessed event for continue_dev");
@@ -323,7 +323,7 @@ targets: []
                     && v["evidence"]["scope"]["kind"] == "project"
                     && v["evidence"]["scope"]["path"] == canonical_a.as_str()
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed with project scope = repoA");
@@ -339,7 +339,7 @@ targets: []
                     && v["evidence"]["scope"]["kind"] == "project"
                     && v["evidence"]["scope"]["path"] == canonical_b.as_str()
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed with project scope = repoB");
@@ -400,7 +400,7 @@ targets: []
                     && v["evidence"]["scope"]["kind"] == "project"
                     && v["evidence"]["scope"]["path"] == canonical_a.as_str()
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed for claude_code repoA");
@@ -417,7 +417,7 @@ targets: []
                     && v["evidence"]["scope"]["kind"] == "project"
                     && v["evidence"]["scope"]["path"] == canonical_b.as_str()
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed for claude_code repoB");
@@ -482,7 +482,7 @@ targets: []
                     && v["evidence"]["scope"]["kind"] == "project"
                     && v["evidence"]["scope"]["path"] == canonical_a.as_str()
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed for codex repoA");
@@ -497,7 +497,7 @@ targets: []
                     && v["evidence"]["scope"]["kind"] == "project"
                     && v["evidence"]["scope"]["path"] == canonical_b.as_str()
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed for codex repoB");
@@ -555,7 +555,7 @@ targets:
                     && v["evidence"]["tool"] == "gemini"
                     && v["evidence"]["scope"]["kind"] == "user_global"
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed for gemini");
@@ -613,7 +613,7 @@ targets:
                     && v["evidence"]["scope"]["kind"] == "application"
                     && v["evidence"]["scope"]["app"] == "cursor"
             },
-            Duration::from_secs(15),
+            fs_event_timeout(),
         )
         .await
         .expect("expected AiGuardRiskAssessed for cursor");
@@ -721,7 +721,7 @@ targets:
                 v["evidence"]["kind"] == "ai_guard_risk_assessed"
                     && v["evidence"]["tool"] == "claude_code"
             },
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected an AiGuardRiskAssessed event for claude_code");
@@ -827,7 +827,7 @@ targets:
                 v["evidence"]["kind"] == "ai_guard_risk_assessed"
                     && v["evidence"]["tool"] == "claude_code"
             },
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected an AiGuardRiskAssessed event for claude_code");
@@ -953,7 +953,7 @@ targets:
                 v["evidence"]["kind"] == "ai_guard_risk_assessed"
                     && v["evidence"]["tool"] == "claude_code"
             },
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected an AiGuardRiskAssessed event for claude_code");

--- a/crates/sigil-agent/tests/common/mod.rs
+++ b/crates/sigil-agent/tests/common/mod.rs
@@ -24,10 +24,18 @@ pub fn policy_for_paths(paths: &[&str], tier: &str) -> String {
     yaml
 }
 
-/// Wait budget for OS-watcher-driven (`wait_for_event`) assertions. macOS
-/// FSEvents delivery can lag well past a few seconds under parallel test load
-/// (issue #25), so give it more headroom there; other platforms keep the tight
-/// 5s and fail fast.
+/// Wait budget for OS-watcher-driven (`wait_for_event` and equivalent poll
+/// loops) assertions. `wait_for_event` returns as soon as the event arrives, so
+/// a generous budget is free on success and only bounds the *failure* deadline.
+/// OS watcher delivery (FSEvents, inotify) lags badly under the heavy
+/// cross-process parallelism of `cargo test --workspace` (issues #25, #66), so
+/// keep ample headroom — and let a loaded host raise it further without a
+/// rebuild via `SIGIL_TEST_FS_TIMEOUT_SECS`.
 pub fn fs_event_timeout() -> std::time::Duration {
-    std::time::Duration::from_secs(if cfg!(target_os = "macos") { 15 } else { 5 })
+    let base = if cfg!(target_os = "macos") { 30 } else { 15 };
+    let secs = std::env::var("SIGIL_TEST_FS_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(base);
+    std::time::Duration::from_secs(secs)
 }

--- a/crates/sigil-agent/tests/host_meta_snapshot_e2e.rs
+++ b/crates/sigil-agent/tests/host_meta_snapshot_e2e.rs
@@ -5,8 +5,7 @@
 #![cfg(all(unix, feature = "operator-cli"))]
 
 mod common;
-use common::TestAgentBuilder;
-use std::time::Duration;
+use common::{fs_event_timeout, TestAgentBuilder};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn agent_emits_host_meta_snapshot_on_boot() {
@@ -18,7 +17,7 @@ async fn agent_emits_host_meta_snapshot_on_boot() {
     let ev = agent
         .wait_for_event(
             |v| v["evidence"]["kind"] == "host_meta_snapshot",
-            Duration::from_secs(10),
+            fs_event_timeout(),
         )
         .await
         .expect("expected a HostMetaSnapshot event within 10s");

--- a/crates/sigil-agent/tests/large_file.rs
+++ b/crates/sigil-agent/tests/large_file.rs
@@ -1,6 +1,5 @@
 mod common;
-use common::{policy_for_paths, TestAgentBuilder};
-use std::time::Duration;
+use common::{fs_event_timeout, policy_for_paths, TestAgentBuilder};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn it_large_file_emits_incomplete() {
@@ -20,7 +19,7 @@ async fn it_large_file_emits_incomplete() {
                     && v["evidence"]["evidence_quality"] == "incomplete"
                     && v["evidence"]["size_after"] == 11 * 1024 * 1024
             },
-            Duration::from_secs(8),
+            fs_event_timeout(),
         )
         .await
         .expect("expected incomplete-quality file_change");

--- a/crates/sigil-agent/tests/reload_policy_e2e.rs
+++ b/crates/sigil-agent/tests/reload_policy_e2e.rs
@@ -3,7 +3,7 @@
 #![cfg(all(unix, feature = "operator-cli"))]
 
 mod common;
-use common::{policy_for_paths, TestAgentBuilder};
+use common::{fs_event_timeout, policy_for_paths, TestAgentBuilder};
 use serde_json::json;
 use std::time::Duration;
 
@@ -50,7 +50,7 @@ async fn reload_policy_picks_up_on_disk_edits() {
 
     // The IPC reply returns as soon as the watch is nudged, not when the
     // reload completes, so poll `targets` until the new policy is visible.
-    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let deadline = std::time::Instant::now() + fs_event_timeout();
     let mut after_glob: Option<String> = None;
     while std::time::Instant::now() < deadline {
         let after = agent.control(&json!({"cmd": "targets"})).await;


### PR DESCRIPTION
## Problem

`cargo test --workspace` flakes: under the concurrent-watcher load of the full suite, OS watcher delivery (macOS FSEvents, Linux inotify) lags well past a few seconds, so FS-driven integration tests time out intermittently — a **different one each run**, all passing in isolation.

(The two `sigil-core` tests originally named in #66 turned out to be a transient — they pass 201/201 even under heavy background load. The reproducible flakes are the FS-event waits: `basic_events`, `large_file`, `critical_tier`, the `ai_guard_e2e` pair, …)

## Fix

Centralize the wait budget on `fs_event_timeout()` and make it **generous + tunable**:

- 30s on macOS / 15s elsewhere (up from 15/5), overridable via **`SIGIL_TEST_FS_TIMEOUT_SECS`** for heavily oversubscribed hosts. `wait_for_event` returns as soon as the event arrives, so a larger budget is **free on success** and only bounds genuine failures.
- Migrate the hardcoded timeouts scattered across the suite to the one helper: `large_file` (8s), `reload_policy` (3s deadline), `ai_guard_e2e` (10/15s ×15), `host_meta` (10s). Now the whole suite shares a single knob.

Extends the #25 `fs_event_timeout` precedent.

## Notes

- A polling-watcher approach was tried (force the test agent onto a scan-interval watcher to dodge OS event drops) but **reverted**: it breaks `destructive_claude_settings_emits_critical_then_clean_settings_emits_low`, which deletes+recreates a file to force an FSEvents `Created` event — a 100 ms poll coalesces that and the re-assessment never fires. So this PR keeps the OS-native watcher and just widens/centralizes the budget.
- CI (more cores, less contention) stays green; the env knob covers constrained local hosts running the entire workspace at once.

`cargo fmt` / `clippy -D warnings` clean.

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)