### PR TITLE
feat(selinux): confined sigil_agent_t/sender_t/server_t policy module (#69)

### DIFF
--- a/crates/sigil-agent/Cargo.toml
+++ b/crates/sigil-agent/Cargo.toml
@@ -113,12 +113,15 @@ assets = [
     { source = "../../LICENSE", dest = "/usr/share/doc/sigil/LICENSE", mode = "0644", doc = true },
     { source = "../../packaging/sysusers.d/sigil.conf", dest = "/usr/lib/sysusers.d/sigil.conf", mode = "0644" },
     { source = "../../packaging/tmpfiles.d/sigil.conf", dest = "/usr/lib/tmpfiles.d/sigil.conf", mode = "0644" },
+    { source = "../../packaging/selinux/sigil.te", dest = "/usr/share/selinux/packages/sigil/sigil.te", mode = "0644" },
+    { source = "../../packaging/selinux/sigil.fc", dest = "/usr/share/selinux/packages/sigil/sigil.fc", mode = "0644" },
 ]
 # No hard runtime deps beyond glibc, which is always present; leave Requires empty.
 post_install_script = """\
 systemctl daemon-reload >/dev/null 2>&1 || :
 command -v systemd-sysusers >/dev/null 2>&1 && systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || :
 command -v systemd-tmpfiles >/dev/null 2>&1 && systemd-tmpfiles --create /usr/lib/tmpfiles.d/sigil.conf >/dev/null 2>&1 || :
+if command -v semodule >/dev/null 2>&1 && [ -f /usr/share/selinux/devel/Makefile ]; then ( cd /usr/share/selinux/packages/sigil && make -f /usr/share/selinux/devel/Makefile sigil.pp >/dev/null 2>&1 && semodule -i sigil.pp >/dev/null 2>&1 ) || : ; command -v restorecon >/dev/null 2>&1 && restorecon -R /usr/bin/sigil /var/lib/sigil /var/log/sigil /etc/sigil >/dev/null 2>&1 || : ; fi
 """
 pre_uninstall_script = """\
 if [ "$1" = 0 ] ; then

--- a/crates/sigil-sender/Cargo.toml
+++ b/crates/sigil-sender/Cargo.toml
@@ -89,13 +89,17 @@ assets = [
     { source = "../../LICENSE", dest = "/usr/share/doc/sigil-sender/LICENSE", mode = "0644", doc = true },
     { source = "../../packaging/sysusers.d/sigil.conf", dest = "/usr/lib/sysusers.d/sigil.conf", mode = "0644" },
     { source = "../../packaging/tmpfiles.d/sigil.conf", dest = "/usr/lib/tmpfiles.d/sigil.conf", mode = "0644" },
+    { source = "../../packaging/selinux/sigil.te", dest = "/usr/share/selinux/packages/sigil/sigil.te", mode = "0644" },
+    { source = "../../packaging/selinux/sigil.fc", dest = "/usr/share/selinux/packages/sigil/sigil.fc", mode = "0644" },
 ]
 # Apply sysusers/tmpfiles so a standalone sender install creates the sigil
 # group/user + dirs before the unit's Group=sigil resolves (#61). Idempotent.
+# Also load the SELinux module (#69) when the policy devel toolchain is present.
 post_install_script = """\
 systemctl daemon-reload >/dev/null 2>&1 || :
 command -v systemd-sysusers >/dev/null 2>&1 && systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || :
 command -v systemd-tmpfiles >/dev/null 2>&1 && systemd-tmpfiles --create /usr/lib/tmpfiles.d/sigil.conf >/dev/null 2>&1 || :
+if command -v semodule >/dev/null 2>&1 && [ -f /usr/share/selinux/devel/Makefile ]; then ( cd /usr/share/selinux/packages/sigil && make -f /usr/share/selinux/devel/Makefile sigil.pp >/dev/null 2>&1 && semodule -i sigil.pp >/dev/null 2>&1 ) || : ; command -v restorecon >/dev/null 2>&1 && restorecon -R /usr/bin/sigil-sender /var/lib/sigil-sender /var/log/sigil-sender /etc/sigil >/dev/null 2>&1 || : ; fi
 """
 pre_uninstall_script = """\
 if [ "$1" = 0 ] ; then

--- a/crates/sigil-server/Cargo.toml
+++ b/crates/sigil-server/Cargo.toml
@@ -86,12 +86,16 @@ assets = [
     { source = "../../README.md", dest = "/usr/share/doc/sigil-server/README.md", mode = "0644", doc = true },
     { source = "../../LICENSE", dest = "/usr/share/doc/sigil-server/LICENSE", mode = "0644", doc = true },
     { source = "../../packaging/sysusers.d/sigil.conf", dest = "/usr/lib/sysusers.d/sigil.conf", mode = "0644" },
+    { source = "../../packaging/selinux/sigil.te", dest = "/usr/share/selinux/packages/sigil/sigil.te", mode = "0644" },
+    { source = "../../packaging/selinux/sigil.fc", dest = "/usr/share/selinux/packages/sigil/sigil.fc", mode = "0644" },
 ]
 # Create the sigil user/group so the unit's User=sigil resolves before start
 # (#10 slice 2). Idempotent; no-op when the agent package already created it.
+# Also load the SELinux module (#69) when the policy devel toolchain is present.
 post_install_script = """\
 systemctl daemon-reload >/dev/null 2>&1 || :
 command -v systemd-sysusers >/dev/null 2>&1 && systemd-sysusers /usr/lib/sysusers.d/sigil.conf >/dev/null 2>&1 || :
+if command -v semodule >/dev/null 2>&1 && [ -f /usr/share/selinux/devel/Makefile ]; then ( cd /usr/share/selinux/packages/sigil && make -f /usr/share/selinux/devel/Makefile sigil.pp >/dev/null 2>&1 && semodule -i sigil.pp >/dev/null 2>&1 ) || : ; command -v restorecon >/dev/null 2>&1 && restorecon -R /usr/bin/sigil-server /var/lib/sigil-server /var/log/sigil-server /etc/sigil >/dev/null 2>&1 || : ; fi
 """
 pre_uninstall_script = """\
 if [ "$1" = 0 ] ; then

--- a/packaging/selinux/README.md
+++ b/packaging/selinux/README.md
@@ -1,0 +1,52 @@
+# Sigil SELinux policy (#69)
+
+Confines the three de-rooted sigil daemons (#10) into dedicated SELinux domains
+on RHEL-family systems (Rocky/RHEL/Fedora) instead of leaving them in
+`unconfined_service_t`:
+
+| daemon | domain | binary type |
+|--------|--------|-------------|
+| `sigil` (agent) | `sigil_agent_t` | `sigil_agent_exec_t` |
+| `sigil-sender`  | `sigil_sender_t` | `sigil_sender_exec_t` |
+| `sigil-server`  | `sigil_server_t` | `sigil_server_exec_t` |
+
+State/log/runtime get dedicated file types (`sigil_var_lib_t`, `sigil_var_log_t`,
+`sigil_conf_t`, `sigil_*_var_lib_t`, …). The agent can read any file (it does
+file-integrity monitoring by design) but is otherwise tightly confined; the
+sender/server only touch their own state, the agent's spool/socket, and the
+network they need.
+
+## Why `init_nnp_daemon_domain`
+
+The units keep systemd's `NoNewPrivileges=yes` plus sandboxing
+(`ProtectSystem=strict`, `ProtectKernelModules=yes`, …). Under `NoNewPrivileges`
+the kernel blocks the exec-time SELinux domain transition unless the policy
+grants `process2:nnp_transition` — otherwise it falls back to a *bounded*
+transition and is denied. `init_nnp_daemon_domain(...)` grants exactly that, so
+the daemons get **both** the systemd hardening **and** SELinux confinement with
+no unit drop-in.
+
+## Build + install (Rocky/RHEL 9)
+
+```sh
+sudo dnf install -y selinux-policy-devel   # provides the devel Makefile
+make -f /usr/share/selinux/devel/Makefile sigil.pp
+sudo semodule -i sigil.pp
+sudo restorecon -Rv /usr/bin/sigil* /var/lib/sigil* /var/log/sigil* /etc/sigil
+sudo systemctl restart sigil sigil-server sigil-sender   # whichever are installed
+```
+
+Verify confinement + zero denials:
+
+```sh
+ps -eZ | grep sigil          # → sigil_agent_t / sigil_sender_t / sigil_server_t
+sudo ausearch -m avc -ts recent | grep sigil   # → nothing
+```
+
+Remove: `sudo semodule -r sigil`.
+
+Verified enforcing-clean on Rocky Linux 9.7 (aarch64) with all three daemons
+running (0 AVC denials, even with `dontaudit` disabled).
+
+> The `.deb` path is unaffected — Debian/Ubuntu use AppArmor, not SELinux. An
+> AppArmor profile would be a sibling follow-up.

--- a/packaging/selinux/sigil.fc
+++ b/packaging/selinux/sigil.fc
@@ -1,0 +1,18 @@
+# Sigil file contexts (#69). Order: -server / -sender before the bare /var/lib/sigil
+# regex isn't required (the regex needs a following '/' so '-server' won't match),
+# but list them explicitly for clarity.
+
+/usr/bin/sigil          --      gen_context(system_u:object_r:sigil_agent_exec_t,s0)
+/usr/bin/sigil-sender   --      gen_context(system_u:object_r:sigil_sender_exec_t,s0)
+/usr/bin/sigil-server   --      gen_context(system_u:object_r:sigil_server_exec_t,s0)
+
+/etc/sigil(/.*)?                gen_context(system_u:object_r:sigil_conf_t,s0)
+
+/var/lib/sigil(/.*)?            gen_context(system_u:object_r:sigil_var_lib_t,s0)
+/var/log/sigil(/.*)?            gen_context(system_u:object_r:sigil_var_log_t,s0)
+
+/var/lib/sigil-sender(/.*)?     gen_context(system_u:object_r:sigil_sender_var_lib_t,s0)
+/var/log/sigil-sender(/.*)?     gen_context(system_u:object_r:sigil_sender_var_log_t,s0)
+
+/var/lib/sigil-server(/.*)?     gen_context(system_u:object_r:sigil_server_var_lib_t,s0)
+/var/log/sigil-server(/.*)?     gen_context(system_u:object_r:sigil_server_var_log_t,s0)

--- a/packaging/selinux/sigil.te
+++ b/packaging/selinux/sigil.te
@@ -1,0 +1,154 @@
+policy_module(sigil, 0.1.0)
+
+## Sigil SELinux policy (#69). Confines the three de-rooted sigil daemons (#10)
+## into dedicated domains instead of unconfined_service_t. Authored from the
+## observed access on Rocky/RHEL 9 (audit2allow), tightened to interfaces.
+
+require {
+    type cgroup_t;
+    type var_run_t;
+}
+
+########################################
+# Domains. The units keep systemd's NoNewPrivileges=yes + sandboxing;
+# init_nnp_daemon_domain grants nnp_transition so the exec-time domain
+# transition still happens under NNP — both hardenings coexist, no drop-in.
+########################################
+type sigil_agent_t;
+type sigil_agent_exec_t;
+init_daemon_domain(sigil_agent_t, sigil_agent_exec_t)
+init_nnp_daemon_domain(sigil_agent_t)
+
+type sigil_sender_t;
+type sigil_sender_exec_t;
+init_daemon_domain(sigil_sender_t, sigil_sender_exec_t)
+init_nnp_daemon_domain(sigil_sender_t)
+
+type sigil_server_t;
+type sigil_server_exec_t;
+init_daemon_domain(sigil_server_t, sigil_server_exec_t)
+init_nnp_daemon_domain(sigil_server_t)
+
+########################################
+# File / dir / socket / port types.
+########################################
+type sigil_conf_t;
+files_config_file(sigil_conf_t)
+
+type sigil_var_lib_t;
+files_type(sigil_var_lib_t)
+
+type sigil_var_log_t;
+logging_log_file(sigil_var_log_t)
+
+type sigil_sender_var_lib_t;
+files_type(sigil_sender_var_lib_t)
+
+type sigil_sender_var_log_t;
+logging_log_file(sigil_sender_var_log_t)
+
+type sigil_server_var_lib_t;
+files_type(sigil_server_var_lib_t)
+
+type sigil_server_var_log_t;
+logging_log_file(sigil_server_var_log_t)
+
+########################################
+# Common to all three daemons.
+########################################
+# systemd places each service in a cgroup it reads at startup.
+allow sigil_agent_t cgroup_t:dir search;
+allow sigil_agent_t cgroup_t:file getattr;
+allow sigil_sender_t cgroup_t:dir search;
+allow sigil_sender_t cgroup_t:file getattr;
+allow sigil_server_t cgroup_t:dir search;
+allow sigil_server_t cgroup_t:file getattr;
+
+# Read /etc/sigil (config + mTLS material).
+read_files_pattern(sigil_agent_t, sigil_conf_t, sigil_conf_t)
+list_dirs_pattern(sigil_agent_t, sigil_conf_t, sigil_conf_t)
+read_files_pattern(sigil_sender_t, sigil_conf_t, sigil_conf_t)
+list_dirs_pattern(sigil_sender_t, sigil_conf_t, sigil_conf_t)
+read_files_pattern(sigil_server_t, sigil_conf_t, sigil_conf_t)
+list_dirs_pattern(sigil_server_t, sigil_conf_t, sigil_conf_t)
+
+########################################
+# Agent — file-integrity monitoring (reads arbitrary files by design),
+# user enumeration, host fingerprint, own state/events/control-socket.
+########################################
+# FIM: read any file/dir and watch them for changes (inotify).
+files_read_all_files(sigil_agent_t)
+files_list_all(sigil_agent_t)
+files_getattr_all_dirs(sigil_agent_t)
+# Reading other users' files as root needs DAC override.
+allow sigil_agent_t self:capability { dac_read_search dac_override };
+# inotify watches across the tree.
+allow sigil_agent_t { file_type }:dir watch;
+allow sigil_agent_t { file_type }:file watch;
+
+# User enumeration (passwd / nsswitch).
+auth_use_nsswitch(sigil_agent_t)
+
+# Host fingerprint: hostname, resolv.conf, network interfaces (runs `ip`/ifconfig,
+# reads /proc/net + netlink).
+sysnet_read_config(sigil_agent_t)
+sysnet_exec_ifconfig(sigil_agent_t)
+kernel_read_network_state(sigil_agent_t)
+kernel_read_system_state(sigil_agent_t)
+corecmd_exec_bin(sigil_agent_t)
+allow sigil_agent_t self:netlink_route_socket { bind create getattr nlmsg_read read setopt write };
+allow sigil_agent_t self:unix_dgram_socket { create ioctl };
+
+# Own state.db (/var/lib/sigil) + events JSONL (/var/log/sigil).
+manage_dirs_pattern(sigil_agent_t, sigil_var_lib_t, sigil_var_lib_t)
+manage_files_pattern(sigil_agent_t, sigil_var_lib_t, sigil_var_lib_t)
+allow sigil_agent_t sigil_var_lib_t:file map;
+manage_dirs_pattern(sigil_agent_t, sigil_var_log_t, sigil_var_log_t)
+manage_files_pattern(sigil_agent_t, sigil_var_log_t, sigil_var_log_t)
+
+# Control socket. systemd's RuntimeDirectory=sigil creates /run/sigil and
+# labels it var_run_t; the agent creates + listens on the stream socket there.
+allow sigil_agent_t var_run_t:dir { search getattr add_name remove_name write };
+allow sigil_agent_t var_run_t:sock_file manage_sock_file_perms;
+allow sigil_agent_t self:unix_stream_socket { create bind listen accept getattr getopt setopt };
+
+########################################
+# Sender — reads the agent spool, connects the control socket, ships over the
+# network (mTLS), writes its own state/dead-letter.
+########################################
+# Read the agent's events spool (sigil_var_log_t).
+list_dirs_pattern(sigil_sender_t, sigil_var_log_t, sigil_var_log_t)
+read_files_pattern(sigil_sender_t, sigil_var_log_t, sigil_var_log_t)
+
+# Own state + dead-letter.
+manage_dirs_pattern(sigil_sender_t, sigil_sender_var_lib_t, sigil_sender_var_lib_t)
+manage_files_pattern(sigil_sender_t, sigil_sender_var_lib_t, sigil_sender_var_lib_t)
+manage_dirs_pattern(sigil_sender_t, sigil_sender_var_log_t, sigil_sender_var_log_t)
+manage_files_pattern(sigil_sender_t, sigil_sender_var_log_t, sigil_sender_var_log_t)
+
+# Connect to the agent's control socket (under /run/sigil = var_run_t).
+allow sigil_sender_t var_run_t:dir search;
+allow sigil_sender_t var_run_t:sock_file { getattr write };
+allow sigil_sender_t sigil_agent_t:unix_stream_socket connectto;
+
+# Network egress (HTTPS/mTLS to the server) + DNS.
+allow sigil_sender_t self:tcp_socket { create connect getattr getopt setopt read write };
+corenet_tcp_connect_all_ports(sigil_sender_t)
+corenet_tcp_sendrecv_generic_node(sigil_sender_t)
+sysnet_dns_name_resolve(sigil_sender_t)
+auth_use_nsswitch(sigil_sender_t)
+
+########################################
+# Server — listens on its TCP port, accepts mTLS, writes its own state.
+########################################
+manage_dirs_pattern(sigil_server_t, sigil_server_var_lib_t, sigil_server_var_lib_t)
+manage_files_pattern(sigil_server_t, sigil_server_var_lib_t, sigil_server_var_lib_t)
+manage_dirs_pattern(sigil_server_t, sigil_server_var_log_t, sigil_server_var_log_t)
+manage_files_pattern(sigil_server_t, sigil_server_var_log_t, sigil_server_var_log_t)
+
+# Listen + accept on the sigil port.
+allow sigil_server_t self:tcp_socket { create bind listen accept getattr getopt setopt shutdown read write };
+corenet_tcp_bind_generic_node(sigil_server_t)
+corenet_tcp_bind_all_unreserved_ports(sigil_server_t)
+sysnet_dns_name_resolve(sigil_server_t)
+auth_use_nsswitch(sigil_server_t)


### PR DESCRIPTION
Ships a SELinux policy module that confines the three de-rooted sigil daemons (#10) into dedicated domains on RHEL-family systems, instead of leaving them in `unconfined_service_t`.

| daemon | domain |
|--------|--------|
| `sigil` (agent) | `sigil_agent_t` |
| `sigil-sender` | `sigil_sender_t` |
| `sigil-server` | `sigil_server_t` |

State/log/config get dedicated types (`sigil_var_lib_t`, `sigil_var_log_t`, `sigil_conf_t`, `sigil_{sender,server}_var_lib_t`, …). Per-daemon least privilege: the **agent** may read any file (it does file-integrity monitoring by design — `files_read_all_files`) but is otherwise tightly confined (no arbitrary writes, limited caps, no general network); the **sender** only reads the agent's spool, connects the control socket, and ships over the network; the **server** binds its port and writes its own state.

## Key finding — `init_nnp_daemon_domain`

The units keep systemd's `NoNewPrivileges=yes` + sandboxing (`ProtectSystem=strict`, `ProtectKernelModules=yes`, …). Under `NoNewPrivileges` the kernel blocks the exec-time SELinux domain transition unless the policy grants `process2:nnp_transition` — otherwise it falls back to a *bounded* transition and is **denied** (`security_bounded_transition`). `init_nnp_daemon_domain(...)` grants exactly that, so the daemons get **both** the systemd hardening **and** SELinux confinement — no unit drop-in, no lost hardening.

## Packaging

Each daemon RPM ships `packaging/selinux/sigil.{te,fc}` under `/usr/share/selinux/packages/sigil/`; `post_install` builds + loads the module (`semodule -i`, idempotent) and relabels — **guarded** on the policy devel toolchain (`semodule` + `/usr/share/selinux/devel/Makefile`), so it no-ops on non-SELinux hosts and the daemons just run unconfined there. The `.deb` path is unaffected (Debian/Ubuntu use AppArmor — a sibling follow-up).

## Verification (Rocky Linux 9.7 aarch64, SELinux **enforcing**)

On a dedicated box:
- All three daemons run in their confined domains with **zero AVC denials** — verified even with `dontaudit` disabled (so nothing is silently suppressed).
- systemd hardening preserved: `NoNewPrivileges=yes` stays effective alongside the SELinux transition.
- **End-to-end packaged flow:** removed the module → `dnf reinstall` the agent RPM → `post_install` auto-built + loaded the module, relabeled `/usr/bin/sigil` to `sigil_agent_exec_t`, and the agent restarted confined in `sigil_agent_t` under enforcing.

`packaging/selinux/README.md` documents manual build/install + the NNP rationale.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)