### PR TITLE
fix(manifest): rotate build-signing trust anchor to sigil-build-2026b (#74)

### DIFF
--- a/crates/sigil-core/src/manifest/mod.rs
+++ b/crates/sigil-core/src/manifest/mod.rs
@@ -15,8 +15,8 @@ pub const MANIFEST_SCHEMA_VERSION: u8 = 1;
 /// CI secret and is used by the release workflow to sign each release's build
 /// manifest; `sigil doctor --verify-self` checks a manifest against these keys.
 pub const SIGIL_BUILD_PUBKEYS: &[(&str, &str)] = &[(
-    "sigil-build-2026a",
-    "ed25519:NfkTZEW7tjw/XMoBc39dUs05mpqO+tUGhaqqt1tEy9c=",
+    "sigil-build-2026b",
+    "ed25519:82p5N6z+3HmSUPg/AmZlQO8CVIyZIjriYwiPJAXMDn8=",
 )];
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## What

Replaces the compiled-in build-attestation trust anchor in `SIGIL_BUILD_PUBKEYS`:

```
sigil-build-2026a  →  sigil-build-2026b
```

## Why

The interim anchor `sigil-build-2026a` was generated on a developer box, so its provenance is too weak to root build attestation (#13). `sigil-build-2026b` was generated by the maintainer in a controlled environment; the matching private key lives only in the `SIGIL_BUILD_SIGNING_KEY` CI secret (already updated).

## Clean replacement — no overlap needed

Every published release (`v0.2.0` and earlier) **predates** the `#13` manifest-signing wiring, so **no release was ever signed by the interim key**. There is no existing signed artifact to keep verifiable, so the old anchor is removed outright rather than overlapped. `SIGIL_BUILD_PUBKEYS` remains a slice, so *future* rotations can list old+new anchors together during a transition window.

The **next** tagged release will be the first signed build manifest, signed by `sigil-build-2026b`.

## Verification

- New pubkey decodes to a valid 32-byte ed25519 key.
- `cargo fmt` / `cargo clippy -D warnings` clean.
- `manifest::tests` (8) + `doctor::verify_self_tests` (6) green — verify machinery exercised end-to-end with injected keypairs; `unknown_key_id` now also covers any stray `2026a`-signed input.
- Full positive `sign → doctor --verify-self` chain with the real key is exercised on the next signed release (the private key is intentionally not held here).

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)