### PR TITLE
feat(mcp): single-host sigil-check default; sigil-fleet operator-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,13 @@ one operator CLI, one read-only MCP server, and three shared libraries.
 **MCP server**
 
 - `sigil-mcp` — read-only MCP server (`sigil-mcp` binary), two auto-detected
-  modes. **Fleet mode** exposes a `sigil-server`'s bearer-gated read API as
-  Model Context Protocol tools so an MCP client (Claude Desktop/Code) can read
-  and reason over fleet posture. **Local mode** (no server URL) reads the local
-  `sigil-agent` control socket to surface *this machine's* AI Guard posture —
-  no server, no fleet. Read-only by construction: no write or remediation tools.
+  modes that register under distinct names. **`sigil-check`** (default, no server
+  URL) reads the local `sigil-agent` control socket to surface *only this
+  machine's* AI Guard posture — no server, no fleet; this is what an AI coding
+  agent (Claude Desktop/Code, Codex) registers. **`sigil-fleet`** (operators)
+  exposes a `sigil-server`'s bearer-gated read API as Model Context Protocol
+  tools for fleet-wide posture, run beside `sigil-server` / `sigil-manager`.
+  Read-only by construction: no write or remediation tools.
   See [`crates/sigil-mcp/README.md`](crates/sigil-mcp/README.md).
 
 **Libraries**

--- a/crates/sigil-mcp/README.md
+++ b/crates/sigil-mcp/README.md
@@ -1,32 +1,32 @@
 # sigil-mcp
 
-Read-only MCP server for Sigil security posture. Two modes, auto-detected from
-the environment — both read-only by construction (no write/remediation tools):
+Read-only MCP server for Sigil security posture. One binary, two modes
+auto-detected from the environment — both read-only by construction (no
+write/remediation tools). The modes have **distinct server names** so an MCP
+client (and you) can tell them apart:
 
-- **Fleet mode** (`SIGIL_SERVER_BASE_URL` set): exposes a `sigil-server`'s GET
-  read API as MCP tools so an MCP client (Claude Desktop/Code, etc.) can read
-  and reason over **fleet** security posture.
-- **Local mode** (no server URL): reads the local `sigil-agent`'s control socket
-  and exposes **this machine's** AI Guard posture — no server, no fleet. See
-  [Local mode](#local-mode-individual-self-assessment-no-server) below.
+- **`sigil-check`** — Local mode (default, no `SIGIL_SERVER_BASE_URL`). Reads the
+  local `sigil-agent`'s control socket and exposes **only this machine's** AI
+  Guard posture. No server, no fleet. This is what an AI coding agent (Claude
+  Code/Desktop, Codex, …) registers on a developer's box. See
+  [sigil-check](#sigil-check-this-hosts-own-posture-no-server) below.
+- **`sigil-fleet`** — Fleet mode (`SIGIL_SERVER_BASE_URL` set). Exposes a
+  `sigil-server`'s GET read API as MCP tools so an **operator** can read and
+  reason over a whole fleet's posture. Run it beside `sigil-server` /
+  `sigil-manager`, not as the default an agent gets.
 
 ## Tools
-Fleet mode: `list_hosts`, `get_host`, `fleet_risk`, `fleet_compliance`,
-`query_events`, `get_event`, `get_policy`, `server_meta`, `healthz`.
-Local mode: `my_risk`, `my_guard_detail`, `my_findings`.
-
-## Configuration (env)
-
-| Var | Meaning |
-|-----|---------|
-| `SIGIL_SERVER_BASE_URL` | read API base, e.g. `http://127.0.0.1:9090` (proxy) or `https://host:8443` |
-| `SIGIL_SERVER_READ_TOKEN` | bearer token |
-| `SIGIL_CLIENT_CERT` / `SIGIL_CLIENT_KEY` / `SIGIL_CA_CERT` | optional, for direct mTLS to `:8443` (omit when using a bearer-only reverse proxy) |
+`sigil-check` (this host): `my_risk`, `my_guard_detail`, `my_findings`.
+`sigil-fleet` (operators): `list_hosts`, `get_host`, `fleet_risk`,
+`fleet_compliance`, `query_events`, `get_event`, `get_policy`, `server_meta`,
+`healthz`.
 
 ## Register with an MCP client
 
 The fastest, paste-proof way — `--print-config` stamps the **absolute path** of
-the running binary, so it works even when the client doesn't see your shell PATH:
+the running binary, so it works even when the client doesn't see your shell PATH.
+It emits `sigil-check` (single host, no server) as the default, with `sigil-fleet`
+shown as a commented operator add-on:
 
 ```sh
 sigil-mcp --print-config codex     # Codex (~/.codex/config.toml)
@@ -34,10 +34,50 @@ sigil-mcp --print-config claude    # Claude Code / Claude Desktop (mcpServers JS
 sigil-mcp --print-config           # both
 ```
 
-Then fill in `SIGIL_SERVER_BASE_URL` / `SIGIL_SERVER_READ_TOKEN` (fleet mode), or
-delete the `env` for [local mode](#local-mode-individual-self-assessment-no-server).
+Claude Desktop / Code (stdio), single host — no env needed:
 
-Claude Desktop / Code (stdio) looks like:
+```json
+{
+  "mcpServers": {
+    "sigil-check": { "command": "/absolute/path/to/sigil-mcp" }
+  }
+}
+```
+
+> **`command` must be an absolute path** (or a name on the *client's* PATH). MCP
+> clients are usually GUI/login-launched and don't inherit your interactive shell
+> PATH, and a build-from-source binary lives at `target/release/sigil-mcp` —
+> never on PATH.
+>
+> **Troubleshooting — `MCP startup failed: No such file or directory (os error 2)`**:
+> the client can't find the binary. Use the absolute path (run
+> `sigil-mcp --print-config <client>` to get a correct block).
+
+## sigil-check (this host's own posture, no server)
+
+With `SIGIL_SERVER_BASE_URL` unset, `sigil-mcp` runs as **`sigil-check`**: it reads
+the running local `sigil-agent`'s control socket and exposes this machine's AI
+Guard posture as `my_risk` (per-tool risk band/score), `my_guard_detail` (rubric,
+parsers, rule packs), and `my_findings` (per-repo discovery + watched hook
+scripts). It can never see another host.
+
+The socket path defaults to the same location `sigil-agent` uses
+(`$XDG_RUNTIME_DIR/sigil/control.sock`, `/var/run/sigil/control.sock` as root,
+or `/tmp/sigil-<uid>/control.sock`); override with `SIGIL_AGENT_CONTROL_SOCKET`.
+v1 expects the agent and `sigil-mcp` to run as the **same user** (the control
+socket is `0660`); root-daemon + group access is tracked in #10.
+
+## sigil-fleet (operators — fleet-wide, via sigil-server)
+
+For operators who want the whole fleet, point `sigil-mcp` at a `sigil-server`'s
+read API. This is a separate registration (`sigil-fleet`), run alongside
+`sigil-server` / `sigil-manager` — not the default a coding agent gets.
+
+| Var | Meaning |
+|-----|---------|
+| `SIGIL_SERVER_BASE_URL` | read API base, e.g. `http://127.0.0.1:9090` (proxy) or `https://host:8443` |
+| `SIGIL_SERVER_READ_TOKEN` | bearer token |
+| `SIGIL_CLIENT_CERT` / `SIGIL_CLIENT_KEY` / `SIGIL_CA_CERT` | optional, for direct mTLS to `:8443` (omit when using a bearer-only reverse proxy) |
 
 ```json
 {
@@ -53,37 +93,6 @@ Claude Desktop / Code (stdio) looks like:
 }
 ```
 
-> **`command` must be an absolute path** (or a name on the *client's* PATH). MCP
-> clients are usually GUI/login-launched and don't inherit your interactive shell
-> PATH, and a build-from-source binary lives at `target/release/sigil-mcp` —
-> never on PATH.
->
-> **Troubleshooting — `MCP startup failed: No such file or directory (os error 2)`**:
-> the client can't find the binary. Use the absolute path (run
-> `sigil-mcp --print-config <client>` to get a correct block).
-
-## Local mode (individual self-assessment, no server)
-
-With `SIGIL_SERVER_BASE_URL` unset, `sigil-mcp` reads the running local
-`sigil-agent`'s control socket and exposes this machine's AI Guard posture as
-`my_risk` (per-tool risk band/score), `my_guard_detail` (rubric, parsers, rule
-packs), and `my_findings` (per-repo discovery + watched hook scripts).
-
-```json
-{
-  "mcpServers": {
-    "sigil-local": { "command": "sigil-mcp" }
-  }
-}
-```
-
-The socket path defaults to the same location `sigil-agent` uses
-(`$XDG_RUNTIME_DIR/sigil/control.sock`, `/var/run/sigil/control.sock` as root,
-or `/tmp/sigil-<uid>/control.sock`); override with `SIGIL_AGENT_CONTROL_SOCKET`.
-v1 expects the agent and `sigil-mcp` to run as the **same user** (the control
-socket is `0660`); root-daemon + group access is tracked in #10.
-
-## Note for operators
 Configuration is validated at startup, but connectivity is not probed — an
 unreachable `SIGIL_SERVER_BASE_URL` or bad token surfaces on the first tool
 call (with a clear error), not at launch. Logs go to stderr; stdout is the

--- a/crates/sigil-mcp/src/local_tools.rs
+++ b/crates/sigil-mcp/src/local_tools.rs
@@ -1,6 +1,6 @@
 use crate::local::LocalUpstream;
 use rmcp::handler::server::router::tool::ToolRouter;
-use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
 use std::sync::Arc;
 
@@ -60,6 +60,12 @@ impl SigilLocal {
 impl ServerHandler for SigilLocal {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
+            // Single-host identity: this server only ever exposes THIS machine's
+            // posture. Operators who want the fleet run `sigil-fleet` instead.
+            server_info: Implementation {
+                name: "sigil-check".to_string(),
+                ..Implementation::from_build_env()
+            },
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             instructions: Some(
                 "Read-only view of THIS machine's Sigil AI Guard posture (no fleet, no server). \

--- a/crates/sigil-mcp/src/print_config.rs
+++ b/crates/sigil-mcp/src/print_config.rs
@@ -2,6 +2,11 @@
 //! config block that pins the **absolute** path of this binary
 //! (`std::env::current_exe()`), so registration works even when the client
 //! doesn't see the user's interactive-shell PATH (#72).
+//!
+//! The default registration is `sigil-check`: this host's own posture, single
+//! host, no server required. The fleet-wide `sigil-fleet` view is for operators
+//! (run beside sigil-server / sigil-manager) and is shown as a commented add-on,
+//! never as the default an AI coding agent gets.
 
 /// Supported clients (and their aliases) for `render_config`.
 pub const CLIENTS: &str = "codex, claude";
@@ -9,18 +14,28 @@ pub const CLIENTS: &str = "codex, claude";
 fn codex_block(exe: &str) -> String {
     format!(
         "# Codex — add to ~/.codex/config.toml\n\
-         [mcp_servers.sigil-fleet]\n\
+         # sigil-check — THIS host's own Sigil posture (single host, no server):\n\
+         [mcp_servers.sigil-check]\n\
          command = \"{exe}\"\n\
-         # Fleet mode — point at your sigil-server's read API:\n\
-         env = {{ SIGIL_SERVER_BASE_URL = \"https://your-sigil-server:PORT\", SIGIL_SERVER_READ_TOKEN = \"your-read-token\" }}\n\
-         # Local mode (this host's own posture, no server): delete the env line.\n"
+         \n\
+         # Operators only — fleet-wide view via your sigil-server's read API.\n\
+         # Register this as a SECOND server beside sigil-server / sigil-manager;\n\
+         # don't replace sigil-check above.\n\
+         # [mcp_servers.sigil-fleet]\n\
+         # command = \"{exe}\"\n\
+         # env = {{ SIGIL_SERVER_BASE_URL = \"https://your-sigil-server:PORT\", SIGIL_SERVER_READ_TOKEN = \"your-read-token\" }}\n"
     )
 }
 
 fn claude_block(exe: &str) -> String {
     format!(
         "// Claude Code / Claude Desktop — \"mcpServers\" entry\n\
-         {{\n  \"mcpServers\": {{\n    \"sigil-fleet\": {{\n      \"command\": \"{exe}\",\n      \"env\": {{\n        \"SIGIL_SERVER_BASE_URL\": \"https://your-sigil-server:PORT\",\n        \"SIGIL_SERVER_READ_TOKEN\": \"your-read-token\"\n      }}\n    }}\n  }}\n}}\n// Local mode (this host's own posture, no server): omit the \"env\" object.\n"
+         // sigil-check — THIS host's own Sigil posture (single host, no server):\n\
+         {{\n  \"mcpServers\": {{\n    \"sigil-check\": {{\n      \"command\": \"{exe}\"\n    }}\n  }}\n}}\n\
+         // Operators only — fleet-wide view via your sigil-server's read API. Add a\n\
+         // SECOND entry \"sigil-fleet\" with command \"{exe}\" and env\n\
+         // SIGIL_SERVER_BASE_URL + SIGIL_SERVER_READ_TOKEN pointing at your\n\
+         // sigil-server; don't replace sigil-check above.\n"
     )
 }
 
@@ -42,18 +57,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn codex_uses_absolute_exe_path_and_toml_table() {
+    fn codex_defaults_to_single_host_check_with_absolute_exe() {
         let out = render_config("/opt/sigil/sigil-mcp", Some("codex")).unwrap();
-        assert!(out.contains("[mcp_servers.sigil-fleet]"));
+        // sigil-check is the active (uncommented) default; no server env on it.
+        assert!(out.contains("[mcp_servers.sigil-check]"));
         assert!(out.contains("command = \"/opt/sigil/sigil-mcp\""));
+        // Fleet is present only as a commented operator add-on.
+        assert!(out.contains("# [mcp_servers.sigil-fleet]"));
         assert!(out.contains("SIGIL_SERVER_BASE_URL"));
     }
 
     #[test]
-    fn claude_aliases_render_json_with_exe() {
+    fn claude_aliases_render_check_json_with_exe() {
         for c in ["claude", "claude-code", "claude-desktop"] {
             let out = render_config("/abs/sigil-mcp", Some(c)).unwrap();
             assert!(out.contains("\"mcpServers\""), "{c}");
+            assert!(out.contains("\"sigil-check\""), "{c}");
             assert!(out.contains("\"command\": \"/abs/sigil-mcp\""), "{c}");
         }
     }
@@ -61,7 +80,7 @@ mod tests {
     #[test]
     fn no_client_renders_both() {
         let out = render_config("/x/sigil-mcp", None).unwrap();
-        assert!(out.contains("[mcp_servers.sigil-fleet]"));
+        assert!(out.contains("[mcp_servers.sigil-check]"));
         assert!(out.contains("\"mcpServers\""));
     }
 

--- a/crates/sigil-mcp/src/tools.rs
+++ b/crates/sigil-mcp/src/tools.rs
@@ -1,7 +1,7 @@
 use crate::upstream::Upstream;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::schemars;
 use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
 use serde::Deserialize;
@@ -132,12 +132,19 @@ impl SigilFleet {
 impl ServerHandler for SigilFleet {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
+            // Operator-facing fleet view — distinct identity from the single-host
+            // `sigil-check` (local) server so clients can tell the two apart.
+            server_info: Implementation {
+                name: "sigil-fleet".to_string(),
+                ..Implementation::from_build_env()
+            },
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             instructions: Some(
-                "Read-only access to a Sigil fleet's security posture. \
-                 Survey with fleet_risk/list_hosts, drill in with get_host, \
-                 investigate over time with query_events. There are no write \
-                 or remediation tools — this server cannot change anything."
+                "Read-only access to a Sigil fleet's security posture, for operators \
+                 (run alongside sigil-server / sigil-manager). Survey with \
+                 fleet_risk/list_hosts, drill in with get_host, investigate over time \
+                 with query_events. There are no write or remediation tools — this \
+                 server cannot change anything."
                     .to_string(),
             ),
             ..Default::default()


### PR DESCRIPTION
## What

Splits the MCP server into two clearly-named identities and makes the **single-host** one the default:

| Name | Scope | Persona | Default? |
|------|-------|---------|----------|
| **`sigil-check`** | only THIS host | AI coding agent on a dev box | ✅ what `--print-config` emits |
| **`sigil-fleet`** | whole fleet (via `sigil-server` read API) | operator (beside sigil-server / sigil-manager) | commented add-on |

## Why

An AI coding agent that registers `sigil-mcp` should only ever see the host it runs on. Until now the advertised default (`--print-config`) was **fleet mode** pointed at a `sigil-server` — so the default exposed the *entire fleet* to the agent. That's the operator plane's job, not the agent's.

Operators still get the fleet view: from `sigil-server` / `sigil-manager`, or by explicitly registering `sigil-fleet`.

## Changes

- `SigilLocal` now reports `ServerInfo.server_info.name = "sigil-check"`; `SigilFleet` reports `"sigil-fleet"` — so MCP clients (and humans) can tell them apart.
- `--print-config` emits `sigil-check` (single host, **no server env**) as the active default, with `sigil-fleet` (server URL + read token) shown as a commented operator-only add-on.
- README (root + crate) reframed around the two named personas.

**No tools removed, no behavior change to either mode's data** — this is naming + default-posture + docs. Fleet demo assets (GIFs) remain valid as `sigil-fleet` operator demos.

## Verify

- `cargo fmt` / `cargo clippy -D warnings` clean.
- `sigil-mcp` tests 31/31 green (print-config tests updated to assert `sigil-check` is the active default and `sigil-fleet` is commented).
- `sigil-mcp --print-config` output eyeballed — default is `[mcp_servers.sigil-check]` with no env; fleet is commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)