### PR TITLE
feat(hook): Codex + Cursor adapters (#64)

### DIFF
--- a/crates/sigil-hook/src/adapters/codex.rs
+++ b/crates/sigil-hook/src/adapters/codex.rs
@@ -1,0 +1,158 @@
+use super::HookAdapter;
+use crate::redact::capture;
+use sigil_core::event::AiTool;
+use sigil_core::hook_proto::*;
+
+/// Codex CLI `PreToolUse` hook. Codex deliberately reuses the Claude Code hook
+/// shape (`tool_name` / `tool_input` / `tool_use_id`, plus `turn_id` and a
+/// Codex-only `permission_mode`), so this mirrors the Claude adapter but keys
+/// shell detection on the `tool_input.command` field (Codex's shell tool is
+/// `shell`/`local_shell`, not literally `Bash`) and treats `apply_patch` /
+/// `file_path` inputs as file edits.
+pub struct Codex;
+
+impl HookAdapter for Codex {
+    fn agent(&self) -> AiTool {
+        AiTool::Codex
+    }
+
+    fn normalize(
+        &self,
+        p: &serde_json::Value,
+        level: CaptureLevel,
+    ) -> Result<HookInvocation, CaptureStatus> {
+        let tool = p
+            .get("tool_name")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptureStatus::Malformed)?;
+        let input = p
+            .get("tool_input")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        let action = if let Some(rest) = tool.strip_prefix("mcp__") {
+            let mut it = rest.splitn(2, "__");
+            let server = it.next().unwrap_or("").to_string();
+            let mcp_tool = it.next().unwrap_or("").to_string();
+            let args = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&args, level);
+            HookAction::McpCall {
+                server,
+                tool: mcp_tool,
+                args_hash: c.hash,
+                args_preview: c.preview,
+            }
+        } else if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
+            // Shell tool — keyed on the command field, not the exact tool_name.
+            let c = capture(cmd, level);
+            HookAction::Bash {
+                command_hash: c.hash,
+                command_preview: c.preview,
+            }
+        } else if matches!(tool, "Edit" | "Write" | "apply_patch")
+            || input.get("file_path").is_some()
+        {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or(tool);
+            let c = capture(path, level);
+            HookAction::FileEdit {
+                path_hash: c.hash,
+                path_preview: c.preview,
+                edit_hash: None,
+            }
+        } else {
+            let detail = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&detail, level);
+            HookAction::Other {
+                label: tool.to_string(),
+                detail_hash: c.hash,
+                detail_preview: c.preview,
+            }
+        };
+
+        Ok(HookInvocation {
+            agent: AiTool::Codex,
+            // Codex provides `session_id`; fall back to `turn_id` for correlation.
+            agent_session_id: p
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .or_else(|| p.get("turn_id").and_then(|v| v.as_str()))
+                .map(String::from),
+            tool_use_id: p
+                .get("tool_use_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            action,
+            capture_level: level,
+            capture_status: CaptureStatus::Ok,
+            cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_shell_command() {
+        let p = serde_json::json!({
+            "session_id":"s1","tool_use_id":"t1","turn_id":"turn1","cwd":"/repo",
+            "tool_name":"shell","tool_input":{"command":"cargo test"}
+        });
+        let inv = Codex.normalize(&p, CaptureLevel::Redacted).unwrap();
+        assert_eq!(inv.agent, AiTool::Codex);
+        assert_eq!(inv.agent_session_id.as_deref(), Some("s1"));
+        match inv.action {
+            HookAction::Bash {
+                command_preview, ..
+            } => assert_eq!(command_preview.unwrap(), "cargo test"),
+            _ => panic!("expected Bash"),
+        }
+    }
+
+    #[test]
+    fn falls_back_to_turn_id_for_session() {
+        let p = serde_json::json!({
+            "turn_id":"turn9","tool_name":"shell","tool_input":{"command":"ls"}
+        });
+        let inv = Codex.normalize(&p, CaptureLevel::Redacted).unwrap();
+        assert_eq!(inv.agent_session_id.as_deref(), Some("turn9"));
+    }
+
+    #[test]
+    fn normalizes_mcp_tool() {
+        let p = serde_json::json!({
+            "tool_name":"mcp__github__create_issue","tool_input":{"title":"x"}
+        });
+        match Codex.normalize(&p, CaptureLevel::Redacted).unwrap().action {
+            HookAction::McpCall { server, tool, .. } => {
+                assert_eq!(server, "github");
+                assert_eq!(tool, "create_issue");
+            }
+            _ => panic!("expected McpCall"),
+        }
+    }
+
+    #[test]
+    fn apply_patch_is_file_edit() {
+        let p = serde_json::json!({
+            "tool_name":"apply_patch","tool_input":{"file_path":"/repo/src/lib.rs"}
+        });
+        assert!(matches!(
+            Codex.normalize(&p, CaptureLevel::Redacted).unwrap().action,
+            HookAction::FileEdit { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_tool_is_other() {
+        let p = serde_json::json!({"tool_name":"update_plan","tool_input":{"plan":"x"}});
+        match Codex.normalize(&p, CaptureLevel::Redacted).unwrap().action {
+            HookAction::Other { label, .. } => assert_eq!(label, "update_plan"),
+            _ => panic!("expected Other"),
+        }
+    }
+}

--- a/crates/sigil-hook/src/adapters/cursor.rs
+++ b/crates/sigil-hook/src/adapters/cursor.rs
@@ -1,0 +1,153 @@
+use super::HookAdapter;
+use crate::redact::capture;
+use sigil_core::event::AiTool;
+use sigil_core::hook_proto::*;
+
+/// Cursor hooks. Unlike the Claude-shaped agents, Cursor fires a *distinct
+/// event per tool class* (`beforeShellExecution`, `beforeMCPExecution`) rather
+/// than one `PreToolUse` with a `tool_name`, so this adapter dispatches on
+/// `hook_event_name`. Shell puts the command at the top level (`command`); MCP
+/// carries `tool_name` + `tool_input` + a server location (`url` or `command`).
+/// Ids: `conversation_id` (session) and `generation_id` (per-call).
+pub struct Cursor;
+
+impl HookAdapter for Cursor {
+    fn agent(&self) -> AiTool {
+        AiTool::Cursor
+    }
+
+    fn normalize(
+        &self,
+        p: &serde_json::Value,
+        level: CaptureLevel,
+    ) -> Result<HookInvocation, CaptureStatus> {
+        let event = p
+            .get("hook_event_name")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptureStatus::Malformed)?;
+
+        let action = match event {
+            "beforeShellExecution" => {
+                let cmd = p.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                let c = capture(cmd, level);
+                HookAction::Bash {
+                    command_hash: c.hash,
+                    command_preview: c.preview,
+                }
+            }
+            "beforeMCPExecution" => {
+                let tool = p
+                    .get("tool_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // Server location is `url` (remote) or `command` (stdio).
+                let server = p
+                    .get("url")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| p.get("command").and_then(|v| v.as_str()))
+                    .unwrap_or("")
+                    .to_string();
+                let args = p
+                    .get("tool_input")
+                    .map(|v| v.to_string())
+                    .unwrap_or_default();
+                let c = capture(&args, level);
+                HookAction::McpCall {
+                    server,
+                    tool,
+                    args_hash: c.hash,
+                    args_preview: c.preview,
+                }
+            }
+            other => {
+                let detail = p
+                    .get("tool_input")
+                    .map(|v| v.to_string())
+                    .or_else(|| p.get("command").and_then(|v| v.as_str()).map(String::from))
+                    .unwrap_or_default();
+                let c = capture(&detail, level);
+                HookAction::Other {
+                    label: other.to_string(),
+                    detail_hash: c.hash,
+                    detail_preview: c.preview,
+                }
+            }
+        };
+
+        Ok(HookInvocation {
+            agent: AiTool::Cursor,
+            agent_session_id: p
+                .get("conversation_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            tool_use_id: p
+                .get("generation_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            action,
+            capture_level: level,
+            capture_status: CaptureStatus::Ok,
+            cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_execution_is_bash() {
+        let p = serde_json::json!({
+            "hook_event_name":"beforeShellExecution",
+            "conversation_id":"c1","generation_id":"g1","cwd":"/repo",
+            "command":"rm -rf build"
+        });
+        let inv = Cursor.normalize(&p, CaptureLevel::Redacted).unwrap();
+        assert_eq!(inv.agent, AiTool::Cursor);
+        assert_eq!(inv.agent_session_id.as_deref(), Some("c1"));
+        assert_eq!(inv.tool_use_id.as_deref(), Some("g1"));
+        match inv.action {
+            HookAction::Bash {
+                command_preview, ..
+            } => assert_eq!(command_preview.unwrap(), "rm -rf build"),
+            _ => panic!("expected Bash"),
+        }
+    }
+
+    #[test]
+    fn mcp_execution_is_mcp_call() {
+        let p = serde_json::json!({
+            "hook_event_name":"beforeMCPExecution",
+            "conversation_id":"c1",
+            "tool_name":"create_issue","tool_input":{"title":"x"},
+            "url":"https://mcp.github.example"
+        });
+        match Cursor.normalize(&p, CaptureLevel::Redacted).unwrap().action {
+            HookAction::McpCall { server, tool, .. } => {
+                assert_eq!(tool, "create_issue");
+                assert_eq!(server, "https://mcp.github.example");
+            }
+            _ => panic!("expected McpCall"),
+        }
+    }
+
+    #[test]
+    fn unknown_event_is_other() {
+        let p = serde_json::json!({"hook_event_name":"afterFileEdit","tool_input":{"path":"x"}});
+        match Cursor.normalize(&p, CaptureLevel::Redacted).unwrap().action {
+            HookAction::Other { label, .. } => assert_eq!(label, "afterFileEdit"),
+            _ => panic!("expected Other"),
+        }
+    }
+
+    #[test]
+    fn missing_event_name_is_malformed() {
+        let p = serde_json::json!({"command":"ls"});
+        assert_eq!(
+            Cursor.normalize(&p, CaptureLevel::Redacted).unwrap_err(),
+            CaptureStatus::Malformed
+        );
+    }
+}

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -1,6 +1,8 @@
 use sigil_core::event::AiTool;
 use sigil_core::hook_proto::{CaptureLevel, CaptureStatus, HookInvocation};
 pub mod claude_code;
+pub mod codex;
+pub mod cursor;
 
 /// One impl per agent. Turns a vendor stdin payload into a normalized
 /// HookInvocation. (Shape mirrors ai_guard/parser, but is a distinct trait —
@@ -17,6 +19,8 @@ pub trait HookAdapter {
 pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
     match name {
         "claude-code" => Some(Box::new(claude_code::ClaudeCode)),
+        "codex" => Some(Box::new(codex::Codex)),
+        "cursor" => Some(Box::new(cursor::Cursor)),
         _ => None,
     }
 }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -127,6 +127,18 @@ enum Cmd {
         capture: CaptureArg,
     },
 
+    /// Codex CLI PreToolUse entrypoint: read stdin, emit, exit 0.
+    Codex {
+        #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
+        capture: CaptureArg,
+    },
+
+    /// Cursor before{Shell,MCP}Execution entrypoint: read stdin, emit, exit 0.
+    Cursor {
+        #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
+        capture: CaptureArg,
+    },
+
     /// Print (or write) the sigil-hook registration into an agent's settings.
     Install {
         /// Agent to register with. Currently only "claude-code" is supported.
@@ -172,6 +184,8 @@ fn main() {
     let cli = Cli::parse();
     match cli.cmd {
         Cmd::ClaudeCode { capture } => run_hook("claude-code", capture.into()),
+        Cmd::Codex { capture } => run_hook("codex", capture.into()),
+        Cmd::Cursor { capture } => run_hook("cursor", capture.into()),
         Cmd::Install {
             agent,
             write,


### PR DESCRIPTION
Adds two per-agent hook adapters behind the existing `HookAdapter` trait (the multi-agent design from Stage 1). Vendor hook schemas **web-verified June 2026** before implementing.

| Agent | Hook | Mapping |
|---|---|---|
| **Codex** | `PreToolUse` (Claude-shaped — reuses Claude hook settings) | `tool_input.command` → Bash, `mcp__srv__tool` → McpCall, `apply_patch`/`file_path` → FileEdit, else Other. session = `session_id`/`turn_id`, `tool_use_id`. |
| **Cursor** | `beforeShellExecution` / `beforeMCPExecution` (event-per-tool-class) | dispatch on `hook_event_name`: shell → Bash (top-level `command`), MCP → McpCall (server from `url`/`command`). ids: `conversation_id` / `generation_id`. |

- New `sigil-hook codex` / `sigil-hook cursor` entrypoints (same redact + fail-open + watchdog path as `claude-code`).
- Unknown tools/events degrade to `Other { label }` — robust to vendor schema churn.
- 9 new adapter tests (5 Codex, 4 Cursor); `sigil-hook` now 27 unit + 2 integration, clippy clean. Entrypoint smoke: exit 0, zero stdout/stderr.

## Notes / follow-ups
- **Gemini CLI intentionally skipped.** Google is sunsetting Gemini CLI on **2026-06-18** in favor of **Antigravity** (a new agentic platform, not a rename). An **Antigravity** adapter — with its own `AiTool` variant + verified hook schema — is tracked as a separate follow-up.
- **Install registration** for Codex (`~/.codex/hooks.json`) and Cursor (own hooks config) is a follow-up; this PR wires the runtime **normalization + entrypoints**. `install --agent claude-code` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)