### PR TITLE
feat(hook): Antigravity adapter (#64)

### DIFF
--- a/crates/sigil-hook/src/adapters/antigravity.rs
+++ b/crates/sigil-hook/src/adapters/antigravity.rs
@@ -1,0 +1,191 @@
+use super::HookAdapter;
+use crate::redact::capture;
+use sigil_core::event::AiTool;
+use sigil_core::hook_proto::*;
+
+/// Antigravity (Google) — successor to Gemini CLI (sunset 2026-06-18). Its
+/// `PreToolUse` hook adopts the Claude Code payload shape
+/// (`session_id` / `cwd` / `tool_name` / `tool_input` / `tool_use_id`,
+/// `hook_event_name: "PreToolUse"`), so this mirrors the Claude adapter — but we
+/// also defensively handle Gemini-carryover tool names
+/// (`run_shell_command` / `write_file` / `replace`) in case Antigravity still
+/// emits any of them. Unknown tools degrade to `Other { label }`.
+pub struct Antigravity;
+
+impl HookAdapter for Antigravity {
+    fn agent(&self) -> AiTool {
+        AiTool::Antigravity
+    }
+
+    fn normalize(
+        &self,
+        p: &serde_json::Value,
+        level: CaptureLevel,
+    ) -> Result<HookInvocation, CaptureStatus> {
+        let tool = p
+            .get("tool_name")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptureStatus::Malformed)?;
+        let input = p
+            .get("tool_input")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        let action = if let Some(rest) = tool.strip_prefix("mcp__") {
+            let mut it = rest.splitn(2, "__");
+            let server = it.next().unwrap_or("").to_string();
+            let mcp_tool = it.next().unwrap_or("").to_string();
+            let args = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&args, level);
+            HookAction::McpCall {
+                server,
+                tool: mcp_tool,
+                args_hash: c.hash,
+                args_preview: c.preview,
+            }
+        } else if tool == "Bash" || tool == "run_shell_command" || input.get("command").is_some() {
+            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let c = capture(cmd, level);
+            HookAction::Bash {
+                command_hash: c.hash,
+                command_preview: c.preview,
+            }
+        } else if matches!(
+            tool,
+            "Edit" | "Write" | "MultiEdit" | "write_file" | "replace"
+        ) || input.get("file_path").is_some()
+        {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or(tool);
+            let c = capture(path, level);
+            HookAction::FileEdit {
+                path_hash: c.hash,
+                path_preview: c.preview,
+                edit_hash: None,
+            }
+        } else {
+            let detail = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&detail, level);
+            HookAction::Other {
+                label: tool.to_string(),
+                detail_hash: c.hash,
+                detail_preview: c.preview,
+            }
+        };
+
+        Ok(HookInvocation {
+            agent: AiTool::Antigravity,
+            agent_session_id: p
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            tool_use_id: p
+                .get("tool_use_id")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            action,
+            capture_level: level,
+            capture_status: CaptureStatus::Ok,
+            cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_style_bash() {
+        let p = serde_json::json!({
+            "session_id":"s1","tool_use_id":"t1","cwd":"/repo",
+            "hook_event_name":"PreToolUse",
+            "tool_name":"Bash","tool_input":{"command":"npm test"}
+        });
+        let inv = Antigravity.normalize(&p, CaptureLevel::Redacted).unwrap();
+        assert_eq!(inv.agent, AiTool::Antigravity);
+        assert_eq!(inv.agent_session_id.as_deref(), Some("s1"));
+        match inv.action {
+            HookAction::Bash {
+                command_preview, ..
+            } => assert_eq!(command_preview.unwrap(), "npm test"),
+            _ => panic!("expected Bash"),
+        }
+    }
+
+    #[test]
+    fn gemini_carryover_run_shell_command_is_bash() {
+        let p = serde_json::json!({
+            "tool_name":"run_shell_command","tool_input":{"command":"ls -la"}
+        });
+        assert!(matches!(
+            Antigravity
+                .normalize(&p, CaptureLevel::Redacted)
+                .unwrap()
+                .action,
+            HookAction::Bash { .. }
+        ));
+    }
+
+    #[test]
+    fn edit_is_file_edit() {
+        let p = serde_json::json!({
+            "tool_name":"Edit","tool_input":{"file_path":"/repo/src/main.rs","old_string":"a","new_string":"b"}
+        });
+        match Antigravity
+            .normalize(&p, CaptureLevel::Redacted)
+            .unwrap()
+            .action
+        {
+            HookAction::FileEdit { path_hash, .. } => assert_eq!(path_hash.len(), 64),
+            _ => panic!("expected FileEdit"),
+        }
+    }
+
+    #[test]
+    fn gemini_carryover_write_file_is_file_edit() {
+        let p = serde_json::json!({
+            "tool_name":"write_file","tool_input":{"file_path":"/repo/x.txt","content":"y"}
+        });
+        assert!(matches!(
+            Antigravity
+                .normalize(&p, CaptureLevel::Redacted)
+                .unwrap()
+                .action,
+            HookAction::FileEdit { .. }
+        ));
+    }
+
+    #[test]
+    fn mcp_tool() {
+        let p = serde_json::json!({
+            "tool_name":"mcp__github__create_issue","tool_input":{"title":"x"}
+        });
+        match Antigravity
+            .normalize(&p, CaptureLevel::Redacted)
+            .unwrap()
+            .action
+        {
+            HookAction::McpCall { server, tool, .. } => {
+                assert_eq!(server, "github");
+                assert_eq!(tool, "create_issue");
+            }
+            _ => panic!("expected McpCall"),
+        }
+    }
+
+    #[test]
+    fn unknown_tool_is_other() {
+        let p = serde_json::json!({"tool_name":"Glob","tool_input":{"pattern":"*.rs"}});
+        match Antigravity
+            .normalize(&p, CaptureLevel::Redacted)
+            .unwrap()
+            .action
+        {
+            HookAction::Other { label, .. } => assert_eq!(label, "Glob"),
+            _ => panic!("expected Other"),
+        }
+    }
+}

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 use sigil_core::event::AiTool;
 use sigil_core::hook_proto::{CaptureLevel, CaptureStatus, HookInvocation};
+pub mod antigravity;
 pub mod claude_code;
 pub mod codex;
 pub mod cursor;
@@ -21,6 +22,7 @@ pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
         "claude-code" => Some(Box::new(claude_code::ClaudeCode)),
         "codex" => Some(Box::new(codex::Codex)),
         "cursor" => Some(Box::new(cursor::Cursor)),
+        "antigravity" => Some(Box::new(antigravity::Antigravity)),
         _ => None,
     }
 }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -139,6 +139,12 @@ enum Cmd {
         capture: CaptureArg,
     },
 
+    /// Antigravity PreToolUse entrypoint: read stdin, emit, exit 0.
+    Antigravity {
+        #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
+        capture: CaptureArg,
+    },
+
     /// Print (or write) the sigil-hook registration into an agent's settings.
     Install {
         /// Agent to register with. Currently only "claude-code" is supported.
@@ -186,6 +192,7 @@ fn main() {
         Cmd::ClaudeCode { capture } => run_hook("claude-code", capture.into()),
         Cmd::Codex { capture } => run_hook("codex", capture.into()),
         Cmd::Cursor { capture } => run_hook("cursor", capture.into()),
+        Cmd::Antigravity { capture } => run_hook("antigravity", capture.into()),
         Cmd::Install {
             agent,
             write,


### PR DESCRIPTION
Adds the **Antigravity** runtime hook adapter, completing Antigravity coverage (static parser shipped in #86/#87; this is the runtime hook side).

Antigravity (Google) is the **successor to Gemini CLI** (sunset **2026-06-18**). Its `PreToolUse` hook adopts the **Claude Code payload shape** (web-verified June 2026): `session_id` / `cwd` / `tool_name` / `tool_input` / `tool_use_id`, `hook_event_name: "PreToolUse"`.

## What
- `adapters/antigravity.rs` mirrors the Claude adapter (`Bash`, `Edit`/`Write`/`MultiEdit`, `mcp__srv__tool`, else `Other`), and **defensively** maps Gemini-carryover tool names: `run_shell_command` → Bash, `write_file`/`replace` → FileEdit. Unknown tools degrade to `Other { label }`.
- New `sigil-hook antigravity` entrypoint (same redact + fail-open + watchdog path).
- 6 adapter tests (Claude-style Bash, Gemini-carryover shell, Edit, write_file, MCP, unknown→Other); `sigil-hook` now 33 unit + 2 integration, clippy clean; entrypoint smoke: exit 0, zero output.

## Follow-up
- **Install registration** for Antigravity (`settings.json` PreToolUse / plugin `hooks.json`) — this PR wires runtime normalization + the entrypoint; `install --agent` stays Claude-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)