### PR TITLE
fix: Antigravity on-hardware corrections (approval key + install) + Windows

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
@@ -5,8 +5,9 @@
 //!   - MCP servers: `~/.gemini/config/mcp_config.json` (`mcpServers`, a separate
 //!     file — unlike Gemini, MCP is not inline in settings.json)
 //!   - terminal sandbox: `enableTerminalSandbox` (boolean, default false)
-//!   - approval mode: `approval_mode` (`default`/`auto_edit`/`yolo`/`plan`),
-//!     where `yolo` skips ALL confirmation and `auto_edit` auto-approves edits.
+//!   - tool permission: `toolPermission` (`request-review` default / `auto-approve`),
+//!     verified against the real `agy` 1.0.4 binary + runtime log. (NOT Gemini's
+//!     `approval_mode` — Antigravity dropped it.)
 //!
 //! UserGlobal scope only for now; the per-repo (`<repo>/.antigravity/settings.json`)
 //! parser needs an `antigravity_workspaces` policy field and is a follow-up.
@@ -71,18 +72,27 @@ pub(crate) fn emit_sandbox(v: &Value, out: &mut Vec<AiGuardReason>) {
     }
 }
 
-/// `approval_mode` (top-level) or `general.defaultApprovalMode` (nested, Gemini
-/// carry-over) in {`yolo`, `auto_edit`} -> AutoApprovalEnabled. `yolo` skips all
-/// tool/command confirmation; `auto_edit` auto-approves edits. `default`/`plan`
-/// are safe.
+/// `toolPermission == "auto-approve"` -> AutoApprovalEnabled (the agent runs
+/// tools without confirmation). `request-review` (the default) is safe.
+///
+/// Verified against the real `agy` 1.0.4 binary + runtime log
+/// (`CLI settings initialized: ... toolPermission=request-review`): the key is
+/// `toolPermission`, NOT Gemini's `approval_mode` (`yolo`/`auto_edit`), which
+/// Antigravity dropped. A truthy `permissions.allowAll` is also flagged.
 pub(crate) fn emit_approval(v: &Value, out: &mut Vec<AiGuardReason>) {
-    let mode = v.get("approval_mode").and_then(Value::as_str).or_else(|| {
-        v.get("general")
-            .and_then(|g| g.get("defaultApprovalMode"))
-            .and_then(Value::as_str)
-    });
-    if let Some(m @ ("yolo" | "auto_edit")) = mode {
-        out.push(AiGuardReason::AutoApprovalEnabled { mode: m.into() });
+    if v.get("toolPermission").and_then(Value::as_str) == Some("auto-approve") {
+        out.push(AiGuardReason::AutoApprovalEnabled {
+            mode: "auto-approve".into(),
+        });
+    } else if v
+        .get("permissions")
+        .and_then(|p| p.get("allowAll"))
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        out.push(AiGuardReason::AutoApprovalEnabled {
+            mode: "allow_all".into(),
+        });
     }
 }
 
@@ -196,33 +206,34 @@ mod tests {
             .any(|r| matches!(r, AiGuardReason::SandboxDisabled)));
     }
     #[test]
-    fn yolo_emits_auto_approval() {
+    fn auto_approve_emits_auto_approval() {
         let d = tempdir().unwrap();
-        write_settings(d.path(), r#"{"approval_mode":"yolo"}"#);
-        assert!(assess(d.path())
-            .iter()
-            .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { mode } if mode == "yolo")));
-    }
-    #[test]
-    fn auto_edit_emits_auto_approval() {
-        let d = tempdir().unwrap();
-        write_settings(d.path(), r#"{"approval_mode":"auto_edit"}"#);
+        write_settings(d.path(), r#"{"toolPermission":"auto-approve"}"#);
         assert!(assess(d.path()).iter().any(
-            |r| matches!(r, AiGuardReason::AutoApprovalEnabled { mode } if mode == "auto_edit")
+            |r| matches!(r, AiGuardReason::AutoApprovalEnabled { mode } if mode == "auto-approve")
         ));
     }
     #[test]
-    fn nested_gemini_carryover_approval_detected() {
+    fn permissions_allow_all_emits_auto_approval() {
         let d = tempdir().unwrap();
-        write_settings(d.path(), r#"{"general":{"defaultApprovalMode":"yolo"}}"#);
+        write_settings(d.path(), r#"{"permissions":{"allowAll":true}}"#);
         assert!(assess(d.path())
             .iter()
             .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })));
     }
     #[test]
-    fn plan_mode_is_safe() {
+    fn request_review_is_safe() {
         let d = tempdir().unwrap();
-        write_settings(d.path(), r#"{"approval_mode":"plan"}"#);
+        write_settings(d.path(), r#"{"toolPermission":"request-review"}"#);
+        assert!(!assess(d.path())
+            .iter()
+            .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })));
+    }
+    #[test]
+    fn gemini_approval_mode_no_longer_matches() {
+        // The old Gemini key was dropped by Antigravity; must NOT false-fire.
+        let d = tempdir().unwrap();
+        write_settings(d.path(), r#"{"approval_mode":"yolo"}"#);
         assert!(!assess(d.path())
             .iter()
             .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })));
@@ -259,7 +270,7 @@ mod tests {
         std::fs::create_dir_all(repo.join(".antigravity")).unwrap();
         std::fs::write(
             repo.join(".antigravity").join("settings.json"),
-            r#"{"enableTerminalSandbox":false,"approval_mode":"yolo"}"#,
+            r#"{"enableTerminalSandbox":false,"toolPermission":"auto-approve"}"#,
         )
         .unwrap();
         let p = AntigravityProjectParser {

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -399,7 +399,8 @@ mod tests {
     fn codex_uses_nested_and_notes_config_toml() {
         let s = render_block("/abs/sigil-hook", "codex", "redacted");
         assert!(s.contains("/abs/sigil-hook codex --capture redacted"));
-        assert!(s.contains(".codex/hooks.json"));
+        // Path-separator-agnostic: PathBuf renders `\` on Windows.
+        assert!(s.contains("codex") && s.contains("hooks.json"));
         assert!(s.contains("config.toml"));
         let mut v = json!({});
         assert!(merge_into(&mut v, "/abs/sigil-hook", "codex", "redacted"));

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -275,19 +275,29 @@ pub fn count_sigil_entries(root: &Value, exe: &str, agent: &str) -> usize {
     }
 }
 
-/// `$XDG_STATE_HOME/sigil` or `$HOME/.local/state/sigil`.
+/// The user's home directory, cross-platform: `HOME` (Unix) or `USERPROFILE`
+/// (Windows, where `HOME` is usually unset).
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var_os("USERPROFILE").filter(|s| !s.is_empty()))
+        .map(PathBuf::from)
+}
+
+/// `$XDG_STATE_HOME/sigil` or `<home>/.local/state/sigil`.
 pub fn state_dir() -> PathBuf {
     if let Ok(base) = std::env::var("XDG_STATE_HOME") {
         PathBuf::from(base).join("sigil")
     } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home).join(".local/state/sigil")
+        home_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join(".local/state/sigil")
     }
 }
 
 /// Map agent name → absolute path to its hook config file.
 pub fn settings_path(agent: &str) -> Option<PathBuf> {
-    let home = PathBuf::from(std::env::var("HOME").ok()?);
+    let home = home_dir()?;
     let p = match agent {
         "claude-code" => home.join(".claude/settings.json"),
         "codex" => home.join(".codex/hooks.json"),


### PR DESCRIPTION
Corrections from **on-hardware verification** — installed the real Antigravity CLI (`agy` 1.0.4) and inspected the binary + runtime + `agy plugin` behavior. Bundled with the Windows CI fix so a single merge restores `main` to green.

## 1. Static parser approval key (corrects #86/#87)
Runtime log: `CLI settings initialized: ... toolPermission=request-review`; `approval_mode`/`yolo`/`auto_edit` appear **0** times in the binary (those were the Gemini keys Antigravity dropped). `emit_approval` now detects `toolPermission == "auto-approve"` (+ `permissions.allowAll`); `request-review` is safe.

## 2. Drop file-based Antigravity install (corrects #89)
`agy plugin list` = "No imported plugins" and hooks load only from an **imported plugin** (`agy plugin install/import`) — a top-level `settings.json` `PreToolUse` is **not read** (verified via agy's own log). A JSON-file merge can't register an Antigravity hook, so `install --agent antigravity` is removed (the runtime `sigil-hook antigravity` entrypoint stays). Codex + Cursor install unchanged. Plugin-bundle install is a follow-up.

## 3. Windows CI fix (the real cause of the red `main`)
`install::settings_path()` read only `$HOME`, unset on Windows → `None` → `render_block` fell back to `"<settings>"` → the codex test's path assertion failed. Added `home_dir()` = `HOME` or `USERPROFILE`; used in `settings_path` + `state_dir`. Verified by simulating the Windows env locally (HOME unset + USERPROFILE set). CI now green on all 5 platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)