### PR TITLE
feat(hook): sigil-hook Stage 1 — runtime observe at the agent tool boundary (#64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           ver="${GITHUB_REF_NAME#v}"
           dist="sigil-${ver}-${{ matrix.target }}"
           mkdir "$dist"
-          for b in sigil sigil-sender sigil-server sigil-sign sigil-mcp; do
+          for b in sigil sigil-sender sigil-server sigil-sign sigil-mcp sigil-hook; do
             cp "target/${{ matrix.target }}/release/$b" "$dist/"
           done
           cp README.md LICENSE NOTICE "$dist/" 2>/dev/null || true
@@ -72,7 +72,7 @@ jobs:
           $ver = "${env:GITHUB_REF_NAME}" -replace '^v',''
           $dist = "sigil-$ver-${{ matrix.target }}"
           New-Item -ItemType Directory -Path $dist | Out-Null
-          foreach ($b in 'sigil','sigil-sender','sigil-server','sigil-sign','sigil-mcp') {
+          foreach ($b in 'sigil','sigil-sender','sigil-server','sigil-sign','sigil-mcp','sigil-hook') {
             Copy-Item "target/${{ matrix.target }}/release/$b.exe" $dist
           }
           Copy-Item README.md,LICENSE,NOTICE $dist -ErrorAction SilentlyContinue
@@ -168,7 +168,7 @@ jobs:
             tgz="dist/sigil-${ver}-${tgt}.tar.gz"
             d="$(mktemp -d)"; tar -xzf "$tgz" -C "$d"
             inner="$d/sigil-${ver}-${tgt}"
-            for b in sigil sigil-sender sigil-server sigil-sign sigil-mcp; do
+            for b in sigil sigil-sender sigil-server sigil-sign sigil-mcp sigil-hook; do
               args+=(--artifact "name=${b},target=${tgt},file=${inner}/${b}")
             done
           done
@@ -221,7 +221,7 @@ jobs:
           Download the `.zip` for your architecture (`x86_64` for most PCs,
           `aarch64` for Arm devices such as Surface Pro X) and add it to your PATH.
 
-          Every archive contains all five binaries: `sigil`, `sigil-sender`, `sigil-server`, `sigil-sign`, `sigil-mcp`.
+          Every archive contains all six binaries: `sigil`, `sigil-sender`, `sigil-server`, `sigil-sign`, `sigil-mcp`, `sigil-hook`.
 
           `sigil-mcp` is the read-only fleet MCP server — point an MCP client (Claude Desktop/Code) at a `sigil-server`'s read API to query and reason over fleet posture. See [crates/sigil-mcp/README.md](https://github.com/Ju571nK/sigil/blob/main/crates/sigil-mcp/README.md).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sigil-hook"
+version = "0.2.1"
+dependencies = [
+ "blake3",
+ "clap",
+ "libc",
+ "regex",
+ "serde",
+ "serde_json",
+ "sigil-core",
+ "tempfile",
+ "time",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "sigil-mcp"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,8 +3120,6 @@ dependencies = [
  "serde_json",
  "sigil-core",
  "tempfile",
- "time",
- "tokio",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "crates/sigil-rules-basic", "crates/sigil-sender", "crates/sigil-signer", "crates/sigil-server", "crates/sigil-mcp"]
+members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "crates/sigil-rules-basic", "crates/sigil-sender", "crates/sigil-signer", "crates/sigil-server", "crates/sigil-mcp", "crates/sigil-hook"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/sigil-agent/src/hook_listener.rs
+++ b/crates/sigil-agent/src/hook_listener.rs
@@ -134,26 +134,33 @@ fn to_event(env: HookEnvelope, peer_uid: u32, host_id: &str) -> sigil_core::even
     let inv = env.payload;
 
     // Decompose the action into normalized fields.
-    let (kind, hash, preview) = match &inv.action {
+    // 4-tuple: (kind, hash, preview, other_label)
+    // other_label is Some(tool_name) only for the Other arm, None for all others.
+    let (kind, hash, preview, other_label) = match &inv.action {
         HookAction::Bash {
             command_hash,
             command_preview,
-        } => ("bash", command_hash.clone(), command_preview.clone()),
+        } => ("bash", command_hash.clone(), command_preview.clone(), None),
         HookAction::FileEdit {
             path_hash,
             path_preview,
             ..
-        } => ("file_edit", path_hash.clone(), path_preview.clone()),
+        } => ("file_edit", path_hash.clone(), path_preview.clone(), None),
         HookAction::McpCall {
             args_hash,
             args_preview,
             ..
-        } => ("mcp_call", args_hash.clone(), args_preview.clone()),
+        } => ("mcp_call", args_hash.clone(), args_preview.clone(), None),
         HookAction::Other {
+            label,
             detail_hash,
             detail_preview,
-            ..
-        } => ("other", detail_hash.clone(), detail_preview.clone()),
+        } => (
+            "other",
+            detail_hash.clone(),
+            detail_preview.clone(),
+            Some(label.clone()),
+        ),
     };
 
     sigil_core::event::Event {
@@ -171,6 +178,7 @@ fn to_event(env: HookEnvelope, peer_uid: u32, host_id: &str) -> sigil_core::even
             agent_session_id: inv.agent_session_id,
             tool_use_id: inv.tool_use_id,
             action_kind: kind.to_string(),
+            other_label,
             action_hash: hash,
             action_preview: preview,
             capture_level: enum_str(&inv.capture_level),
@@ -248,6 +256,44 @@ mod tests {
                 assert_eq!(h.capture_status, "unsupported_agent_schema");
                 assert_eq!(h.action_kind, "bash");
                 assert_eq!(h.peer_uid, 1000);
+                assert_eq!(h.other_label, None, "bash action must not set other_label");
+            }
+            other => panic!("expected HookInvocation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_event_persists_other_label_for_other_action() {
+        // I2: HookAction::Other carries the tool name; it must persist in
+        // HookInvocationEvidence.other_label so operators can filter by tool.
+        let env = HookEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::now_v7(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookInvocation {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
+                action: HookAction::Other {
+                    label: "WebFetch".into(),
+                    detail_hash: "ab".repeat(32),
+                    detail_preview: None,
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+        };
+        let ev = to_event(env, 501, "host-y");
+        match ev.evidence {
+            Evidence::HookInvocation(h) => {
+                assert_eq!(h.action_kind, "other");
+                assert_eq!(
+                    h.other_label,
+                    Some("WebFetch".into()),
+                    "other_label must carry the tool name"
+                );
             }
             other => panic!("expected HookInvocation, got {other:?}"),
         }

--- a/crates/sigil-agent/src/hook_listener.rs
+++ b/crates/sigil-agent/src/hook_listener.rs
@@ -1,0 +1,181 @@
+//! Hook IPC listener (`hook.sock`). One-way: the agent reads `HookEnvelope`
+//! JSON lines from AI hook emitters (sigil-hook) and converts them to
+//! `CommittableEvent` entries in the event sink. The emitter never reads a
+//! response — `hook.sock` is write-only from the client's perspective.
+//!
+//! Security model (spec §9): DAC perms (0660) are the access gate.
+//! `SO_PEERCRED` is read to stamp the kernel-verified peer uid onto the event
+//! for attribution — it is NOT used to accept/reject connections.
+//!
+//! Concurrency: a `Semaphore` bounds inflight connections. When saturated the
+//! connection is dropped BEFORE reading (never hold an fd open waiting on a
+//! full sink). `try_send` is used so a full event channel never blocks the
+//! listener loop.
+
+use crate::state_task::CommittableEvent;
+use sigil_core::event::{
+    Evidence, HookInvocationEvidence, Severity, SourceKind, Subject, AGENT_VERSION, SCHEMA_VERSION,
+};
+use sigil_core::hook_proto::{HookAction, HookEnvelope};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::net::UnixListener;
+use tokio::sync::{mpsc, Semaphore};
+
+/// Maximum concurrent in-flight connections.
+const MAX_INFLIGHT: usize = 32;
+
+/// Maximum bytes read per connection before giving up (1 MiB).
+const MAX_LINE: u64 = 1024 * 1024;
+
+/// Bind `socket`, set 0o660 permissions, and start the accept loop.
+///
+/// Each accepted connection is handled in its own `tokio::spawn`ed task.
+/// When `MAX_INFLIGHT` slots are all occupied the new connection is dropped
+/// immediately without reading (a debug log records it). On parse success the
+/// resulting `CommittableEvent` is sent with `try_send` — if the channel is
+/// full the event is silently dropped rather than blocking.
+///
+/// This function runs until the tokio runtime shuts down (it does not return
+/// under normal operation).
+#[cfg(unix)]
+pub async fn serve(
+    socket: PathBuf,
+    tx: mpsc::Sender<CommittableEvent>,
+    host_id: String,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Remove a stale socket file from a previous run.
+    if socket.exists() {
+        let _ = std::fs::remove_file(&socket);
+    }
+    // Ensure parent directory exists.
+    if let Some(p) = socket.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+
+    let listener = UnixListener::bind(&socket)?;
+    // Set 0660 explicitly — do not rely on process umask.
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o660))?;
+
+    let sem = Arc::new(Semaphore::new(MAX_INFLIGHT));
+    tracing::info!(path = ?socket, "hook IPC listening");
+
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = ?e, "hook accept failed");
+                continue;
+            }
+        };
+
+        // Overload check: try to acquire a permit BEFORE reading anything.
+        // If the semaphore is exhausted, drop the connection without reading.
+        let permit = match sem.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::debug!("hook overload: dropping connection (MAX_INFLIGHT reached)");
+                drop(stream);
+                continue;
+            }
+        };
+
+        // Read SO_PEERCRED now, while we still own the stream. On failure
+        // (e.g., abstract-namespace socket on old kernels) fall back to u32::MAX
+        // so the event is still recorded with an obviously-sentinel uid.
+        let peer_uid = stream.peer_cred().map(|c| c.uid()).unwrap_or(u32::MAX);
+
+        let tx = tx.clone();
+        let host_id = host_id.clone();
+
+        tokio::spawn(async move {
+            // Permit is held for the lifetime of this task.
+            let _permit = permit;
+
+            let mut line = String::new();
+            // Limit bytes read to guard against a misbehaving / malicious sender
+            // filling memory. `take` wraps the raw stream; BufReader sits on top.
+            let mut rd = BufReader::new(stream.take(MAX_LINE));
+            if rd.read_line(&mut line).await.is_err() {
+                return;
+            }
+
+            let env: HookEnvelope = match serde_json::from_str(line.trim()) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::debug!(error = ?e, "hook: malformed envelope; dropping");
+                    return;
+                }
+            };
+
+            let ev = to_event(env, peer_uid, &host_id);
+            let committable = CommittableEvent {
+                event: ev,
+                new_hash: None,
+                path_for_db: PathBuf::new(),
+                target_id: String::new(),
+            };
+
+            // try_send: if the channel is full (sink backpressure) we drop rather
+            // than block. The listener must remain responsive to new connections.
+            if tx.try_send(committable).is_err() {
+                tracing::debug!("hook: event channel full; dropping hook event");
+            }
+        });
+    }
+}
+
+/// Convert a decoded `HookEnvelope` + kernel-verified `peer_uid` into an
+/// `Event` suitable for the sink pipeline.
+fn to_event(env: HookEnvelope, peer_uid: u32, host_id: &str) -> sigil_core::event::Event {
+    let inv = env.payload;
+
+    // Decompose the action into normalized fields.
+    let (kind, hash, preview) = match &inv.action {
+        HookAction::Bash {
+            command_hash,
+            command_preview,
+        } => ("bash", command_hash.clone(), command_preview.clone()),
+        HookAction::FileEdit {
+            path_hash,
+            path_preview,
+            ..
+        } => ("file_edit", path_hash.clone(), path_preview.clone()),
+        HookAction::McpCall {
+            args_hash,
+            args_preview,
+            ..
+        } => ("mcp_call", args_hash.clone(), args_preview.clone()),
+        HookAction::Other {
+            detail_hash,
+            detail_preview,
+            ..
+        } => ("other", detail_hash.clone(), detail_preview.clone()),
+    };
+
+    sigil_core::event::Event {
+        schema_version: SCHEMA_VERSION,
+        event_id: uuid::Uuid::now_v7(),
+        ts: time::OffsetDateTime::now_utc(),
+        host_id: host_id.to_string(),
+        agent_version: AGENT_VERSION.to_string(),
+        severity: Severity::Info,
+        source: SourceKind::AgentHook,
+        subject: Subject::Self_,
+        evidence: Evidence::HookInvocation(HookInvocationEvidence {
+            agent: inv.agent,
+            peer_uid,
+            agent_session_id: inv.agent_session_id,
+            tool_use_id: inv.tool_use_id,
+            action_kind: kind.to_string(),
+            action_hash: hash,
+            action_preview: preview,
+            capture_level: format!("{:?}", inv.capture_level).to_lowercase(),
+            capture_status: format!("{:?}", inv.capture_status).to_lowercase(),
+        }),
+        target_id: None,
+    }
+}

--- a/crates/sigil-agent/src/hook_listener.rs
+++ b/crates/sigil-agent/src/hook_listener.rs
@@ -173,9 +173,83 @@ fn to_event(env: HookEnvelope, peer_uid: u32, host_id: &str) -> sigil_core::even
             action_kind: kind.to_string(),
             action_hash: hash,
             action_preview: preview,
-            capture_level: format!("{:?}", inv.capture_level).to_lowercase(),
-            capture_status: format!("{:?}", inv.capture_status).to_lowercase(),
+            capture_level: enum_str(&inv.capture_level),
+            capture_status: enum_str(&inv.capture_status),
         }),
         target_id: None,
+    }
+}
+
+/// Serialize a `rename_all = "snake_case"` enum to its wire string. The
+/// persisted evidence schema must match the serde wire form exactly
+/// (`"hash_only"`, `"unsupported_agent_schema"`, …), NOT the Rust Debug form.
+/// Falls back to an empty string if the value somehow isn't a JSON string.
+fn enum_str<T: serde::Serialize>(v: &T) -> String {
+    serde_json::to_value(v)
+        .ok()
+        .and_then(|j| j.as_str().map(String::from))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigil_core::hook_proto::{
+        CaptureLevel, CaptureStatus, HookInvocation, HookMsgType, HOOK_PROTOCOL_VERSION,
+    };
+
+    fn envelope_with(level: CaptureLevel, status: CaptureStatus) -> HookEnvelope {
+        HookEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::now_v7(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookInvocation {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: None,
+                },
+                capture_level: level,
+                capture_status: status,
+                cwd: None,
+            },
+        }
+    }
+
+    #[test]
+    fn enum_str_yields_snake_case_wire_strings() {
+        assert_eq!(enum_str(&CaptureLevel::HashOnly), "hash_only");
+        assert_eq!(enum_str(&CaptureLevel::Redacted), "redacted");
+        assert_eq!(enum_str(&CaptureLevel::Raw), "raw");
+        assert_eq!(
+            enum_str(&CaptureStatus::UnsupportedAgentSchema),
+            "unsupported_agent_schema"
+        );
+        assert_eq!(enum_str(&CaptureStatus::Ok), "ok");
+        assert_eq!(
+            enum_str(&CaptureStatus::RedactionFailed),
+            "redaction_failed"
+        );
+    }
+
+    #[test]
+    fn to_event_persists_snake_case_capture_fields() {
+        let env = envelope_with(
+            CaptureLevel::HashOnly,
+            CaptureStatus::UnsupportedAgentSchema,
+        );
+        let ev = to_event(env, 1000, "host-x");
+        match ev.evidence {
+            Evidence::HookInvocation(h) => {
+                assert_eq!(h.capture_level, "hash_only");
+                assert_eq!(h.capture_status, "unsupported_agent_schema");
+                assert_eq!(h.action_kind, "bash");
+                assert_eq!(h.peer_uid, 1000);
+            }
+            other => panic!("expected HookInvocation, got {other:?}"),
+        }
     }
 }

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -9,6 +9,10 @@ pub mod doctor;
 pub mod gc_config;
 pub mod hasher;
 pub mod heartbeat;
+// The hook listener uses Unix-domain sockets (tokio UnixListener); Windows agent
+// IPC is a named pipe (see control.rs) and a named-pipe hook listener is a
+// follow-up, so the module is unix-only for Stage 1.
+#[cfg(unix)]
 pub mod hook_listener;
 pub mod host_meta_snapshot;
 pub mod host_meta_snapshot_task;

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -9,6 +9,7 @@ pub mod doctor;
 pub mod gc_config;
 pub mod hasher;
 pub mod heartbeat;
+pub mod hook_listener;
 pub mod host_meta_snapshot;
 pub mod host_meta_snapshot_task;
 pub mod host_meta_task;

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -691,6 +691,31 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         );
     }
 
+    // Hook IPC listener (sigil-hook Stage 1 #64): sits in the same socket
+    // directory as the control socket, at `hook.sock`. One-way: emitters write
+    // HookEnvelope JSON lines; no response is ever sent. Peer-cred stamping,
+    // overload reject, and try_send are handled inside `hook_listener::serve`.
+    #[cfg(unix)]
+    {
+        let hook_sock = cfg.control_socket.with_file_name("hook.sock");
+        let tx_hook = tx_sink.clone();
+        let host_id_hook = host_id.clone();
+        sup.track(
+            "hook_listener",
+            tokio::spawn(async move {
+                if let Err(e) =
+                    crate::hook_listener::serve(hook_sock.clone(), tx_hook, host_id_hook).await
+                {
+                    tracing::error!(
+                        error = ?e,
+                        socket = %hook_sock.display(),
+                        "hook IPC listener exited; hook events will not be captured"
+                    );
+                }
+            }),
+        );
+    }
+
     // Drop-report fan-in: forward DropReports to sink as RateLimitExceeded events.
     {
         let tx_sink_dr = tx_sink.clone();

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -518,6 +518,8 @@ fn evidence_summary(e: &sigil_core::event::Evidence) -> (&'static str, String) {
             format!("tool={tool:?} bucket={bucket:?}"),
         ),
         Evidence::HostMetaSnapshot { .. } => ("host_meta_snapshot", String::new()),
+        Evidence::HookInvocation(_) => ("hook_invocation", String::new()),
+        Evidence::Unknown => ("unknown", String::new()),
     }
 }
 

--- a/crates/sigil-agent/src/sink_task.rs
+++ b/crates/sigil-agent/src/sink_task.rs
@@ -67,5 +67,7 @@ fn evidence_kind_str(e: &sigil_core::event::Evidence) -> &'static str {
         SenderLagCritical { .. } => "sender_lag_critical",
         AiGuardRiskAssessed { .. } => "ai_guard_risk_assessed",
         HostMetaSnapshot { .. } => "host_meta_snapshot",
+        HookInvocation(_) => "hook_invocation",
+        Unknown => "unknown",
     }
 }

--- a/crates/sigil-agent/tests/hook_listener_e2e.rs
+++ b/crates/sigil-agent/tests/hook_listener_e2e.rs
@@ -1,0 +1,103 @@
+//! Integration test: hook.sock listener — peer-cred stamp, event queuing.
+//! Step 1 of TDD for Task 7 (sigil-hook Stage 1 #64).
+
+#[cfg(unix)]
+mod unix_only {
+    use sigil_agent::hook_listener;
+    use sigil_agent::state_task::CommittableEvent;
+    use sigil_core::event::{Evidence, SourceKind};
+    use sigil_core::hook_proto::{
+        CaptureLevel, CaptureStatus, HookAction, HookEnvelope, HookInvocation, HookMsgType,
+        HOOK_PROTOCOL_VERSION,
+    };
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::UnixStream;
+    use tokio::sync::mpsc;
+    use tokio::time::timeout;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hook_listener_stamps_peer_uid_and_action_kind() {
+        // 1. Create a temp dir + socket path.
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path: PathBuf = dir.path().join("hook.sock");
+
+        // 2. Channel — capacity 16 is plenty for one event.
+        let (tx, mut rx) = mpsc::channel::<CommittableEvent>(16);
+
+        // 3. Start the hook listener in a background task.
+        let sock_path_clone = sock_path.clone();
+        let _listener_task = tokio::spawn(async move {
+            hook_listener::serve(sock_path_clone, tx, "host-1".to_string())
+                .await
+                .expect("hook listener should not exit early");
+        });
+
+        // 4. Wait for the socket file to appear (max 2 s).
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if sock_path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("hook.sock should appear within 2 s");
+
+        // 5. Connect a UnixStream client and write one HookEnvelope JSON line.
+        let mut client = UnixStream::connect(&sock_path)
+            .await
+            .expect("should connect to hook.sock");
+
+        let envelope = HookEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::now_v7(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookInvocation {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                agent_session_id: Some("sess-42".into()),
+                tool_use_id: Some("tu-1".into()),
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: Some("git status".into()),
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+        };
+
+        let mut line = serde_json::to_string(&envelope).expect("serialize envelope");
+        line.push('\n');
+        client
+            .write_all(line.as_bytes())
+            .await
+            .expect("write envelope to socket");
+        // Flush / close write side so the listener sees EOF after the line.
+        client.shutdown().await.ok();
+
+        // 6. Assert one CommittableEvent arrives on rx within 2 s.
+        let committable = timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("CommittableEvent should arrive within 2 s")
+            .expect("channel must not close");
+
+        let ev = &committable.event;
+        assert_eq!(ev.source, SourceKind::AgentHook, "source must be AgentHook");
+
+        // The listener stamps peer_uid from the kernel (SO_PEERCRED).
+        // In a test, both ends run as the same user, so peer_uid == getuid().
+        let expected_uid = unsafe { libc::getuid() };
+
+        match &ev.evidence {
+            Evidence::HookInvocation(h) => {
+                assert_eq!(h.peer_uid, expected_uid, "peer_uid must match process uid");
+                assert_eq!(h.action_kind, "bash", "action_kind must be 'bash'");
+            }
+            other => panic!("expected HookInvocation evidence, got: {other:?}"),
+        }
+    }
+}

--- a/crates/sigil-agent/tests/hook_listener_e2e.rs
+++ b/crates/sigil-agent/tests/hook_listener_e2e.rs
@@ -5,7 +5,7 @@
 mod unix_only {
     use sigil_agent::hook_listener;
     use sigil_agent::state_task::CommittableEvent;
-    use sigil_core::event::{Evidence, SourceKind};
+    use sigil_core::event::{Evidence, Severity, SourceKind, Subject};
     use sigil_core::hook_proto::{
         CaptureLevel, CaptureStatus, HookAction, HookEnvelope, HookInvocation, HookMsgType,
         HOOK_PROTOCOL_VERSION,
@@ -87,6 +87,9 @@ mod unix_only {
 
         let ev = &committable.event;
         assert_eq!(ev.source, SourceKind::AgentHook, "source must be AgentHook");
+        assert_eq!(ev.severity, Severity::Info, "severity must be Info");
+        assert_eq!(ev.subject, Subject::Self_, "subject must be Self_");
+        assert_eq!(ev.host_id, "host-1", "host_id must be the configured value");
 
         // The listener stamps peer_uid from the kernel (SO_PEERCRED).
         // In a test, both ends run as the same user, so peer_uid == getuid().
@@ -98,6 +101,116 @@ mod unix_only {
                 assert_eq!(h.action_kind, "bash", "action_kind must be 'bash'");
             }
             other => panic!("expected HookInvocation evidence, got: {other:?}"),
+        }
+    }
+
+    /// Helper: build a valid Bash envelope as a newline-terminated JSON line.
+    fn bash_envelope_line(preview: &str) -> String {
+        let envelope = HookEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::now_v7(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookInvocation {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: Some(preview.to_string()),
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+        };
+        let mut line = serde_json::to_string(&envelope).expect("serialize envelope");
+        line.push('\n');
+        line
+    }
+
+    /// Overload: open more than MAX_INFLIGHT (32) connections that connect but
+    /// never send a line. Each holds a semaphore permit, saturating the bound.
+    /// The accept loop must NOT block — a fresh connection that DOES send a line
+    /// is dropped-before-read on overload, yet the listener keeps accepting and,
+    /// once the lingering connections close (freeing permits), a valid emit
+    /// flows through. Deterministic via timeouts; the core assertion is that the
+    /// listener never deadlocks under saturation.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn hook_listener_survives_connection_overload() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path: PathBuf = dir.path().join("hook.sock");
+
+        let (tx, mut rx) = mpsc::channel::<CommittableEvent>(64);
+
+        let sock_path_clone = sock_path.clone();
+        let _listener_task = tokio::spawn(async move {
+            hook_listener::serve(sock_path_clone, tx, "host-overload".to_string())
+                .await
+                .expect("hook listener should not exit early");
+        });
+
+        // Wait for the socket to appear.
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if sock_path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("hook.sock should appear within 2 s");
+
+        // Open MAX_INFLIGHT + 4 = 36 connections that connect but never send.
+        // Each successful accept that wins a permit holds it open (its task is
+        // parked in read_line waiting for bytes that never come). The rest are
+        // dropped-before-read by the overload guard. Either way, the accept loop
+        // must keep running.
+        const LINGER: usize = 36;
+        let mut lingering: Vec<UnixStream> = Vec::with_capacity(LINGER);
+        for _ in 0..LINGER {
+            // Connect must not hang — bound it.
+            let s = timeout(Duration::from_secs(2), UnixStream::connect(&sock_path))
+                .await
+                .expect("connect must not hang under overload")
+                .expect("connect should succeed");
+            lingering.push(s);
+        }
+
+        // Prove the listener is STILL accepting new connections under saturation:
+        // a brand-new connect must complete quickly (the accept loop is alive).
+        let probe = timeout(Duration::from_secs(2), UnixStream::connect(&sock_path))
+            .await
+            .expect("listener must keep accepting connections under overload")
+            .expect("probe connect should succeed");
+        drop(probe);
+
+        // Now release the lingering connections, freeing their permits.
+        lingering.clear();
+        // Give the listener a moment to drain dropped tasks / free permits.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // A valid emit after the pressure subsides must flow through — proving
+        // the listener recovered rather than wedged.
+        let mut client = timeout(Duration::from_secs(2), UnixStream::connect(&sock_path))
+            .await
+            .expect("post-overload connect must not hang")
+            .expect("post-overload connect should succeed");
+        client
+            .write_all(bash_envelope_line("recovered").as_bytes())
+            .await
+            .expect("write envelope after overload");
+        client.shutdown().await.ok();
+
+        let committable = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("a valid emit must arrive after overload subsides")
+            .expect("channel must not close");
+        assert_eq!(committable.event.source, SourceKind::AgentHook);
+        match &committable.event.evidence {
+            Evidence::HookInvocation(h) => assert_eq!(h.action_kind, "bash"),
+            other => panic!("expected HookInvocation, got {other:?}"),
         }
     }
 }

--- a/crates/sigil-agent/tests/hook_listener_e2e.rs
+++ b/crates/sigil-agent/tests/hook_listener_e2e.rs
@@ -136,6 +136,12 @@ mod unix_only {
     /// once the lingering connections close (freeing permits), a valid emit
     /// flows through. Deterministic via timeouts; the core assertion is that the
     /// listener never deadlocks under saturation.
+    ///
+    /// NOTE on non-determinism: the assertion that exactly 32 permits become
+    /// saturated depends on async scheduling — some of the 36 lingering connects
+    /// may be dropped-before-read by the overload guard rather than consuming a
+    /// permit. The REAL invariant being tested is "the accept loop never
+    /// deadlocks under connection saturation", not exact permit accounting.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn hook_listener_survives_connection_overload() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -207,6 +207,9 @@ pub struct HookInvocationEvidence {
     pub tool_use_id: Option<String>,
     /// Normalized action kind: "bash" | "file_edit" | "mcp_call" | "other".
     pub action_kind: String,
+    /// Tool name when `action_kind == "other"`, else `None`. Carries the
+    /// original tool name (e.g. "WebFetch") for non-Bash/Edit/MCP tools.
+    pub other_label: Option<String>,
     /// blake3 over the raw pre-mask normalized action (lowercase hex).
     pub action_hash: String,
     /// Redacted/capped preview, or `None` under hash_only.
@@ -1010,6 +1013,7 @@ mod tests {
             agent_session_id: None,
             tool_use_id: Some("tu".into()),
             action_kind: "bash".into(),
+            other_label: None,
             action_hash: "cd".repeat(32),
             action_preview: Some("ls".into()),
             capture_level: "redacted".into(),

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -20,6 +20,11 @@ pub enum Severity {
 pub enum SourceKind {
     FileSystem,
     Agent,
+    /// sigil-hook runtime observation (#64).
+    AgentHook,
+    /// Forward-compat fallback (see Evidence::Unknown).
+    #[serde(other)]
+    Unknown,
 }
 
 /// Technical identifier of the observed thing.
@@ -188,6 +193,26 @@ pub enum AiGuardReason {
     /// Phase 3b.8 — the agent's default approval mode auto-approves a class
     /// of tool calls without prompting (e.g. Gemini `defaultApprovalMode: "auto_edit"`).
     AutoApprovalEnabled { mode: String },
+}
+
+/// Persisted form of a hook observation (#64). Distinct from the IPC
+/// `hook_proto::HookInvocation` so the SIEM schema and the IPC schema evolve
+/// independently. `peer_uid` is stamped by the agent from the kernel
+/// (`SO_PEERCRED`), never self-reported by the hook.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HookInvocationEvidence {
+    pub agent: AiTool,
+    pub peer_uid: u32,
+    pub agent_session_id: Option<String>,
+    pub tool_use_id: Option<String>,
+    /// Normalized action kind: "bash" | "file_edit" | "mcp_call" | "other".
+    pub action_kind: String,
+    /// blake3 over the raw pre-mask normalized action (lowercase hex).
+    pub action_hash: String,
+    /// Redacted/capped preview, or `None` under hash_only.
+    pub action_preview: Option<String>,
+    pub capture_level: String,
+    pub capture_status: String,
 }
 
 /// Phase 3b.4-pre — full host identity / OS / network snapshot, emitted by
@@ -407,6 +432,12 @@ pub enum Evidence {
         /// unchanged since last emit). `false` = boot scan or change detected.
         is_reattestation: bool,
     },
+    /// sigil-hook Stage 1 (#64). One observed agent tool call.
+    HookInvocation(HookInvocationEvidence),
+    /// Forward-compat: an evidence kind this build doesn't recognize. A newer
+    /// producer's variant deserializes here instead of failing the whole event.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Schema version. Bumps follow the policy in spec section 3.3.
@@ -969,6 +1000,39 @@ mod tests {
         let j = serde_json::to_value(&a).unwrap();
         assert_eq!(j["kind"], "auto_approval_enabled");
         assert_eq!(j["mode"], "auto_edit");
+    }
+
+    #[test]
+    fn hook_invocation_event_round_trips() {
+        let ev = Evidence::HookInvocation(HookInvocationEvidence {
+            agent: AiTool::ClaudeCode,
+            peer_uid: 1000,
+            agent_session_id: None,
+            tool_use_id: Some("tu".into()),
+            action_kind: "bash".into(),
+            action_hash: "cd".repeat(32),
+            action_preview: Some("ls".into()),
+            capture_level: "redacted".into(),
+            capture_status: "ok".into(),
+        });
+        let j = serde_json::to_string(&ev).unwrap();
+        assert!(j.contains("\"kind\":\"hook_invocation\""));
+        let back: Evidence = serde_json::from_str(&j).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn unknown_evidence_kind_does_not_fail_deserialize() {
+        let j = r#"{"kind":"some_future_kind","whatever":1}"#;
+        let back: Evidence = serde_json::from_str(j).unwrap();
+        assert!(matches!(back, Evidence::Unknown));
+    }
+
+    #[test]
+    fn unknown_source_kind_does_not_fail_deserialize() {
+        let j = r#"{"kind":"some_future_source"}"#;
+        let back: SourceKind = serde_json::from_str(j).unwrap();
+        assert!(matches!(back, SourceKind::Unknown));
     }
 
     #[test]

--- a/crates/sigil-core/src/hook_proto.rs
+++ b/crates/sigil-core/src/hook_proto.rs
@@ -1,0 +1,117 @@
+//! Wire protocol for the one-way hook IPC socket (`hook.sock`). Shared by
+//! `sigil-hook` (emitter) and `sigil-agent` (listener). Types only — no I/O.
+//! Distinct from `control_proto` (operator API) by design: a high-frequency,
+//! multi-agent, latency-sensitive emit path must not share the operator socket.
+use crate::event::AiTool;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Hook IPC protocol version. Bump on any breaking wire change.
+pub const HOOK_PROTOCOL_VERSION: u16 = 1;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum HookMsgType {
+    HookInvocation,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HookEnvelope {
+    pub protocol_version: u16,
+    pub msg_type: HookMsgType,
+    pub request_id: Uuid,
+    pub sent_at_unix_ms: u64,
+    pub payload: HookInvocation,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HookInvocation {
+    pub agent: AiTool,
+    pub agent_session_id: Option<String>,
+    pub tool_use_id: Option<String>,
+    pub action: HookAction,
+    pub capture_level: CaptureLevel,
+    pub capture_status: CaptureStatus,
+    pub cwd: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HookAction {
+    Bash {
+        command_hash: String,
+        command_preview: Option<String>,
+    },
+    FileEdit {
+        path_hash: String,
+        path_preview: Option<String>,
+        edit_hash: Option<String>,
+    },
+    McpCall {
+        server: String,
+        tool: String,
+        args_hash: String,
+        args_preview: Option<String>,
+    },
+    Other {
+        label: String,
+        detail_hash: String,
+        detail_preview: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureLevel {
+    Redacted,
+    Raw,
+    HashOnly,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureStatus {
+    Ok,
+    Malformed,
+    Oversized,
+    Timeout,
+    UnsupportedAgentSchema,
+    RedactionFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::AiTool;
+
+    #[test]
+    fn envelope_round_trips_with_bash_action() {
+        let env = HookEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::nil(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookInvocation {
+                agent: AiTool::ClaudeCode,
+                agent_session_id: Some("sess-1".into()),
+                tool_use_id: Some("tu-1".into()),
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: Some("git status".into()),
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains("\"msg_type\":\"hook_invocation\""));
+        assert!(s.contains("\"kind\":\"bash\""));
+        let back: HookEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.protocol_version, HOOK_PROTOCOL_VERSION);
+        match back.payload.action {
+            HookAction::Bash { command_hash, .. } => assert_eq!(command_hash.len(), 64),
+            _ => panic!("expected bash"),
+        }
+    }
+}

--- a/crates/sigil-core/src/lib.rs
+++ b/crates/sigil-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod control_proto;
 pub mod debounce;
 pub mod event;
 pub mod hashing;
+pub mod hook_proto;
 pub mod host_id;
 pub mod host_meta;
 pub mod license;

--- a/crates/sigil-hook/Cargo.toml
+++ b/crates/sigil-hook/Cargo.toml
@@ -19,8 +19,6 @@ clap = { workspace = true }
 blake3 = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }
-time = { workspace = true }
-tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/sigil-hook/Cargo.toml
+++ b/crates/sigil-hook/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "sigil-hook"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Runtime observer at the AI coding agent tool boundary (PreToolUse hook)."
+
+[[bin]]
+name = "sigil-hook"
+path = "src/main.rs"
+
+[dependencies]
+sigil-core = { path = "../sigil-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+blake3 = { workspace = true }
+uuid = { workspace = true }
+regex = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/sigil-hook/src/adapters/claude_code.rs
+++ b/crates/sigil-hook/src/adapters/claude_code.rs
@@ -135,6 +135,70 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn normalizes_edit() {
+        // I3: FileEdit adapter — path_hash is a 64-char blake3 hex, path_preview
+        // contains the path under Redacted, and hash is stable across capture levels.
+        let payload = serde_json::json!({
+            "tool_name": "Edit",
+            "tool_input": { "file_path": "/repo/src/main.rs" }
+        });
+        let inv_redacted = ClaudeCode
+            .normalize(&payload, CaptureLevel::Redacted)
+            .unwrap();
+        let inv_hash_only = ClaudeCode
+            .normalize(&payload, CaptureLevel::HashOnly)
+            .unwrap();
+
+        match (inv_redacted.action, inv_hash_only.action) {
+            (
+                HookAction::FileEdit {
+                    path_hash: hash_r,
+                    path_preview: preview_r,
+                    ..
+                },
+                HookAction::FileEdit {
+                    path_hash: hash_h,
+                    path_preview: preview_h,
+                    ..
+                },
+            ) => {
+                // Hash must be 64-char blake3 hex.
+                assert_eq!(hash_r.len(), 64, "path_hash must be 64 hex chars");
+                // Hash must be stable across capture levels (hashed over raw path).
+                assert_eq!(hash_r, hash_h, "path_hash must be identical across levels");
+                // Under Redacted, preview contains the path.
+                let preview = preview_r.expect("Redacted must include path_preview");
+                assert!(
+                    preview.contains("/repo/src/main.rs"),
+                    "path_preview must contain the file path; got: {preview:?}"
+                );
+                // Under HashOnly, no preview.
+                assert!(
+                    preview_h.is_none(),
+                    "HashOnly must not include path_preview"
+                );
+            }
+            _ => panic!("expected FileEdit action for Edit tool"),
+        }
+    }
+
+    #[test]
+    fn normalizes_write_and_multiedit() {
+        // Write and MultiEdit must also produce FileEdit actions.
+        for tool in ["Write", "MultiEdit"] {
+            let p = serde_json::json!({
+                "tool_name": tool,
+                "tool_input": { "file_path": "/tmp/out.txt" }
+            });
+            let inv = ClaudeCode.normalize(&p, CaptureLevel::Redacted).unwrap();
+            assert!(
+                matches!(inv.action, HookAction::FileEdit { .. }),
+                "{tool} must normalize to FileEdit"
+            );
+        }
+    }
+
     // Latency microbench (spec §11): the in-process normalize+redact+serialize
     // path is the per-tool-call tax that "always exit 0" would otherwise hide.
     // 5ms/call is a hugely generous ceiling (real cost is microseconds); the

--- a/crates/sigil-hook/src/adapters/claude_code.rs
+++ b/crates/sigil-hook/src/adapters/claude_code.rs
@@ -134,4 +134,26 @@ mod tests {
             HookAction::Other { .. }
         ));
     }
+
+    // Latency microbench (spec §11): the in-process normalize+redact+serialize
+    // path is the per-tool-call tax that "always exit 0" would otherwise hide.
+    // 5ms/call is a hugely generous ceiling (real cost is microseconds); the
+    // test exists to catch a pathological regression, not to micro-tune.
+    #[test]
+    fn normalize_redact_serialize_is_fast() {
+        let p = serde_json::json!({
+            "tool_name":"Bash","tool_input":{"command":"a".repeat(200)}
+        });
+        let start = std::time::Instant::now();
+        for _ in 0..1000 {
+            let inv = ClaudeCode.normalize(&p, CaptureLevel::Redacted).unwrap();
+            let _ = serde_json::to_string(&inv).unwrap();
+        }
+        let per = start.elapsed() / 1000;
+        println!("normalize+redact+serialize per-call: {per:?}");
+        assert!(
+            per < std::time::Duration::from_millis(5),
+            "per-call {per:?}"
+        );
+    }
 }

--- a/crates/sigil-hook/src/adapters/claude_code.rs
+++ b/crates/sigil-hook/src/adapters/claude_code.rs
@@ -1,0 +1,137 @@
+use super::HookAdapter;
+use crate::redact::capture;
+use sigil_core::event::AiTool;
+use sigil_core::hook_proto::*;
+
+pub struct ClaudeCode;
+
+impl HookAdapter for ClaudeCode {
+    fn agent(&self) -> AiTool {
+        AiTool::ClaudeCode
+    }
+
+    fn normalize(
+        &self,
+        p: &serde_json::Value,
+        level: CaptureLevel,
+    ) -> Result<HookInvocation, CaptureStatus> {
+        let tool = p
+            .get("tool_name")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptureStatus::Malformed)?;
+        let input = p
+            .get("tool_input")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let action = if tool == "Bash" {
+            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let c = capture(cmd, level);
+            HookAction::Bash {
+                command_hash: c.hash,
+                command_preview: c.preview,
+            }
+        } else if let Some(rest) = tool.strip_prefix("mcp__") {
+            let mut it = rest.splitn(2, "__");
+            let server = it.next().unwrap_or("").to_string();
+            let mcp_tool = it.next().unwrap_or("").to_string();
+            let args = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&args, level);
+            HookAction::McpCall {
+                server,
+                tool: mcp_tool,
+                args_hash: c.hash,
+                args_preview: c.preview,
+            }
+        } else if matches!(tool, "Edit" | "Write" | "MultiEdit") {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let c = capture(path, level);
+            HookAction::FileEdit {
+                path_hash: c.hash,
+                path_preview: c.preview,
+                edit_hash: None,
+            }
+        } else {
+            let detail = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&detail, level);
+            HookAction::Other {
+                label: tool.to_string(),
+                detail_hash: c.hash,
+                detail_preview: c.preview,
+            }
+        };
+        Ok(HookInvocation {
+            agent: AiTool::ClaudeCode,
+            agent_session_id: p
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            tool_use_id: p
+                .get("tool_use_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            action,
+            capture_level: level,
+            capture_status: CaptureStatus::Ok,
+            cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigil_core::hook_proto::{CaptureLevel, HookAction};
+
+    fn bash_payload() -> serde_json::Value {
+        serde_json::json!({
+            "session_id":"s1","tool_use_id":"t1","cwd":"/repo",
+            "tool_name":"Bash","tool_input":{"command":"rm -rf build"}
+        })
+    }
+
+    #[test]
+    fn normalizes_bash() {
+        let inv = ClaudeCode
+            .normalize(&bash_payload(), CaptureLevel::Redacted)
+            .unwrap();
+        assert_eq!(inv.agent_session_id.as_deref(), Some("s1"));
+        match inv.action {
+            HookAction::Bash {
+                command_preview, ..
+            } => assert_eq!(command_preview.unwrap(), "rm -rf build"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn normalizes_mcp_tool_name() {
+        let p =
+            serde_json::json!({"tool_name":"mcp__github__create_issue","tool_input":{"title":"x"}});
+        match ClaudeCode
+            .normalize(&p, CaptureLevel::Redacted)
+            .unwrap()
+            .action
+        {
+            HookAction::McpCall { server, tool, .. } => {
+                assert_eq!(server, "github");
+                assert_eq!(tool, "create_issue");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn unknown_tool_becomes_other() {
+        let p = serde_json::json!({"tool_name":"WebFetch","tool_input":{"url":"x"}});
+        assert!(matches!(
+            ClaudeCode
+                .normalize(&p, CaptureLevel::Redacted)
+                .unwrap()
+                .action,
+            HookAction::Other { .. }
+        ));
+    }
+}

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -1,0 +1,25 @@
+// Consumed by later tasks (hook dispatch). Unused items are expected until then.
+#![allow(dead_code)]
+
+use sigil_core::event::AiTool;
+use sigil_core::hook_proto::{CaptureLevel, CaptureStatus, HookInvocation};
+pub mod claude_code;
+
+/// One impl per agent. Turns a vendor stdin payload into a normalized
+/// HookInvocation. (Shape mirrors ai_guard/parser, but is a distinct trait —
+/// that one assesses on-disk config, this one normalizes runtime stdin.)
+pub trait HookAdapter {
+    fn agent(&self) -> AiTool;
+    fn normalize(
+        &self,
+        payload: &serde_json::Value,
+        level: CaptureLevel,
+    ) -> Result<HookInvocation, CaptureStatus>;
+}
+
+pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
+    match name {
+        "claude-code" => Some(Box::new(claude_code::ClaudeCode)),
+        _ => None,
+    }
+}

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -1,6 +1,3 @@
-// Consumed by later tasks (hook dispatch). Unused items are expected until then.
-#![allow(dead_code)]
-
 use sigil_core::event::AiTool;
 use sigil_core::hook_proto::{CaptureLevel, CaptureStatus, HookInvocation};
 pub mod claude_code;

--- a/crates/sigil-hook/src/emit.rs
+++ b/crates/sigil-hook/src/emit.rs
@@ -5,12 +5,17 @@ use std::time::Duration;
 
 /// Best-effort one-line emit. NEVER returns Err for a normal failure (agent
 /// down, reset, pipe broken) — those are success from the agent's POV.
-pub fn send_envelope(socket: &Path, line: &str, connect_timeout: Duration) -> std::io::Result<()> {
+///
+/// `write_timeout` is applied via `set_write_timeout` on the stream.
+/// NOTE: `UnixStream::connect()` itself is NOT separately bounded — the
+/// caller's process watchdog (`arm_watchdog`) is the backstop for a stuck
+/// connect.
+pub fn send_envelope(socket: &Path, line: &str, write_timeout: Duration) -> std::io::Result<()> {
     let stream = match UnixStream::connect(socket) {
         Ok(s) => s,
         Err(_) => return Ok(()), // agent down / socket missing → silent success
     };
-    stream.set_write_timeout(Some(connect_timeout)).ok();
+    stream.set_write_timeout(Some(write_timeout)).ok();
     let mut stream = stream;
     let _ = stream.write_all(line.as_bytes());
     let _ = stream.write_all(b"\n");

--- a/crates/sigil-hook/src/emit.rs
+++ b/crates/sigil-hook/src/emit.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::Duration;
 
@@ -10,7 +8,10 @@ use std::time::Duration;
 /// NOTE: `UnixStream::connect()` itself is NOT separately bounded — the
 /// caller's process watchdog (`arm_watchdog`) is the backstop for a stuck
 /// connect.
+#[cfg(unix)]
 pub fn send_envelope(socket: &Path, line: &str, write_timeout: Duration) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
     let stream = match UnixStream::connect(socket) {
         Ok(s) => s,
         Err(_) => return Ok(()), // agent down / socket missing → silent success
@@ -19,6 +20,15 @@ pub fn send_envelope(socket: &Path, line: &str, write_timeout: Duration) -> std:
     let mut stream = stream;
     let _ = stream.write_all(line.as_bytes());
     let _ = stream.write_all(b"\n");
+    Ok(())
+}
+
+/// Non-unix stub. The agent's IPC on Windows is a named pipe (see `control.rs`'s
+/// `#[cfg(windows)]` path); Stage 1 does not wire a named-pipe hook emit yet, so
+/// the emit is a no-op here (fail-open, consistent with a down agent). Named-pipe
+/// emit is a follow-up.
+#[cfg(not(unix))]
+pub fn send_envelope(_socket: &Path, _line: &str, _write_timeout: Duration) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -31,7 +41,7 @@ pub fn arm_watchdog(budget: Duration) {
     });
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     #[test]

--- a/crates/sigil-hook/src/emit.rs
+++ b/crates/sigil-hook/src/emit.rs
@@ -1,0 +1,37 @@
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::Duration;
+
+/// Best-effort one-line emit. NEVER returns Err for a normal failure (agent
+/// down, reset, pipe broken) — those are success from the agent's POV.
+pub fn send_envelope(socket: &Path, line: &str, connect_timeout: Duration) -> std::io::Result<()> {
+    let stream = match UnixStream::connect(socket) {
+        Ok(s) => s,
+        Err(_) => return Ok(()), // agent down / socket missing → silent success
+    };
+    stream.set_write_timeout(Some(connect_timeout)).ok();
+    let mut stream = stream;
+    let _ = stream.write_all(line.as_bytes());
+    let _ = stream.write_all(b"\n");
+    Ok(())
+}
+
+/// Spawn a watchdog that hard-exits 0 after `budget`, so even a pathological
+/// blocking stdin read cannot stall the agent's tool call.
+pub fn arm_watchdog(budget: Duration) {
+    std::thread::spawn(move || {
+        std::thread::sleep(budget);
+        std::process::exit(0);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn emit_to_missing_socket_is_ok() {
+        let path = std::path::Path::new("/nonexistent/sigil/hook.sock");
+        assert!(send_envelope(path, "{\"x\":1}", std::time::Duration::from_millis(150)).is_ok());
+    }
+}

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -1,0 +1,336 @@
+// Consumed by install/uninstall subcommands. Writes and reads Claude Code's
+// ~/.claude/settings.json to register/deregister the sigil-hook PreToolUse
+// entry without clobbering unrelated hooks.
+
+use serde_json::Value;
+use std::io;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// ---------------------------------------------------------------------------
+// Helper: build the command string
+// ---------------------------------------------------------------------------
+
+fn command_string(exe: &str, agent: &str, capture: &str) -> String {
+    format!("{exe} {agent} --capture {capture}")
+}
+
+// ---------------------------------------------------------------------------
+// Helper: first whitespace token of a command string (= the binary path)
+// ---------------------------------------------------------------------------
+
+fn first_token(cmd: &str) -> &str {
+    cmd.split_whitespace().next().unwrap_or("")
+}
+
+// ---------------------------------------------------------------------------
+// Public: render a human-pasteable block showing the settings fragment
+// ---------------------------------------------------------------------------
+
+/// Returns a comment + pretty-printed JSON fragment that the operator can
+/// paste into ~/.claude/settings.json, plus an undo hint.
+pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
+    let cmd = command_string(exe, agent, capture);
+    let entry = serde_json::json!({
+        "matcher": "*",
+        "hooks": [{ "type": "command", "command": cmd }]
+    });
+    let fragment = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [entry]
+        }
+    });
+    let pretty = serde_json::to_string_pretty(&fragment).unwrap_or_default();
+    format!(
+        "// Merge this into ~/.claude/settings.json under \"hooks\":\n\
+         {pretty}\n\
+         // remove with: sigil-hook uninstall --agent {agent} --write\n"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Public: merge our entry into a settings Value (idempotent)
+// ---------------------------------------------------------------------------
+
+/// Ensure `root["hooks"]["PreToolUse"]` contains exactly one sigil-hook entry
+/// for `exe`. Returns `true` if the document was modified, `false` if it was
+/// already up-to-date (idempotent no-op).
+pub fn merge_into(root: &mut Value, exe: &str, agent: &str, capture: &str) -> bool {
+    let cmd = command_string(exe, agent, capture);
+
+    // Ensure root is an object.
+    if !root.is_object() {
+        *root = serde_json::json!({});
+    }
+
+    // Ensure root["hooks"] is an object.
+    if root["hooks"].is_null() || !root["hooks"].is_object() {
+        root["hooks"] = serde_json::json!({});
+    }
+
+    // Ensure root["hooks"]["PreToolUse"] is an array.
+    if root["hooks"]["PreToolUse"].is_null() || !root["hooks"]["PreToolUse"].is_array() {
+        root["hooks"]["PreToolUse"] = serde_json::json!([]);
+    }
+
+    let arr = root["hooks"]["PreToolUse"]
+        .as_array_mut()
+        .expect("just ensured it's an array");
+
+    // Search for an existing entry whose command first-token == exe.
+    let existing_idx = arr.iter().position(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|hooks| {
+                hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| first_token(c) == exe)
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    });
+
+    let new_entry = serde_json::json!({
+        "matcher": "*",
+        "hooks": [{ "type": "command", "command": cmd }]
+    });
+
+    if let Some(idx) = existing_idx {
+        // Check if the existing entry's command already matches exactly.
+        let existing_cmd = arr[idx]
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .and_then(|hooks| hooks.first())
+            .and_then(|h| h.get("command"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("");
+
+        if existing_cmd == cmd {
+            // Already up-to-date — idempotent no-op.
+            return false;
+        }
+        // Update in-place.
+        arr[idx] = new_entry;
+        true
+    } else {
+        // Not found — push.
+        arr.push(new_entry);
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public: remove sigil-hook entries from PreToolUse
+// ---------------------------------------------------------------------------
+
+/// Remove every PreToolUse entry whose command first-token == `exe`. Returns
+/// `true` if anything was removed. Leaves unrelated hooks untouched.
+pub fn remove_from(root: &mut Value, exe: &str) -> bool {
+    let arr = match root["hooks"]["PreToolUse"].as_array_mut() {
+        Some(a) => a,
+        None => return false,
+    };
+
+    let before = arr.len();
+    arr.retain(|entry| {
+        !entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|hooks| {
+                hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| first_token(c) == exe)
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    });
+    arr.len() < before
+}
+
+// ---------------------------------------------------------------------------
+// Public: paths
+// ---------------------------------------------------------------------------
+
+/// Returns `$XDG_STATE_HOME/sigil` or `$HOME/.local/state/sigil`.
+pub fn state_dir() -> PathBuf {
+    if let Ok(base) = std::env::var("XDG_STATE_HOME") {
+        PathBuf::from(base).join("sigil")
+    } else {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        PathBuf::from(home).join(".local/state/sigil")
+    }
+}
+
+/// Map agent name → absolute path to its settings file.
+/// Currently only `claude-code` is supported; returns None for unknown agents.
+pub fn settings_path(agent: &str) -> Option<PathBuf> {
+    match agent {
+        "claude-code" => {
+            let home = std::env::var("HOME").ok()?;
+            Some(PathBuf::from(home).join(".claude/settings.json"))
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public: write baseline + update discovery index
+// ---------------------------------------------------------------------------
+
+/// Write `state_dir()/hook-registration.json` with metadata about the
+/// installed hook, and append the absolute `settings_path` to the discovery
+/// index at `state_dir()/hook-index.json` (deduplicated).
+pub fn write_baseline(
+    agent: &str,
+    settings_path: &std::path::Path,
+    exe: &str,
+    agent_arg: &str,
+    capture: &str,
+    matcher: &str,
+) -> io::Result<()> {
+    let dir = state_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    let cmd = command_string(exe, agent_arg, capture);
+    let block_hash = blake3::hash(cmd.as_bytes()).to_hex().to_string();
+    let written_at_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let settings_path_str = settings_path.to_string_lossy().to_string();
+
+    let baseline = serde_json::json!({
+        "agent": agent,
+        "settings_path": settings_path_str,
+        "command": cmd,
+        "capture": capture,
+        "matcher": matcher,
+        "block_hash": block_hash,
+        "written_at_unix": written_at_unix,
+    });
+
+    let reg_path = dir.join("hook-registration.json");
+    let pretty = serde_json::to_string_pretty(&baseline).map_err(io::Error::other)?;
+    std::fs::write(&reg_path, pretty.as_bytes())?;
+
+    // Read-modify-write the index (deduped).
+    let index_path = dir.join("hook-index.json");
+    let mut entries: Vec<String> = if index_path.exists() {
+        let raw = std::fs::read(&index_path)?;
+        serde_json::from_slice::<Vec<String>>(&raw).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    if !entries.contains(&settings_path_str) {
+        entries.push(settings_path_str);
+        let json = serde_json::to_string_pretty(&entries).map_err(io::Error::other)?;
+        std::fs::write(&index_path, json.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Count helper — used by tests AND by callers
+// ---------------------------------------------------------------------------
+
+/// Count entries in `root["hooks"]["PreToolUse"]` whose command first-token == `exe`.
+pub fn count_sigil_entries(root: &Value, exe: &str) -> usize {
+    root["hooks"]["PreToolUse"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|entry| {
+                    entry
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|hooks| {
+                            hooks.iter().any(|h| {
+                                h.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map(|c| first_token(c) == exe)
+                                    .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Tests (Step 1 — written first, before implementation is wired in)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn render_block_has_abs_path_and_capture() {
+        let s = render_block("/abs/sigil-hook", "claude-code", "redacted");
+        assert!(s.contains("/abs/sigil-hook claude-code --capture redacted"));
+        assert!(s.contains("PreToolUse"));
+    }
+    #[test]
+    fn merge_into_empty_adds_entry() {
+        let mut v = json!({});
+        assert!(merge_into(
+            &mut v,
+            "/abs/sigil-hook",
+            "claude-code",
+            "redacted"
+        ));
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook"), 1);
+    }
+    #[test]
+    fn merge_into_is_idempotent() {
+        let mut v = json!({});
+        assert!(merge_into(
+            &mut v,
+            "/abs/sigil-hook",
+            "claude-code",
+            "redacted"
+        ));
+        assert!(!merge_into(
+            &mut v,
+            "/abs/sigil-hook",
+            "claude-code",
+            "redacted"
+        )); // no change
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook"), 1);
+    }
+    #[test]
+    fn merge_into_updates_capture_in_place() {
+        let mut v = json!({});
+        merge_into(&mut v, "/abs/sigil-hook", "claude-code", "redacted");
+        assert!(merge_into(&mut v, "/abs/sigil-hook", "claude-code", "raw")); // changed
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook"), 1);
+        // the command now says --capture raw
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.contains("--capture raw"));
+        assert!(!s.contains("--capture redacted"));
+    }
+    #[test]
+    fn remove_from_removes_only_sigil_and_preserves_foreign() {
+        let mut v = json!({"hooks":{"PreToolUse":[
+            {"matcher":"*","hooks":[{"type":"command","command":"/other/tool run"}]}
+        ]}});
+        merge_into(&mut v, "/abs/sigil-hook", "claude-code", "redacted");
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook"), 1);
+        assert!(remove_from(&mut v, "/abs/sigil-hook"));
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook"), 0);
+        // foreign hook still present:
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.contains("/other/tool run"));
+    }
+}

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(0);
+}

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,3 +1,5 @@
+mod redact;
+
 fn main() {
     std::process::exit(0);
 }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -83,6 +83,7 @@ fn minimal_unparsed(
 /// Rocky 9). So: prefer the system socket when it exists (root-daemon), else fall
 /// back to the per-user path (non-root/local agent on the same uid).
 /// `SIGIL_HOOK_SOCKET` overrides both.
+#[cfg(unix)]
 fn hook_socket_path() -> PathBuf {
     if let Ok(p) = std::env::var("SIGIL_HOOK_SOCKET") {
         return PathBuf::from(p);
@@ -96,6 +97,15 @@ fn hook_socket_path() -> PathBuf {
     let tmp = std::env::var("TMPDIR").ok();
     sigil_core::control_proto::resolve_control_socket(uid == 0, xdg, tmp, uid)
         .with_file_name("hook.sock")
+}
+
+/// Non-unix: only the `SIGIL_HOOK_SOCKET` override (the emit is a no-op stub on
+/// Windows — see `emit::send_envelope`), so the value is effectively unused.
+#[cfg(not(unix))]
+fn hook_socket_path() -> PathBuf {
+    std::env::var("SIGIL_HOOK_SOCKET")
+        .map(PathBuf::from)
+        .unwrap_or_default()
 }
 
 #[derive(Parser)]

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -15,6 +15,9 @@ const INSTALL_AGENT_DEFAULT: &str = "claude-code";
 const MAX_STDIN: usize = 1024 * 1024;
 
 fn run_hook(agent: &str, capture: CaptureLevel) -> ! {
+    // Spec §7: a panic on the hot path must never print to stderr and must
+    // still exit 0 so the agent's tool call is never blocked.
+    std::panic::set_hook(Box::new(|_| std::process::exit(0)));
     emit::arm_watchdog(Duration::from_millis(200));
     let adapter = match adapters::for_agent(agent) {
         Some(a) => a,

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,3 +1,4 @@
+mod adapters;
 mod redact;
 
 fn main() {

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,5 +1,6 @@
 mod adapters;
 mod emit;
+mod install;
 mod redact;
 
 use sigil_core::hook_proto::*;
@@ -8,6 +9,8 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::{Parser, Subcommand, ValueEnum};
+
+const INSTALL_AGENT_DEFAULT: &str = "claude-code";
 
 const MAX_STDIN: usize = 1024 * 1024;
 
@@ -97,6 +100,29 @@ enum Cmd {
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
         capture: CaptureArg,
     },
+
+    /// Print (or write) the sigil-hook registration into an agent's settings.
+    Install {
+        /// Agent to register with. Currently only "claude-code" is supported.
+        #[arg(long, default_value = INSTALL_AGENT_DEFAULT)]
+        agent: String,
+        /// Apply the change to the settings file (default: print only).
+        #[arg(long)]
+        write: bool,
+        /// Capture level for the registered hook command.
+        #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
+        capture: CaptureArg,
+    },
+
+    /// Remove the sigil-hook registration from an agent's settings.
+    Uninstall {
+        /// Agent to deregister from.
+        #[arg(long, default_value = INSTALL_AGENT_DEFAULT)]
+        agent: String,
+        /// Apply the change to the settings file (default: print what would be removed).
+        #[arg(long)]
+        write: bool,
+    },
 }
 
 #[derive(Copy, Clone, ValueEnum)]
@@ -120,5 +146,156 @@ fn main() {
     let cli = Cli::parse();
     match cli.cmd {
         Cmd::ClaudeCode { capture } => run_hook("claude-code", capture.into()),
+        Cmd::Install {
+            agent,
+            write,
+            capture,
+        } => cmd_install(&agent, write, capture),
+        Cmd::Uninstall { agent, write } => cmd_uninstall(&agent, write),
     }
+}
+
+fn exe_path() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.canonicalize().ok())
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "sigil-hook".to_string())
+}
+
+fn cmd_install(agent: &str, write: bool, capture: CaptureArg) {
+    let capture_str = match capture {
+        CaptureArg::Redacted => "redacted",
+        CaptureArg::Raw => "raw",
+        CaptureArg::HashOnly => "hash-only",
+    };
+    let exe = exe_path();
+
+    if !write {
+        print!("{}", install::render_block(&exe, agent, capture_str));
+        return;
+    }
+
+    // Resolve the settings path for this agent.
+    let sp = match install::settings_path(agent) {
+        Some(p) => p,
+        None => {
+            eprintln!("error: unsupported agent '{agent}'");
+            std::process::exit(1);
+        }
+    };
+
+    // Read existing settings or start from an empty object.
+    let mut root: serde_json::Value = if sp.exists() {
+        let raw = match std::fs::read(&sp) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error reading {}: {e}", sp.display());
+                std::process::exit(1);
+            }
+        };
+        serde_json::from_slice(&raw).unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    let changed = install::merge_into(&mut root, &exe, agent, capture_str);
+
+    // Write back atomically: write to a temp file beside the target, then rename.
+    let pretty = serde_json::to_string_pretty(&root).unwrap_or_default();
+    if let Some(parent) = sp.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("error creating {}: {e}", parent.display());
+            std::process::exit(1);
+        }
+    }
+
+    // Atomic write: temp file + rename.
+    let tmp_path = sp.with_extension("json.sigil-tmp");
+    if let Err(e) = std::fs::write(&tmp_path, pretty.as_bytes()) {
+        eprintln!("error writing temp file {}: {e}", tmp_path.display());
+        std::process::exit(1);
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, &sp) {
+        eprintln!("error renaming to {}: {e}", sp.display());
+        let _ = std::fs::remove_file(&tmp_path);
+        std::process::exit(1);
+    }
+
+    // Write baseline / update discovery index.
+    if let Err(e) = install::write_baseline(agent, &sp, &exe, agent, capture_str, "*") {
+        eprintln!("warning: could not write baseline: {e}");
+    }
+
+    if changed {
+        eprintln!("sigil-hook: installed for {agent} in {}", sp.display());
+    } else {
+        eprintln!("sigil-hook: already installed for {agent} (no change)");
+    }
+}
+
+fn cmd_uninstall(agent: &str, write: bool) {
+    let exe = exe_path();
+
+    let sp = match install::settings_path(agent) {
+        Some(p) => p,
+        None => {
+            eprintln!("error: unsupported agent '{agent}'");
+            std::process::exit(1);
+        }
+    };
+
+    if !sp.exists() {
+        eprintln!(
+            "sigil-hook: settings file not found at {} — nothing to remove",
+            sp.display()
+        );
+        return;
+    }
+
+    let raw = match std::fs::read(&sp) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error reading {}: {e}", sp.display());
+            std::process::exit(1);
+        }
+    };
+    let mut root: serde_json::Value = serde_json::from_slice(&raw).unwrap_or(serde_json::json!({}));
+
+    let count = install::count_sigil_entries(&root, &exe);
+    if count == 0 {
+        eprintln!(
+            "sigil-hook: no entries found for {} in {}",
+            exe,
+            sp.display()
+        );
+        return;
+    }
+
+    if !write {
+        eprintln!(
+            "sigil-hook: would remove {count} entry/entries for {exe} from {} (pass --write to apply)",
+            sp.display()
+        );
+        return;
+    }
+
+    install::remove_from(&mut root, &exe);
+
+    let pretty = serde_json::to_string_pretty(&root).unwrap_or_default();
+    let tmp_path = sp.with_extension("json.sigil-tmp");
+    if let Err(e) = std::fs::write(&tmp_path, pretty.as_bytes()) {
+        eprintln!("error writing temp file {}: {e}", tmp_path.display());
+        std::process::exit(1);
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, &sp) {
+        eprintln!("error renaming to {}: {e}", sp.display());
+        let _ = std::fs::remove_file(&tmp_path);
+        std::process::exit(1);
+    }
+
+    eprintln!(
+        "sigil-hook: removed {count} entry/entries for {agent} from {}",
+        sp.display()
+    );
 }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -76,8 +76,21 @@ fn minimal_unparsed(
     }
 }
 
-/// Same directory the agent's control socket resolves to, but named hook.sock.
+/// Resolve the agent's hook socket. In the root-daemon deployment the agent
+/// (root) binds the SYSTEM socket `/var/run/sigil/hook.sock`, but a hook spawned
+/// by the agent runs as the *developer's* user — resolving by the hook's own uid
+/// would point at a per-user runtime path the daemon never binds (verified on
+/// Rocky 9). So: prefer the system socket when it exists (root-daemon), else fall
+/// back to the per-user path (non-root/local agent on the same uid).
+/// `SIGIL_HOOK_SOCKET` overrides both.
 fn hook_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("SIGIL_HOOK_SOCKET") {
+        return PathBuf::from(p);
+    }
+    let system = PathBuf::from("/var/run/sigil/hook.sock");
+    if system.exists() {
+        return system;
+    }
     let uid = unsafe { libc::geteuid() };
     let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
     let tmp = std::env::var("TMPDIR").ok();

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,6 +1,124 @@
 mod adapters;
+mod emit;
 mod redact;
 
-fn main() {
+use sigil_core::hook_proto::*;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+const MAX_STDIN: usize = 1024 * 1024;
+
+fn run_hook(agent: &str, capture: CaptureLevel) -> ! {
+    emit::arm_watchdog(Duration::from_millis(200));
+    let adapter = match adapters::for_agent(agent) {
+        Some(a) => a,
+        None => std::process::exit(0),
+    };
+
+    let mut buf = Vec::new();
+    let _ = std::io::stdin()
+        .take(MAX_STDIN as u64 + 1)
+        .read_to_end(&mut buf);
+    let oversized = buf.len() > MAX_STDIN;
+    let payload: serde_json::Value =
+        serde_json::from_slice(&buf).unwrap_or(serde_json::Value::Null);
+
+    let mut inv = match adapter.normalize(&payload, capture) {
+        Ok(i) => i,
+        Err(status) => minimal_unparsed(adapter.agent(), capture, status),
+    };
+    if oversized {
+        inv.capture_status = CaptureStatus::Oversized;
+    }
+
+    let env = HookEnvelope {
+        protocol_version: HOOK_PROTOCOL_VERSION,
+        msg_type: HookMsgType::HookInvocation,
+        request_id: uuid::Uuid::now_v7(),
+        sent_at_unix_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+        payload: inv,
+    };
+    if let Ok(line) = serde_json::to_string(&env) {
+        let _ = emit::send_envelope(&hook_socket_path(), &line, Duration::from_millis(150));
+    }
     std::process::exit(0);
+}
+
+fn minimal_unparsed(
+    agent: sigil_core::event::AiTool,
+    level: CaptureLevel,
+    status: CaptureStatus,
+) -> HookInvocation {
+    HookInvocation {
+        agent,
+        agent_session_id: None,
+        tool_use_id: None,
+        action: HookAction::Other {
+            label: "unparsed".into(),
+            detail_hash: String::new(),
+            detail_preview: None,
+        },
+        capture_level: level,
+        capture_status: status,
+        cwd: None,
+    }
+}
+
+/// Same directory the agent's control socket resolves to, but named hook.sock.
+fn hook_socket_path() -> PathBuf {
+    let uid = unsafe { libc::geteuid() };
+    let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+    let tmp = std::env::var("TMPDIR").ok();
+    sigil_core::control_proto::resolve_control_socket(uid == 0, xdg, tmp, uid)
+        .with_file_name("hook.sock")
+}
+
+#[derive(Parser)]
+#[command(
+    name = "sigil-hook",
+    about = "Runtime observer at the AI agent tool boundary"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Claude Code PreToolUse entrypoint: read stdin, emit, exit 0.
+    #[command(name = "claude-code")]
+    ClaudeCode {
+        #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
+        capture: CaptureArg,
+    },
+}
+
+#[derive(Copy, Clone, ValueEnum)]
+enum CaptureArg {
+    Redacted,
+    Raw,
+    HashOnly,
+}
+
+impl From<CaptureArg> for CaptureLevel {
+    fn from(a: CaptureArg) -> Self {
+        match a {
+            CaptureArg::Redacted => CaptureLevel::Redacted,
+            CaptureArg::Raw => CaptureLevel::Raw,
+            CaptureArg::HashOnly => CaptureLevel::HashOnly,
+        }
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::ClaudeCode { capture } => run_hook("claude-code", capture.into()),
+    }
 }

--- a/crates/sigil-hook/src/redact.rs
+++ b/crates/sigil-hook/src/redact.rs
@@ -1,6 +1,3 @@
-// Consumed by later tasks (per-agent adapters). Unused items are expected until then.
-#![allow(dead_code)]
-
 use regex::Regex;
 use sigil_core::hook_proto::CaptureLevel;
 use std::sync::OnceLock;

--- a/crates/sigil-hook/src/redact.rs
+++ b/crates/sigil-hook/src/redact.rs
@@ -1,0 +1,158 @@
+// Consumed by later tasks (per-agent adapters). Unused items are expected until then.
+#![allow(dead_code)]
+
+use regex::Regex;
+use sigil_core::hook_proto::CaptureLevel;
+use std::sync::OnceLock;
+
+const PREVIEW_CAP: usize = 256;
+
+pub struct Captured {
+    pub hash: String,
+    pub preview: Option<String>,
+}
+
+/// Compute a blake3 hex digest over the RAW pre-mask text (stable correlation
+/// id, NOT a privacy guarantee — the hash identifies the exact command), plus
+/// a preview whose shape depends on `level`:
+/// - `HashOnly`  → no preview
+/// - `Raw`       → verbatim text (capped to PREVIEW_CAP bytes at a char boundary)
+/// - `Redacted`  → secret patterns replaced with ‹redacted›, then capped
+pub fn capture(raw: &str, level: CaptureLevel) -> Captured {
+    let hash = blake3::hash(raw.as_bytes()).to_hex().to_string();
+    let preview = match level {
+        CaptureLevel::HashOnly => None,
+        CaptureLevel::Raw => Some(cap(raw)),
+        CaptureLevel::Redacted => Some(cap(&mask(raw))),
+    };
+    Captured { hash, preview }
+}
+
+/// Truncate `s` to at most PREVIEW_CAP bytes, always ending on a valid UTF-8
+/// char boundary so that slicing never panics.  If truncated, appends '…'
+/// (U+2026, 3 UTF-8 bytes) so the caller can detect the cap was reached.
+fn cap(s: &str) -> String {
+    if s.len() <= PREVIEW_CAP {
+        return s.to_string();
+    }
+    // Walk backwards from PREVIEW_CAP to find the largest valid char boundary.
+    let boundary = floor_char_boundary(s, PREVIEW_CAP);
+    format!("{}…", &s[..boundary])
+}
+
+/// Return the largest index ≤ `index` that is a valid UTF-8 char boundary in
+/// `s`.  Always returns a value in `0..=s.len()`.
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    // `str::floor_char_boundary` is stable since Rust 1.77; use it when
+    // available.  We replicate it manually here for older toolchains:
+    if index >= s.len() {
+        return s.len();
+    }
+    // A byte is the start of a UTF-8 code point when it is NOT a continuation
+    // byte (i.e. not of the form 0b10xx_xxxx).
+    let mut i = index;
+    while i > 0 && (s.as_bytes()[i] & 0xC0) == 0x80 {
+        i -= 1;
+    }
+    i
+}
+
+fn patterns() -> &'static [Regex] {
+    static P: OnceLock<Vec<Regex>> = OnceLock::new();
+    P.get_or_init(|| {
+        vec![
+            // KEY=value / KEY: value patterns
+            Regex::new(
+                r"(?i)(token|secret|password|passwd|api[_-]?key|auth|bearer|access[_-]?key)\s*[=:]\s*\S+",
+            )
+            .unwrap(),
+            // HTTP Authorization header
+            Regex::new(r"(?i)Authorization:\s*Bearer\s+\S+").unwrap(),
+            // AWS access-key IDs
+            Regex::new(r"\b(AKIA|ASIA)[0-9A-Z]{16}\b").unwrap(),
+            // GitHub tokens
+            Regex::new(r"\b(ghp_|gho_|github_pat_)[A-Za-z0-9_]{20,}\b").unwrap(),
+            // Generic base64-ish long token (≥ 32 chars)
+            Regex::new(r"\b[A-Za-z0-9+/]{32,}={0,2}\b").unwrap(),
+        ]
+    })
+    .as_slice()
+}
+
+fn mask(s: &str) -> String {
+    let mut out = s.to_string();
+    for re in patterns() {
+        out = re.replace_all(&out, "‹redacted›").into_owned();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigil_core::hook_proto::CaptureLevel;
+
+    #[test]
+    fn hash_is_stable_across_levels_and_over_raw() {
+        let raw = "export API_KEY=supersecret123456789012345678";
+        let a = capture(raw, CaptureLevel::Redacted);
+        let b = capture(raw, CaptureLevel::HashOnly);
+        let c = capture(raw, CaptureLevel::Raw);
+        assert_eq!(a.hash, b.hash);
+        assert_eq!(a.hash, c.hash);
+        assert_eq!(a.hash.len(), 64);
+    }
+
+    #[test]
+    fn redacted_masks_known_secret_and_caps_length() {
+        let raw = "curl -H 'Authorization: Bearer abcdef0123456789abcdef0123456789' x";
+        let out = capture(raw, CaptureLevel::Redacted);
+        let p = out.preview.unwrap();
+        assert!(!p.contains("abcdef0123456789abcdef0123456789"));
+        assert!(p.contains("‹redacted›"));
+    }
+
+    #[test]
+    fn hash_only_has_no_preview() {
+        assert!(capture("anything", CaptureLevel::HashOnly)
+            .preview
+            .is_none());
+    }
+
+    #[test]
+    fn raw_is_verbatim() {
+        let raw = "token=keepme";
+        assert_eq!(capture(raw, CaptureLevel::Raw).preview.unwrap(), raw);
+    }
+
+    #[test]
+    fn cap_is_panic_safe_on_multibyte() {
+        // Each '日' is 3 UTF-8 bytes; 100 chars = 300 bytes > PREVIEW_CAP (256).
+        let long: String = "日".repeat(100);
+        assert!(long.len() > PREVIEW_CAP);
+        // Must not panic regardless of byte-boundary alignment.
+        let out = capture(&long, CaptureLevel::Raw);
+        let preview = out.preview.unwrap();
+        // Result must be valid UTF-8 (Rust String guarantees) and end with '…'.
+        assert!(
+            preview.ends_with('…'),
+            "expected truncation marker, got: {preview:?}"
+        );
+        // The non-ellipsis portion must itself be valid: parse it back.
+        let without_ellipsis = preview.trim_end_matches('…');
+        assert!(
+            std::str::from_utf8(without_ellipsis.as_bytes()).is_ok(),
+            "non-ASCII slice is not valid UTF-8"
+        );
+        // Byte length of the preview content (excluding the 3-byte '…') must be ≤ cap.
+        assert!(without_ellipsis.len() <= PREVIEW_CAP);
+    }
+
+    #[test]
+    fn cap_does_not_truncate_short_multibyte() {
+        // A short multi-byte string that fits within the cap should be returned verbatim.
+        let short = "こんにちは"; // 5 chars × 3 bytes = 15 bytes, well within 256
+        let out = capture(short, CaptureLevel::Raw);
+        assert_eq!(out.preview.unwrap(), short);
+    }
+}

--- a/crates/sigil-hook/tests/hot_path_silence.rs
+++ b/crates/sigil-hook/tests/hot_path_silence.rs
@@ -1,0 +1,87 @@
+//! Integration test: the sigil-hook binary must exit 0 and produce no output
+//! (stdout or stderr) even when fed garbage/invalid input on stdin.
+//!
+//! Covers both the fail-open invariant (spec §7: exit 0 so the agent's tool
+//! call is never blocked) and the silence invariant (the panic hook suppresses
+//! output, and normal parse failures are also silent).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn garbage_stdin_exits_zero_with_no_output() {
+    // Feed clearly-invalid UTF-8 bytes to sigil-hook claude-code.
+    // The binary must: (a) exit with status 0, (b) write nothing to stdout,
+    // (c) write nothing to stderr.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .arg("claude-code")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn sigil-hook");
+
+    // Write invalid UTF-8 followed by clearly non-JSON garbage.
+    if let Some(mut stdin) = child.stdin.take() {
+        let garbage: &[u8] = b"\xFF\xFE not json at all \x00\x80";
+        let _ = stdin.write_all(garbage);
+        // Drop closes stdin so the process sees EOF.
+    }
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait for sigil-hook");
+
+    assert!(
+        output.status.success(),
+        "sigil-hook must exit 0 on garbage input; got: {:?}",
+        output.status
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "sigil-hook must produce no stdout; got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "sigil-hook must produce no stderr; got: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn not_json_string_exits_zero_with_no_output() {
+    // Also test with a plain ASCII non-JSON string to confirm the json parse
+    // failure path is also silent.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .arg("claude-code")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn sigil-hook");
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(b"not json");
+    }
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait for sigil-hook");
+
+    assert!(
+        output.status.success(),
+        "sigil-hook must exit 0 on non-JSON input; got: {:?}",
+        output.status
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "sigil-hook must produce no stdout on non-JSON input; got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "sigil-hook must produce no stderr on non-JSON input; got: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -136,6 +136,7 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
         | Evidence::TlsFailure { .. }
         | Evidence::EventUnprocessableLocal { .. }
         | Evidence::ServerProtocolViolation { .. } => { /* identity + severity only */ }
+        Evidence::HookInvocation(_) | Evidence::Unknown => { /* not indexed in Stage 1 */ }
     }
 }
 

--- a/crates/sigil-server/src/jsonl_scan.rs
+++ b/crates/sigil-server/src/jsonl_scan.rs
@@ -228,6 +228,8 @@ fn filter_match(e: &Event, f: &ScanFilters) -> bool {
         let s = match e.source {
             sigil_core::event::SourceKind::FileSystem => "file_system",
             sigil_core::event::SourceKind::Agent => "agent",
+            sigil_core::event::SourceKind::AgentHook => "agent_hook",
+            sigil_core::event::SourceKind::Unknown => "unknown",
         };
         if !srcs.iter().any(|x| x == s) {
             return false;

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 set -eu
 
 REPO="Ju571nK/sigil"
-BINARIES="sigil sigil-sender sigil-server sigil-sign sigil-mcp"
+BINARIES="sigil sigil-sender sigil-server sigil-sign sigil-mcp sigil-hook"
 INSTALL_DIR="${SIGIL_INSTALL_DIR:-$HOME/.local/bin}"
 
 say() { printf 'sigil-install: %s\n' "$1" >&2; }


### PR DESCRIPTION
Stage 1 of the **sigil-hook** epic (#64): a short-lived `sigil-hook` binary observes AI-agent tool calls (Claude Code PreToolUse first) at the tool boundary, redacts in-process, and emits one self-identifying event to `sigil-agent` over a dedicated one-way `hook.sock`, reusing the existing spool → sender → SIEM pipeline. **Observe-only — never denies, latency-bounded.**

## How this was built
brainstorm → spec (rev 3, **2 codex adversarial review rounds** incorporated) → plan → subagent-driven TDD (10 tasks) → final code review (1 critical + fixes). Spec/plan: `docs/superpowers/{specs,plans}/2026-06-01-sigil-hook-stage1*` (local, gitignored).

## What's here
- **`crates/sigil-hook`** (new 6th binary): per-call entrypoint + Claude Code adapter + redaction + `install`/`uninstall`.
- **`sigil-core::hook_proto`**: versioned one-way IPC contract (`HookEnvelope`/`HookInvocation`/`HookAction`/`CaptureLevel`/`CaptureStatus`), separate from the operator control API.
- **`sigil-core::event`**: persisted `Evidence::HookInvocation` + `SourceKind::AgentHook`, plus `#[serde(other)] Unknown` **forward-compat** fallbacks so a newer agent's event isn't rejected by an older server.
- **`sigil-agent` hook listener**: binds `hook.sock` (0660), **stamps the kernel peer-uid** (attribution; DAC is the access gate — not a root-or-self reject), **drops-before-read on overload** (semaphore + `try_send`, never blocks), maps IPC → `Event` → the existing sink. Spawned beside the control listener.

## Safety invariants (verified)
- **Never denies / never breaks the agent**: always `exit 0`, **zero stdout/stderr** on the hot path, a **watchdog thread** that preempts a blocking stdin read, 1 MiB stdin cap, `ECONNRESET`/`EPIPE`/agent-down treated as success. Proven end-to-end by `tests/hot_path_silence.rs` (garbage stdin → exit 0, empty output) + a **panic hook** that exits 0 silently.
- **Redaction in-process**: blake3 hash over **raw pre-mask** text (a correlation id, documented as **not** privacy) + masked, length-capped preview; raw never crosses IPC under `redacted`/`hash_only`. `cap()` is UTF-8-panic-safe.
- **Latency**: normalize+redact+serialize ≈ **42µs/call** locally (microbench guards a 5ms ceiling).

## Tests
sigil-hook 18 unit + 2 integration; sigil-core hook/event round-trip + forward-compat; sigil-agent hook listener (peer-uid stamp, overload no-deadlock, snake_case capture fields, Other-label persistence). `cargo fmt` + `clippy --workspace -D warnings` clean.

> **Known flake (not from this change):** `it_emits_modified_event` (sigil-agent `basic_events`) is the pre-existing #66 FSEvents-under-load flake — it fails identically on `main` under machine load and passes on fresh CI runners. Not related to this PR.

## Deferred (tracked, not in this PR)
- **Rocky 9 DAC/SELinux enforcing verification** (spec §13): the unconfined user-spawned hook connecting to `sigil_agent_t`'s `hook.sock` should work under the #69 policy via DAC, but this **must be verified on a Rocky enforcing box** before relying on it — a pre-merge checklist item (needs an rpm built from this branch + the disposable .117 box).
- Stage 2 (enforce/deny, sync decision IPC, drift-detection events), Codex/Gemini/Cursor adapters (the trait + dispatch are ready), keyed-hash privacy mode.

Closes #64 **Stage 1** — the epic stays open for Stage 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)