### PR TITLE
chore(release): 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,25 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-01
+
 ### Added
 
+- **aarch64 prebuilt binaries, `.deb`/`.rpm`, and an ed25519-signed build
+  manifest** (#12, #13). Releases now ship `x86_64` **and** `aarch64` Linux
+  packages, plus a `build-manifest.json` whose per-arch blake3 hashes are signed
+  with the compiled-in `SIGIL_BUILD_PUBKEYS` trust anchor; `sigil doctor
+  --verify-self` checks the running binary against it. `packaging/build.sh
+  --target` cross-builds the OS packages.
+- **`sigil-mcp --print-config [codex|claude]`** (#72). Emits a ready-to-paste MCP
+  client registration block that pins the binary's **absolute** path, so
+  registration works even when the client doesn't inherit your shell `PATH`.
+- **SELinux policy module for the three daemons** (#69). Ships
+  `packaging/selinux/sigil.{te,fc}` and loads it from the `.rpm` post-install
+  (guarded — a no-op without the SELinux policy devel toolchain), confining the
+  agent, sender, and server into dedicated domains
+  (`sigil_agent_t`/`sigil_sender_t`/`sigil_server_t`) that coexist with the
+  units' `NoNewPrivileges=yes` hardening. Verified enforcing-clean on Rocky 9.
 - **`sigil-mcp` local mode — individual self-assessment, no server** (#55).
   When `SIGIL_SERVER_BASE_URL` is unset, `sigil-mcp` reads the local
   `sigil-agent` control socket instead of a fleet read API and exposes *this
@@ -53,6 +70,10 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ### Fixed
 
+- **`query_events` multi-host filter** (#73). The MCP `query_events` tool and the
+  server read API disagreed on the `host_id` filter encoding — repeated params
+  tripped the server's `serde_urlencoded` deserializer ("expected a sequence",
+  HTTP 400). Both sides now use one comma-separated `host_id` param.
 - **`sigil-mcp` local-mode socket trust** (#57). The local upstream now verifies
   the control-socket peer is root or the current user (via
   `UnixStream::peer_cred`) before trusting its `DoctorAiGuardReport`, closing a
@@ -72,6 +93,13 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ### Changed
 
+- **`sigil-mcp` defaults to single-host `sigil-check`; the fleet view is the
+  operator-only `sigil-fleet`** (#80). The two auto-detected modes now register
+  under distinct MCP server names: `sigil-check` (no server URL) exposes only
+  *this* host's posture and is what `--print-config` emits by default, while the
+  fleet-wide `sigil-fleet` (pointed at a `sigil-server` read API) is documented
+  as an operator surface to run beside `sigil-server` / `sigil-manager`. No tools
+  were removed — naming, default posture, and docs only.
 - `sigil doctor`'s events-directory permission check is refactored around a pure
   `classify_events_dir_perms` classifier (mirrors the existing socket
   classifier) and validates `root:sigil` ownership; behavior is unchanged, the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3130,11 +3130,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "sigil-sender"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump + CHANGELOG for **0.2.1**. Merge this, then tag `v0.2.1` on `main` to trigger the release workflow.

## Why 0.2.1 matters
First release after the manifest-signing wiring (#13) and the trust-anchor rotation to `sigil-build-2026b` (#74). The release workflow will produce the **first signed `build-manifest.json`**, verifiable with `sigil doctor --verify-self` against the compiled-in `SIGIL_BUILD_PUBKEYS`.

## Changes
- `Cargo.toml` workspace version `0.2.0` → `0.2.1` (+ `Cargo.lock`).
- `CHANGELOG.md`: `[Unreleased]` → `[0.2.1] - 2026-06-01`, and filled in the entries that landed without changelog lines — aarch64 packages + signed manifest (#12, #13), SELinux module (#69), `--print-config` (#72), single-host `sigil-check` default (#80), `query_events` multi-host filter fix (#73) — alongside the already-staged #10 hardening slices and #55/#57/#60/#61.

## Gates (local)
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -D warnings` ✅
- `cargo test --workspace` — green except a single FS-watch flake (`it_emits_modified_event`), which passes 3/3 in isolation; it's the FSEvents-under-parallel-load flake from #66, unrelated to the version bump.

## Release steps after merge
1. `git tag v0.2.1 && git push origin v0.2.1`
2. release.yml builds x86_64 + aarch64, signs the manifest (SIGIL_BUILD_SIGNING_KEY), publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)