### PR TITLE
feat(hook): Antigravity install via agy plugin bundle (#64)

### DIFF
--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -7,10 +7,13 @@
 //       Claude Code: ~/.claude/settings.json
 //       Codex:       ~/.codex/hooks.json   (also needs hooks enabled in
 //                    ~/.codex/config.toml — surfaced as a note)
-//   - Antigravity: TOP-LEVEL `PreToolUse[]` (same entry shape, no `hooks`
-//     wrapper) in ~/.gemini/antigravity-cli/settings.json.
 //   - Cursor: ~/.cursor/hooks.json with `version:1` + per-event arrays
 //     (`beforeShellExecution`, `beforeMCPExecution`) of `{command}`.
+//
+// Antigravity is deliberately absent here: on-hardware verification (real `agy`
+// 1.0.4) proved its hooks are NOT read from any settings.json — they load only
+// from an imported plugin bundle. That install path lives in
+// `install_antigravity.rs` (a directory bundle handed to `agy plugin install`).
 
 use serde_json::{json, Value};
 use std::io;
@@ -21,8 +24,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 enum HookFormat {
     /// `root.hooks.PreToolUse[]` — Claude Code, Codex.
     NestedPreToolUse,
-    /// `root.PreToolUse[]` — Antigravity settings.json (top-level).
-    TopLevelPreToolUse,
     /// `root.version` + `root.hooks.{beforeShellExecution,beforeMCPExecution}[]`.
     Cursor,
 }
@@ -30,7 +31,6 @@ enum HookFormat {
 fn agent_format(agent: &str) -> Option<HookFormat> {
     match agent {
         "claude-code" | "codex" => Some(HookFormat::NestedPreToolUse),
-        "antigravity" => Some(HookFormat::TopLevelPreToolUse),
         "cursor" => Some(HookFormat::Cursor),
         _ => None,
     }
@@ -47,7 +47,7 @@ fn first_token(cmd: &str) -> &str {
     cmd.split_whitespace().next().unwrap_or("")
 }
 
-// --- Claude-style entry helpers (Nested + TopLevel share the entry shape) ---
+// --- Claude-style entry helpers ---
 
 fn claude_entry(cmd: &str) -> Value {
     json!({ "matcher": "*", "hooks": [{ "type": "command", "command": cmd }] })
@@ -78,26 +78,19 @@ fn claude_entry_is_ours(entry: &Value, exe: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Get-or-create the Claude-style PreToolUse array for the given location.
-fn pretooluse_array_mut(root: &mut Value, nested: bool) -> &mut Vec<Value> {
+/// Get-or-create the nested `hooks.PreToolUse` array.
+fn pretooluse_array_mut(root: &mut Value) -> &mut Vec<Value> {
     if !root.is_object() {
         *root = json!({});
     }
-    if nested {
-        if !root["hooks"].is_object() {
-            root["hooks"] = json!({});
-        }
-        let h = &mut root["hooks"];
-        if !h["PreToolUse"].is_array() {
-            h["PreToolUse"] = json!([]);
-        }
-        h["PreToolUse"].as_array_mut().unwrap()
-    } else {
-        if !root["PreToolUse"].is_array() {
-            root["PreToolUse"] = json!([]);
-        }
-        root["PreToolUse"].as_array_mut().unwrap()
+    if !root["hooks"].is_object() {
+        root["hooks"] = json!({});
     }
+    let h = &mut root["hooks"];
+    if !h["PreToolUse"].is_array() {
+        h["PreToolUse"] = json!([]);
+    }
+    h["PreToolUse"].as_array_mut().unwrap()
 }
 
 fn merge_claude(arr: &mut Vec<Value>, exe: &str, cmd: &str) -> bool {
@@ -178,7 +171,6 @@ pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
         .unwrap_or_else(|| "<settings>".into());
     let fragment = match fmt {
         HookFormat::NestedPreToolUse => json!({ "hooks": { "PreToolUse": [claude_entry(&cmd)] } }),
-        HookFormat::TopLevelPreToolUse => json!({ "PreToolUse": [claude_entry(&cmd)] }),
         HookFormat::Cursor => json!({
             "version": 1,
             "hooks": {
@@ -205,12 +197,7 @@ pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
 pub fn merge_into(root: &mut Value, exe: &str, agent: &str, capture: &str) -> bool {
     let cmd = command_string(exe, agent, capture);
     match agent_format(agent) {
-        Some(HookFormat::NestedPreToolUse) => {
-            merge_claude(pretooluse_array_mut(root, true), exe, &cmd)
-        }
-        Some(HookFormat::TopLevelPreToolUse) => {
-            merge_claude(pretooluse_array_mut(root, false), exe, &cmd)
-        }
+        Some(HookFormat::NestedPreToolUse) => merge_claude(pretooluse_array_mut(root), exe, &cmd),
         Some(HookFormat::Cursor) => merge_cursor(root, exe, &cmd),
         None => false,
     }
@@ -220,22 +207,14 @@ pub fn merge_into(root: &mut Value, exe: &str, agent: &str, capture: &str) -> bo
 /// removed. Leaves unrelated hooks untouched.
 pub fn remove_from(root: &mut Value, exe: &str, agent: &str) -> bool {
     match agent_format(agent) {
-        Some(HookFormat::NestedPreToolUse) | Some(HookFormat::TopLevelPreToolUse) => {
-            let nested = agent_format(agent) == Some(HookFormat::NestedPreToolUse);
-            let arr = if nested {
-                root["hooks"]["PreToolUse"].as_array_mut()
-            } else {
-                root["PreToolUse"].as_array_mut()
-            };
-            match arr {
-                Some(a) => {
-                    let before = a.len();
-                    a.retain(|e| !claude_entry_is_ours(e, exe));
-                    a.len() < before
-                }
-                None => false,
+        Some(HookFormat::NestedPreToolUse) => match root["hooks"]["PreToolUse"].as_array_mut() {
+            Some(a) => {
+                let before = a.len();
+                a.retain(|e| !claude_entry_is_ours(e, exe));
+                a.len() < before
             }
-        }
+            None => false,
+        },
         Some(HookFormat::Cursor) => {
             let mut removed = false;
             for ev in CURSOR_EVENTS {
@@ -258,10 +237,6 @@ pub fn count_sigil_entries(root: &Value, exe: &str, agent: &str) -> usize {
             .as_array()
             .map(|a| a.iter().filter(|e| claude_entry_is_ours(e, exe)).count())
             .unwrap_or(0),
-        Some(HookFormat::TopLevelPreToolUse) => root["PreToolUse"]
-            .as_array()
-            .map(|a| a.iter().filter(|e| claude_entry_is_ours(e, exe)).count())
-            .unwrap_or(0),
         Some(HookFormat::Cursor) => CURSOR_EVENTS
             .iter()
             .map(|ev| {
@@ -277,7 +252,7 @@ pub fn count_sigil_entries(root: &Value, exe: &str, agent: &str) -> usize {
 
 /// The user's home directory, cross-platform: `HOME` (Unix) or `USERPROFILE`
 /// (Windows, where `HOME` is usually unset).
-fn home_dir() -> Option<PathBuf> {
+pub fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .filter(|s| !s.is_empty())
         .or_else(|| std::env::var_os("USERPROFILE").filter(|s| !s.is_empty()))
@@ -302,7 +277,6 @@ pub fn settings_path(agent: &str) -> Option<PathBuf> {
         "claude-code" => home.join(".claude/settings.json"),
         "codex" => home.join(".codex/hooks.json"),
         "cursor" => home.join(".cursor/hooks.json"),
-        "antigravity" => home.join(".gemini/antigravity-cli/settings.json"),
         _ => return None,
     };
     Some(p)
@@ -418,28 +392,23 @@ mod tests {
         assert!(v["hooks"]["PreToolUse"].is_array());
     }
 
-    // --- Antigravity (top-level PreToolUse) ---
+    // Antigravity is NOT a settings-merge agent — it installs as an `agy`
+    // plugin bundle (see install_antigravity.rs). The JSON-merge path must
+    // treat it as unsupported so it can never write a settings.json hook that
+    // `agy` silently ignores.
     #[test]
-    fn antigravity_uses_top_level_pretooluse() {
-        let mut v = json!({});
-        assert!(merge_into(
-            &mut v,
-            "/abs/sigil-hook",
-            "antigravity",
-            "redacted"
-        ));
-        // top-level, NOT under hooks
-        assert!(v["PreToolUse"].is_array());
-        assert!(v["hooks"].is_null());
-        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook", "antigravity"), 1);
+    fn antigravity_not_in_settings_merge_path() {
+        assert!(settings_path("antigravity").is_none());
         assert!(!merge_into(
-            &mut v,
+            &mut json!({}),
             "/abs/sigil-hook",
             "antigravity",
             "redacted"
         ));
-        assert!(remove_from(&mut v, "/abs/sigil-hook", "antigravity"));
-        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook", "antigravity"), 0);
+        assert_eq!(
+            count_sigil_entries(&json!({}), "/abs/sigil-hook", "antigravity"),
+            0
+        );
     }
 
     // --- Cursor (version + two event arrays) ---

--- a/crates/sigil-hook/src/install_antigravity.rs
+++ b/crates/sigil-hook/src/install_antigravity.rs
@@ -1,0 +1,191 @@
+// Antigravity (Google `agy` CLI) install. Unlike the JSON-settings agents in
+// install.rs, Antigravity loads hooks ONLY from an imported plugin — on-hardware
+// verification (real `agy` 1.0.4) showed settings.json hooks are silently
+// ignored, while a plugin bundle handed to `agy plugin install <dir>` is loaded
+// (`agy plugin validate` reports "hooks: 1 processed").
+//
+// Canonical bundle layout, verified three ways (`agy plugin validate`, a full
+// install→list→uninstall cycle, and the official `google-antigravity-sdk` /
+// `chrome-devtools-plugin` plugins under ~/.gemini/config/plugins):
+//
+//   <dir>/plugin.json        {name, version, description, license, keywords}
+//   <dir>/hooks/hooks.json   {PreToolUse:[{matcher, hooks:[{type, command}]}]}
+//
+// The `hooks/` subdirectory is required: a root-level hooks.json, an inline
+// `hooks` field in plugin.json, and a hooks.toml are all reported as
+// "hooks: not found". Only `hooks/hooks.json` is processed.
+//
+// `agy plugin install` copies the bundle into ~/.gemini/config/plugins/<name>/
+// and records it in `agy plugin list`; `agy plugin uninstall <name>` reverses it.
+
+use serde_json::{json, Value};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Plugin name `agy` registers it under (also the bundle directory name and the
+/// `agy plugin uninstall` argument).
+pub const PLUGIN_NAME: &str = "sigil-hook";
+
+/// The `antigravity` runtime entrypoint the registered hook invokes.
+fn command_string(exe: &str, capture: &str) -> String {
+    format!("{exe} antigravity --capture {capture}")
+}
+
+/// `<state_dir>/antigravity-plugin/sigil-hook` — the bundle source we
+/// materialize before handing it to `agy plugin install`. Sigil-owned and
+/// stable so re-install/uninstall can find it.
+pub fn staging_dir() -> PathBuf {
+    crate::install::state_dir()
+        .join("antigravity-plugin")
+        .join(PLUGIN_NAME)
+}
+
+/// `<dir>/plugin.json` contents.
+pub fn plugin_json() -> Value {
+    json!({
+        "name": PLUGIN_NAME,
+        "version": env!("CARGO_PKG_VERSION"),
+        "description": "Sigil runtime observer — emits AI agent tool-call events to the local sigil-agent.",
+        "license": "Apache-2.0",
+        "keywords": ["sigil", "security", "observability", "antigravity"],
+    })
+}
+
+/// `<dir>/hooks/hooks.json` contents (bare top-level `PreToolUse`, the only
+/// shape `agy plugin validate` accepts inside a plugin's `hooks/` directory).
+pub fn hooks_json(exe: &str, capture: &str) -> Value {
+    json!({
+        "PreToolUse": [{
+            "matcher": "*",
+            "hooks": [{ "type": "command", "command": command_string(exe, capture) }],
+        }],
+    })
+}
+
+/// Materialize the plugin bundle (`plugin.json` + `hooks/hooks.json`) into
+/// `dir`, creating it (and the `hooks/` subdir) if absent.
+pub fn write_bundle(dir: &Path, exe: &str, capture: &str) -> io::Result<()> {
+    let hooks_dir = dir.join("hooks");
+    std::fs::create_dir_all(&hooks_dir)?;
+    let pj = serde_json::to_string_pretty(&plugin_json()).map_err(io::Error::other)?;
+    std::fs::write(dir.join("plugin.json"), pj.as_bytes())?;
+    let hj = serde_json::to_string_pretty(&hooks_json(exe, capture)).map_err(io::Error::other)?;
+    std::fs::write(hooks_dir.join("hooks.json"), hj.as_bytes())?;
+    Ok(())
+}
+
+/// The `agy` program to invoke: the documented install location
+/// (`<home>/.local/bin/agy`) if present, else bare `agy` (resolved via PATH).
+fn agy_program() -> PathBuf {
+    if let Some(home) = crate::install::home_dir() {
+        let p = home.join(".local/bin/agy");
+        if p.exists() {
+            return p;
+        }
+    }
+    PathBuf::from("agy")
+}
+
+/// Register the bundle with `agy plugin install <dir>`.
+pub fn run_install(dir: &Path) -> io::Result<Output> {
+    Command::new(agy_program())
+        .args(["plugin", "install"])
+        .arg(dir)
+        .output()
+}
+
+/// Deregister with `agy plugin uninstall <PLUGIN_NAME>`.
+pub fn run_uninstall() -> io::Result<Output> {
+    Command::new(agy_program())
+        .args(["plugin", "uninstall", PLUGIN_NAME])
+        .output()
+}
+
+/// Human-readable preview of what `--write` would do (the bundle contents and
+/// the `agy` command), mirroring `install::render_block` for the merge agents.
+pub fn render_block(exe: &str, capture: &str) -> String {
+    let dir = staging_dir();
+    let dir_s = dir.display();
+    let pj = serde_json::to_string_pretty(&plugin_json()).unwrap_or_default();
+    let hj = serde_json::to_string_pretty(&hooks_json(exe, capture)).unwrap_or_default();
+    format!(
+        "// Antigravity registers hooks via an imported plugin, not a settings file.\n\
+         // `sigil-hook install --agent antigravity --write` writes this bundle to\n\
+         //   {dir_s}\n\
+         // then runs: agy plugin install {dir_s}\n\
+         //\n\
+         // {dir_s}/plugin.json:\n\
+         {pj}\n\
+         // {dir_s}/hooks/hooks.json:\n\
+         {hj}\n\
+         // remove with: sigil-hook uninstall --agent antigravity --write\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_json_names_the_plugin_and_carries_version() {
+        let v = plugin_json();
+        assert_eq!(v["name"], json!(PLUGIN_NAME));
+        assert_eq!(v["version"], json!(env!("CARGO_PKG_VERSION")));
+        assert!(v["description"].as_str().unwrap().contains("Sigil"));
+    }
+
+    #[test]
+    fn hooks_json_is_bare_pretooluse_with_command() {
+        let v = hooks_json("/abs/sigil-hook", "redacted");
+        // Top-level PreToolUse (NOT under a `hooks` wrapper) — the shape agy
+        // accepts inside a plugin's hooks/hooks.json.
+        let arr = v["PreToolUse"].as_array().expect("PreToolUse array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["matcher"], json!("*"));
+        let cmd = arr[0]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(cmd, "/abs/sigil-hook antigravity --capture redacted");
+        assert_eq!(arr[0]["hooks"][0]["type"], json!("command"));
+        // No nested `hooks.PreToolUse` — that would be the settings.json shape.
+        assert!(v["hooks"].is_null());
+    }
+
+    #[test]
+    fn hooks_json_threads_capture_level() {
+        let v = hooks_json("/x/sigil-hook", "raw");
+        let cmd = v["PreToolUse"][0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(cmd.ends_with("--capture raw"));
+    }
+
+    #[test]
+    fn write_bundle_creates_canonical_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sigil-hook");
+        write_bundle(&dir, "/abs/sigil-hook", "redacted").unwrap();
+
+        // plugin.json round-trips.
+        let pj: Value =
+            serde_json::from_slice(&std::fs::read(dir.join("plugin.json")).unwrap()).unwrap();
+        assert_eq!(pj["name"], json!(PLUGIN_NAME));
+
+        // hooks live at hooks/hooks.json (the required subdirectory), not root.
+        assert!(!dir.join("hooks.json").exists());
+        let hj: Value =
+            serde_json::from_slice(&std::fs::read(dir.join("hooks/hooks.json")).unwrap()).unwrap();
+        assert_eq!(hj, hooks_json("/abs/sigil-hook", "redacted"));
+    }
+
+    #[test]
+    fn staging_dir_ends_with_plugin_name() {
+        assert!(staging_dir().ends_with(PLUGIN_NAME));
+    }
+
+    #[test]
+    fn render_block_shows_agy_command_and_both_files() {
+        let s = render_block("/abs/sigil-hook", "redacted");
+        assert!(s.contains("agy plugin install"));
+        assert!(s.contains("plugin.json"));
+        assert!(s.contains("hooks/hooks.json"));
+        assert!(s.contains("/abs/sigil-hook antigravity --capture redacted"));
+    }
+}

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,6 +1,7 @@
 mod adapters;
 mod emit;
 mod install;
+mod install_antigravity;
 mod redact;
 
 use sigil_core::hook_proto::*;
@@ -145,7 +146,10 @@ enum Cmd {
         capture: CaptureArg,
     },
 
-    /// Print (or write) the sigil-hook registration into an agent's settings.
+    /// Print (or write) the sigil-hook registration for an agent.
+    ///
+    /// claude-code | codex | cursor merge into a settings JSON file; antigravity
+    /// is registered as an `agy` plugin bundle (`agy plugin install`).
     Install {
         /// Agent to register with: claude-code | codex | cursor | antigravity.
         #[arg(long, default_value = INSTALL_AGENT_DEFAULT)]
@@ -218,6 +222,12 @@ fn cmd_install(agent: &str, write: bool, capture: CaptureArg) {
     };
     let exe = exe_path();
 
+    // Antigravity is not a settings-merge agent: it installs as an `agy` plugin
+    // bundle. Route it through the dedicated path.
+    if agent == "antigravity" {
+        return cmd_install_antigravity(&exe, write, capture_str);
+    }
+
     if !write {
         print!("{}", install::render_block(&exe, agent, capture_str));
         return;
@@ -284,6 +294,10 @@ fn cmd_install(agent: &str, write: bool, capture: CaptureArg) {
 fn cmd_uninstall(agent: &str, write: bool) {
     let exe = exe_path();
 
+    if agent == "antigravity" {
+        return cmd_uninstall_antigravity(write);
+    }
+
     let sp = match install::settings_path(agent) {
         Some(p) => p,
         None => {
@@ -345,4 +359,84 @@ fn cmd_uninstall(agent: &str, write: bool) {
         "sigil-hook: removed {count} entry/entries for {agent} from {}",
         sp.display()
     );
+}
+
+/// Antigravity install: materialize the plugin bundle, then register it with
+/// `agy plugin install`. Without `--write`, print the bundle + command preview.
+fn cmd_install_antigravity(exe: &str, write: bool, capture: &str) {
+    if !write {
+        print!("{}", install_antigravity::render_block(exe, capture));
+        return;
+    }
+
+    let dir = install_antigravity::staging_dir();
+    if let Err(e) = install_antigravity::write_bundle(&dir, exe, capture) {
+        eprintln!(
+            "error writing Antigravity plugin bundle to {}: {e}",
+            dir.display()
+        );
+        std::process::exit(1);
+    }
+
+    match install_antigravity::run_install(&dir) {
+        Ok(out) if out.status.success() => {
+            eprintln!(
+                "sigil-hook: installed Antigravity plugin via agy (bundle: {})",
+                dir.display()
+            );
+        }
+        Ok(out) => {
+            // `agy` ran but rejected the install — surface its diagnostics and
+            // the manual command so the user can finish registration.
+            eprintln!(
+                "sigil-hook: wrote bundle to {} but `agy plugin install` failed:\n{}",
+                dir.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+            eprintln!("run manually: agy plugin install {}", dir.display());
+            std::process::exit(1);
+        }
+        Err(e) => {
+            // `agy` not found / not runnable: the bundle is written, so the user
+            // can register it once `agy` is installed. Not an error exit.
+            eprintln!(
+                "sigil-hook: wrote Antigravity plugin bundle to {} (could not run agy: {e})",
+                dir.display()
+            );
+            eprintln!("register it with: agy plugin install {}", dir.display());
+        }
+    }
+}
+
+/// Antigravity uninstall: deregister via `agy plugin uninstall` and remove the
+/// staged bundle. Without `--write`, print what would happen.
+fn cmd_uninstall_antigravity(write: bool) {
+    let dir = install_antigravity::staging_dir();
+    if !write {
+        eprintln!(
+            "sigil-hook: would run `agy plugin uninstall {}` and remove {} (pass --write to apply)",
+            install_antigravity::PLUGIN_NAME,
+            dir.display()
+        );
+        return;
+    }
+
+    match install_antigravity::run_uninstall() {
+        Ok(out) if out.status.success() => {
+            eprintln!("sigil-hook: removed Antigravity plugin via agy");
+        }
+        Ok(out) => {
+            eprintln!(
+                "sigil-hook: `agy plugin uninstall` returned non-zero:\n{}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "sigil-hook: could not run agy ({e}); remove manually: agy plugin uninstall {}",
+                install_antigravity::PLUGIN_NAME
+            );
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## What

Replaces the (proven-wrong) settings.json install for Antigravity with a real **`agy` plugin-bundle** install.

On-hardware verification (real `agy` 1.0.4) showed Antigravity loads hooks **only** from an imported plugin — hooks written into `~/.gemini/antigravity-cli/settings.json` are silently ignored. The prior path (`HookFormat::TopLevelPreToolUse`) wrote exactly that, so it never registered a working hook.

## Changes

- **`install.rs`**: drop `TopLevelPreToolUse` + the antigravity settings.json mapping. No agent uses the top-level shape anymore, so the merge path simplifies back to nested-only + Cursor.
- **`install_antigravity.rs`** (new): materialize a plugin bundle and register it via `agy plugin install`; `uninstall` via `agy plugin uninstall` + clean the staged bundle. `agy` resolved from `~/.local/bin/agy` or PATH; if absent, the bundle is still written with the manual command printed.
- **`main.rs`**: route `--agent antigravity` through the plugin path; help text updated.

## Canonical bundle layout (verified 3 ways)

`agy plugin validate`, a full install→list→uninstall cycle, and the official `google-antigravity-sdk` / `chrome-devtools-plugin` plugins all agree:

```
<dir>/plugin.json       {name, version, description, license, keywords}
<dir>/hooks/hooks.json   {PreToolUse:[{matcher, hooks:[{type, command}]}]}
```

The `hooks/` subdirectory is **required** — a root `hooks.json`, an inline plugin.json `hooks` field, and `hooks.toml` are all reported `hooks: not found`. Only `hooks/hooks.json` is `processed`.

## Verification (real agy 1.0.4 on macOS)

- Dry-run prints the bundle + `agy plugin install` command.
- `--write` → `agy plugin validate` reports `✔ hooks: 1 processed`; lands at `~/.gemini/config/plugins/sigil-hook/`; registered in `agy plugin list` (`source: local-install`).
- Re-install is idempotent.
- `uninstall --write` deregisters (`No imported plugins.`) and removes the staged bundle.
- `cargo fmt` + `clippy -D warnings` + `cargo test -p sigil-hook` (42 pass, 6 new) green.

> Note: runtime hook *firing* needs an authenticated `agy` session (out of scope for offline CI); the install structure is guaranteed by `validate`/`install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)