### PR TITLE
feat(ai-guard): Antigravity per-repo parser + antigravity_workspaces policy field

### DIFF
--- a/crates/sigil-agent/src/ai_guard/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/mod.rs
@@ -12,7 +12,7 @@ pub mod rule_pack;
 pub mod task;
 pub mod workspace_discovery;
 
-pub use parser::antigravity::AntigravityParser;
+pub use parser::antigravity::{AntigravityParser, AntigravityProjectParser};
 pub use parser::claude_code::{ClaudeCodeParser, ClaudeCodeProjectParser};
 pub use parser::claude_desktop::ClaudeDesktopParser;
 pub use parser::codex::{CodexParser, CodexProjectParser};

--- a/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
@@ -103,6 +103,41 @@ impl AiGuardParser for AntigravityParser {
     }
 }
 
+/// Per-repo parser: `<repo>/.antigravity/settings.json` (sandbox + approval).
+/// Project-scope MCP config is not modeled (MCP lives in the shared user-global
+/// `~/.gemini/config/mcp_config.json`).
+pub struct AntigravityProjectParser {
+    pub repo_root: PathBuf,
+}
+
+impl AntigravityProjectParser {
+    fn settings(&self) -> PathBuf {
+        self.repo_root.join(".antigravity").join("settings.json")
+    }
+}
+
+impl AiGuardParser for AntigravityProjectParser {
+    fn tool(&self) -> AiTool {
+        AiTool::Antigravity
+    }
+    fn scope(&self) -> AiGuardScope {
+        AiGuardScope::Project {
+            path: self.repo_root.clone(),
+        }
+    }
+    fn watched_paths(&self, _home: &Path) -> Vec<PathBuf> {
+        vec![self.settings()]
+    }
+    fn assess(&self, _home: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
+        let mut out = Vec::new();
+        if let Some(settings) = read_json(&self.settings())? {
+            emit_sandbox(&settings, &mut out);
+            emit_approval(&settings, &mut out);
+        }
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +251,27 @@ mod tests {
     fn tool_and_scope() {
         assert_eq!(AntigravityParser.tool(), AiTool::Antigravity);
         assert_eq!(AntigravityParser.scope(), AiGuardScope::UserGlobal);
+    }
+    #[test]
+    fn project_parser_scope_and_detect() {
+        let d = tempdir().unwrap();
+        let repo = d.path().join("repoX");
+        std::fs::create_dir_all(repo.join(".antigravity")).unwrap();
+        std::fs::write(
+            repo.join(".antigravity").join("settings.json"),
+            r#"{"enableTerminalSandbox":false,"approval_mode":"yolo"}"#,
+        )
+        .unwrap();
+        let p = AntigravityProjectParser {
+            repo_root: repo.clone(),
+        };
+        let reasons = p.assess(Path::new("/unused")).unwrap();
+        assert!(reasons
+            .iter()
+            .any(|r| matches!(r, AiGuardReason::SandboxDisabled)));
+        assert!(reasons
+            .iter()
+            .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })));
+        assert_eq!(p.scope(), AiGuardScope::Project { path: repo });
     }
 }

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -150,6 +150,10 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         &effective.cursor_workspaces,
         ".cursor/mcp.json",
     );
+    let antigravity_repos = crate::ai_guard::workspace_discovery::discover_per_repo(
+        &effective.antigravity_workspaces,
+        ".antigravity/settings.json",
+    );
 
     for repo_root in &continue_repos {
         push_continue_synthetic_target(&mut effective, repo_root);
@@ -165,6 +169,9 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     }
     for repo_root in &cursor_repos {
         push_cursor_synthetic_target(&mut effective, repo_root);
+    }
+    for repo_root in &antigravity_repos {
+        push_antigravity_synthetic_target(&mut effective, repo_root);
     }
 
     // Phase 3b.6.1 — build the shared parsers list BEFORE the policy_reload
@@ -205,6 +212,11 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     }
     for repo_root in cursor_repos {
         parsers_vec.push(Arc::new(crate::ai_guard::CursorProjectParser { repo_root }));
+    }
+    for repo_root in antigravity_repos {
+        parsers_vec.push(Arc::new(crate::ai_guard::AntigravityProjectParser {
+            repo_root,
+        }));
     }
     // Phase 3b.7 — declarative rule packs (sigil-rules-basic defaults +
     // operator overlay from signed envelope, already merged into
@@ -1114,6 +1126,25 @@ pub(crate) fn push_gemini_synthetic_target(
     effective.targets.push(sigil_core::policy::WatchTarget {
         id: format!("gemini-project-{h}"),
         description: format!("Phase 3b.8 synthetic: {}", repo_root.display()),
+        tier: sigil_core::policy::Tier::Critical,
+        platform: sigil_core::policy::Platform::Any,
+        paths: vec![config.to_string_lossy().to_string()],
+        recursive: false,
+        follow_symlinks: false,
+        disabled: false,
+    });
+}
+
+/// Push ONE synthetic WatchTarget for an Antigravity per-repo config.
+pub(crate) fn push_antigravity_synthetic_target(
+    effective: &mut sigil_core::policy::EffectivePolicy,
+    repo_root: &std::path::Path,
+) {
+    let config = repo_root.join(".antigravity").join("settings.json");
+    let h = synthetic_target_id_suffix(repo_root);
+    effective.targets.push(sigil_core::policy::WatchTarget {
+        id: format!("antigravity-project-{h}"),
+        description: format!("Antigravity synthetic: {}", repo_root.display()),
         tier: sigil_core::policy::Tier::Critical,
         platform: sigil_core::policy::Platform::Any,
         paths: vec![config.to_string_lossy().to_string()],

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -139,6 +139,10 @@ pub struct PolicyDocument {
     /// `<subdir>/.cursor/mcp.json` marker.
     #[serde(default)]
     pub cursor_workspaces: Vec<String>,
+    /// Antigravity workspace roots. 1-level scan for
+    /// `<subdir>/.antigravity/settings.json` marker.
+    #[serde(default)]
+    pub antigravity_workspaces: Vec<String>,
     /// Phase 3b.7 — operator-supplied rule packs (declarative scan rules).
     /// Wire-additive; merged by id with sigil-rules-basic defaults.
     #[serde(default)]
@@ -215,6 +219,7 @@ pub struct EffectivePolicy {
     pub codex_workspaces: Vec<String>,
     pub gemini_workspaces: Vec<String>,
     pub cursor_workspaces: Vec<String>,
+    pub antigravity_workspaces: Vec<String>,
     pub rule_packs: Vec<RulePack>,
     /// Phase 3b.5 — operator-tunable rubric weights (merged from user
     /// PolicyDocument; defaults map is empty).
@@ -289,6 +294,10 @@ pub fn merge(
         .as_ref()
         .map(|u| u.cursor_workspaces.clone())
         .unwrap_or_default();
+    let antigravity_workspaces = user
+        .as_ref()
+        .map(|u| u.antigravity_workspaces.clone())
+        .unwrap_or_default();
 
     // Phase 3b.7 — id-keyed reconciliation: start with defaults' packs;
     // user packs replace by id or append.
@@ -319,6 +328,7 @@ pub fn merge(
         codex_workspaces,
         gemini_workspaces,
         cursor_workspaces,
+        antigravity_workspaces,
         rule_packs,
         rubric_overrides,
     })
@@ -351,6 +361,7 @@ pub fn defaults() -> Result<PolicyDocument, PolicyError> {
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs,
             rubric_overrides: HashMap::new(),
         }),
@@ -485,6 +496,7 @@ targets:
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         }
@@ -513,6 +525,7 @@ targets:
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -537,6 +550,7 @@ targets:
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -560,6 +574,7 @@ targets:
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -579,6 +594,7 @@ targets:
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -602,6 +618,7 @@ targets:
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -898,6 +915,7 @@ host_id_strategy: hostname
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -939,11 +957,13 @@ host_id_strategy: hostname
             codex_workspaces: vec![],
             gemini_workspaces: vec!["~/src/a".to_string()],
             cursor_workspaces: vec!["~/src/b".to_string()],
+            antigravity_workspaces: vec!["~/src/c".to_string()],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
         let eff = merge(defaults().unwrap(), Some(user), current_platform()).unwrap();
         assert_eq!(eff.gemini_workspaces, vec!["~/src/a".to_string()]);
         assert_eq!(eff.cursor_workspaces, vec!["~/src/b".to_string()]);
+        assert_eq!(eff.antigravity_workspaces, vec!["~/src/c".to_string()]);
     }
 }

--- a/crates/sigil-core/tests/properties.rs
+++ b/crates/sigil-core/tests/properties.rs
@@ -40,6 +40,7 @@ proptest! {
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -67,6 +68,7 @@ proptest! {
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
@@ -80,6 +82,7 @@ proptest! {
             codex_workspaces: vec![],
             gemini_workspaces: vec![],
             cursor_workspaces: vec![],
+            antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };


### PR DESCRIPTION
Completes the Antigravity static parser (#86 shipped UserGlobal) with **project scope**. (This per-repo commit landed on the branch after #86 squash-merged UserGlobal-only, so it needs its own PR.)

- New **`antigravity_workspaces`** policy field (`PolicyDocument` + `EffectivePolicy` + merge), wire-additive (`#[serde(default)]`). All `EffectivePolicy`/`PolicyDocument` literals updated + a merge test.
- **`AntigravityProjectParser`** (Project scope) reads `<repo>/.antigravity/settings.json` (sandbox + approval), discovered 1-level under `antigravity_workspaces` with a synthetic `WatchTarget` (mirrors the Gemini per-repo path).
- Registered in the runtime per-repo parser loop.
- 13 antigravity tests (UserGlobal + project) + policy-merge test for `antigravity_workspaces`.

## Verify
`cargo build --workspace` clean; antigravity 13 + policy 91 + `clippy --workspace -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)