### PR TITLE
feat(ai-guard): rule-pack Project scope + per-repo discovery (#53)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mod.rs
@@ -58,6 +58,13 @@ pub trait AiGuardParser: Send + Sync {
     ) -> Vec<std::path::PathBuf> {
         Vec::new()
     }
+
+    /// Phase 3b.7.2 — identity discriminator. None for built-in (structural)
+    /// parsers; rule-pack parsers override to Some(pack id) so the assessment
+    /// StateMap key and emitted event distinguish overlapping (tool, scope).
+    fn rule_pack_id(&self) -> Option<&str> {
+        None
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sigil-agent/src/ai_guard/rule_pack/expand.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/expand.rs
@@ -1,0 +1,73 @@
+//! Phase 3b.7.2 — expand one authored RulePack into runtime parser instances.
+use crate::ai_guard::rule_pack::parser::RulePackParser;
+use sigil_core::policy::{RulePack, RulePackScope};
+use std::path::PathBuf;
+
+/// UserGlobal -> exactly one parser. Project -> one per repo in `repos`
+/// (empty repos -> zero instances). Regex-compile failures are warn-logged and
+/// skipped (consistent with boot/reload behavior).
+pub fn expand_pack_parsers(pack: &RulePack, repos: &[PathBuf]) -> Vec<RulePackParser> {
+    let mut out = Vec::new();
+    match pack.scope {
+        RulePackScope::UserGlobal => match RulePackParser::new(pack.clone()) {
+            Ok(p) => out.push(p),
+            Err(e) => tracing::warn!(id = %pack.id, error = ?e, "rule_pack: load failed; skipping"),
+        },
+        RulePackScope::Project => {
+            for repo in repos {
+                match RulePackParser::new_project(pack.clone(), repo.clone()) {
+                    Ok(p) => out.push(p),
+                    Err(e) => tracing::warn!(id = %pack.id, repo = %repo.display(), error = ?e,
+                        "rule_pack: per-repo load failed; skipping"),
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai_guard::parser::AiGuardParser;
+    use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
+    use sigil_core::policy::{Matcher, RuleEntry, RuleFormat};
+
+    fn base(scope: RulePackScope) -> RulePack {
+        RulePack {
+            id: "p".into(),
+            pack_version: 1,
+            tool: AiTool::Gemini,
+            scope,
+            watched_paths: vec![".gemini/s.json".into()],
+            platforms: None,
+            rules: vec![RuleEntry {
+                id: "r".into(),
+                on_file: ".gemini/s.json".into(),
+                format: RuleFormat::Json,
+                selector: "$.x".into(),
+                matcher: Matcher::Exists,
+                emit: AiGuardReason::SandboxDisabled,
+            }],
+        }
+    }
+    #[test]
+    fn user_global_expands_to_one() {
+        assert_eq!(
+            expand_pack_parsers(&base(RulePackScope::UserGlobal), &[]).len(),
+            1
+        );
+    }
+    #[test]
+    fn project_expands_per_repo() {
+        let repos = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        let ps = expand_pack_parsers(&base(RulePackScope::Project), &repos);
+        assert_eq!(ps.len(), 2);
+        assert_eq!(ps[0].scope(), AiGuardScope::Project { path: "/a".into() });
+        assert_eq!(ps[1].scope(), AiGuardScope::Project { path: "/b".into() });
+    }
+    #[test]
+    fn project_with_no_repos_expands_to_zero() {
+        assert!(expand_pack_parsers(&base(RulePackScope::Project), &[]).is_empty());
+    }
+}

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -20,12 +20,23 @@ pub fn pack_is_loadable(pack: &sigil_core::policy::RulePack) -> bool {
         );
         return false;
     }
-    if !matches!(pack.scope, sigil_core::policy::RulePackScope::UserGlobal) {
-        tracing::warn!(
-            id = %pack.id, scope = ?pack.scope,
-            "rule_pack: Project scope not yet enabled; skipping"
-        );
-        return false;
+    match pack.scope {
+        sigil_core::policy::RulePackScope::UserGlobal => {}
+        sigil_core::policy::RulePackScope::Project => {
+            // Project on_file paths are resolved relative to each repo_root, so an
+            // absolute path is an authoring error — reject the whole pack loudly.
+            if let Some(bad) = pack
+                .rules
+                .iter()
+                .find(|r| std::path::Path::new(&r.on_file).is_absolute())
+            {
+                tracing::warn!(
+                    id = %pack.id, rule = %bad.id, on_file = %bad.on_file,
+                    "rule_pack: Project scope requires relative on_file; skipping pack"
+                );
+                return false;
+            }
+        }
     }
     if let Some(plats) = &pack.platforms {
         if !plats.is_empty() && !plats.contains(&sigil_core::policy::current_platform()) {
@@ -33,4 +44,54 @@ pub fn pack_is_loadable(pack: &sigil_core::policy::RulePack) -> bool {
         }
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigil_core::event::{AiGuardReason, AiTool};
+    use sigil_core::policy::{Matcher, RuleEntry, RuleFormat, RulePack, RulePackScope};
+
+    fn pack(scope: RulePackScope, on_file: &str) -> RulePack {
+        RulePack {
+            id: "p".into(),
+            pack_version: 1,
+            tool: AiTool::Gemini,
+            scope,
+            watched_paths: vec![],
+            platforms: None,
+            rules: vec![RuleEntry {
+                id: "r".into(),
+                on_file: on_file.into(),
+                format: RuleFormat::Json,
+                selector: "$.x".into(),
+                matcher: Matcher::Exists,
+                emit: AiGuardReason::SandboxDisabled,
+            }],
+        }
+    }
+
+    #[test]
+    fn project_scope_is_loadable() {
+        assert!(pack_is_loadable(&pack(
+            RulePackScope::Project,
+            ".gemini/x.json"
+        )));
+    }
+
+    #[test]
+    fn project_with_absolute_on_file_rejected() {
+        assert!(!pack_is_loadable(&pack(
+            RulePackScope::Project,
+            "/abs/x.json"
+        )));
+    }
+
+    #[test]
+    fn user_global_with_absolute_on_file_still_ok() {
+        assert!(pack_is_loadable(&pack(
+            RulePackScope::UserGlobal,
+            "/abs/x.json"
+        )));
+    }
 }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -20,10 +20,10 @@ pub fn pack_is_loadable(pack: &sigil_core::policy::RulePack) -> bool {
         );
         return false;
     }
-    if !matches!(pack.scope, sigil_core::event::AiGuardScope::UserGlobal) {
+    if !matches!(pack.scope, sigil_core::policy::RulePackScope::UserGlobal) {
         tracing::warn!(
             id = %pack.id, scope = ?pack.scope,
-            "rule_pack: MVP supports UserGlobal scope only; skipping"
+            "rule_pack: Project scope not yet enabled; skipping"
         );
         return false;
     }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -24,13 +24,18 @@ pub fn pack_is_loadable(pack: &sigil_core::policy::RulePack) -> bool {
     match pack.scope {
         sigil_core::policy::RulePackScope::UserGlobal => {}
         sigil_core::policy::RulePackScope::Project => {
-            // Project on_file paths are resolved relative to each repo_root, so an
-            // absolute path is an authoring error — reject the whole pack loudly.
-            if let Some(bad) = pack
-                .rules
-                .iter()
-                .find(|r| std::path::Path::new(&r.on_file).is_absolute())
-            {
+            // Project on_file paths are resolved relative to each repo_root, so a
+            // rooted path is an authoring error — reject the whole pack loudly.
+            // Check the first component rather than `is_absolute()`: on Windows a
+            // leading-slash path (`/abs/x`) is NOT `is_absolute` (it lacks a drive
+            // prefix) yet is still rooted, not repo-relative. RootDir covers
+            // `/x` and `\x`; Prefix covers `C:\x` / UNC.
+            if let Some(bad) = pack.rules.iter().find(|r| {
+                matches!(
+                    std::path::Path::new(&r.on_file).components().next(),
+                    Some(std::path::Component::RootDir | std::path::Component::Prefix(_))
+                )
+            }) {
                 tracing::warn!(
                     id = %pack.id, rule = %bad.id, on_file = %bad.on_file,
                     "rule_pack: Project scope requires relative on_file; skipping pack"

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -2,6 +2,7 @@
 //! sigil-rules-basic defaults + operator policy.yaml overlay and runs
 //! Tier 1 DSL (path glob + JSON/TOML selector + matcher → AiGuardReason emit).
 
+pub mod expand;
 pub mod matcher;
 pub mod parser;
 pub mod selector;

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -33,6 +33,28 @@ impl RulePackParser {
             repo_root: None,
         })
     }
+
+    /// Phase 3b.7.2 — a Project-scoped instance bound to one discovered repo.
+    /// on_file / watched_paths are resolved relative to `repo_root`.
+    pub fn new_project(
+        pack: RulePack,
+        repo_root: std::path::PathBuf,
+    ) -> Result<Self, PackLoadError> {
+        let mut p = Self::new(pack)?;
+        p.repo_root = Some(repo_root);
+        Ok(p)
+    }
+
+    /// UserGlobal: env-expand the raw path (absolute). Project: join the raw
+    /// (relative) path under repo_root.
+    fn resolve(&self, raw: &str) -> Option<PathBuf> {
+        match &self.repo_root {
+            Some(root) => Some(root.join(raw)),
+            None => {
+                sigil_core::policy::expand::expand(raw, &sigil_core::policy::expand::EnvLookup).ok()
+            }
+        }
+    }
 }
 
 impl AiGuardParser for RulePackParser {
@@ -49,27 +71,27 @@ impl AiGuardParser for RulePackParser {
         }
     }
 
+    fn rule_pack_id(&self) -> Option<&str> {
+        Some(&self.pack.id)
+    }
+
     fn watched_paths(&self, _home: &Path) -> Vec<PathBuf> {
         self.pack
             .watched_paths
             .iter()
-            .filter_map(|raw| {
-                sigil_core::policy::expand::expand(raw, &sigil_core::policy::expand::EnvLookup).ok()
-            })
+            .filter_map(|raw| self.resolve(raw))
             .collect()
     }
 
     fn assess(&self, _home: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
         let mut out = Vec::new();
         for (idx, rule) in self.pack.rules.iter().enumerate() {
-            let file_path = sigil_core::policy::expand::expand(
-                &rule.on_file,
-                &sigil_core::policy::expand::EnvLookup,
-            )
-            .map_err(|e| AssessError::Parse {
-                path: PathBuf::from(&rule.on_file),
-                message: format!("expand: {e:?}"),
-            })?;
+            let Some(file_path) = self.resolve(&rule.on_file) else {
+                return Err(AssessError::Parse {
+                    path: PathBuf::from(&rule.on_file),
+                    message: "resolve failed".into(),
+                });
+            };
 
             let text = match std::fs::read_to_string(&file_path) {
                 Ok(s) => s,
@@ -271,5 +293,35 @@ mod tests {
         let p = RulePackParser::new(pack).unwrap();
         assert_eq!(p.tool(), AiTool::Gemini);
         assert!(matches!(p.scope(), AiGuardScope::UserGlobal));
+    }
+
+    #[test]
+    fn new_project_resolves_on_file_under_repo_root() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repoA");
+        std::fs::create_dir_all(repo.join(".gemini")).unwrap();
+        std::fs::write(repo.join(".gemini/settings.json"), r#"{"sandbox": false}"#).unwrap();
+
+        let mut pack = pack_with_one_rule(
+            ".gemini/settings.json",
+            "$.sandbox",
+            Matcher::Equals {
+                value: "false".into(),
+            },
+            AiGuardReason::SandboxDisabled,
+        );
+        pack.scope = RulePackScope::Project;
+        pack.watched_paths = vec![".gemini/settings.json".into()];
+
+        let p = RulePackParser::new_project(pack, repo.clone()).unwrap();
+        assert_eq!(p.scope(), AiGuardScope::Project { path: repo.clone() });
+        assert_eq!(p.rule_pack_id(), Some("test-pack"));
+        assert_eq!(
+            p.watched_paths(Path::new("/unused")),
+            vec![repo.join(".gemini/settings.json")]
+        );
+        let out = p.assess(Path::new("/unused")).unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out[0], AiGuardReason::SandboxDisabled));
     }
 }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -4,13 +4,14 @@ use crate::ai_guard::parser::{AiGuardParser, AssessError};
 use crate::ai_guard::rule_pack::matcher::{compile_pack_regexes, matches_value, CompileError};
 use crate::ai_guard::rule_pack::selector::{eval_json, eval_toml, MatchedValue};
 use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
-use sigil_core::policy::{RuleFormat, RulePack};
+use sigil_core::policy::{RuleFormat, RulePack, RulePackScope};
 use std::path::{Path, PathBuf};
 
 pub struct RulePackParser {
     pub pack: RulePack,
     /// Compiled regexes parallel to pack.rules (None when matcher != Regex).
     compiled_regexes: Vec<Option<regex::Regex>>,
+    pub(crate) repo_root: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -29,6 +30,7 @@ impl RulePackParser {
         Ok(Self {
             pack,
             compiled_regexes,
+            repo_root: None,
         })
     }
 }
@@ -39,7 +41,12 @@ impl AiGuardParser for RulePackParser {
     }
 
     fn scope(&self) -> AiGuardScope {
-        self.pack.scope.clone()
+        match self.pack.scope {
+            RulePackScope::UserGlobal => AiGuardScope::UserGlobal,
+            RulePackScope::Project => AiGuardScope::Project {
+                path: self.repo_root.clone().unwrap_or_default(),
+            },
+        }
     }
 
     fn watched_paths(&self, _home: &Path) -> Vec<PathBuf> {
@@ -122,7 +129,7 @@ fn interpolate_reason(reason: &AiGuardReason, matched: &MatchedValue) -> AiGuard
 mod tests {
     use super::*;
     use sigil_core::event::AiGuardReason;
-    use sigil_core::policy::{Matcher, RuleEntry, RuleFormat, RulePack};
+    use sigil_core::policy::{Matcher, RuleEntry, RuleFormat, RulePack, RulePackScope};
     use tempfile::tempdir;
 
     fn pack_with_one_rule(
@@ -135,7 +142,7 @@ mod tests {
             id: "test-pack".into(),
             pack_version: 1,
             tool: AiTool::Gemini,
-            scope: AiGuardScope::UserGlobal,
+            scope: RulePackScope::UserGlobal,
             watched_paths: vec![on_file_abs.into()],
             platforms: None,
             rules: vec![RuleEntry {
@@ -236,7 +243,7 @@ mod tests {
             id: "bad-regex".into(),
             pack_version: 1,
             tool: AiTool::Gemini,
-            scope: AiGuardScope::UserGlobal,
+            scope: RulePackScope::UserGlobal,
             watched_paths: vec![],
             platforms: None,
             rules: vec![RuleEntry {

--- a/crates/sigil-agent/src/ai_guard/task.rs
+++ b/crates/sigil-agent/src/ai_guard/task.rs
@@ -27,10 +27,12 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::sync::{broadcast, mpsc};
 
-/// Shared state map keyed by `(tool, scope)`. Persists between calls so
-/// `eval_and_maybe_emit` can deduplicate identical reason sets across
-/// triggers. Read by the operator IPC handler (Task 7) for `sigil show risk`.
-pub type StateMap = HashMap<(AiTool, AiGuardScope), CachedAssessment>;
+/// Shared state map keyed by `(tool, scope, pack_id)`. Persists between calls
+/// so `eval_and_maybe_emit` can deduplicate identical reason sets across
+/// triggers. The `pack_id` dimension ensures two parsers sharing the same
+/// (tool, scope) but belonging to different rule packs never collide.
+/// Read by the operator IPC handler (Task 7) for `sigil show risk`.
+pub type StateMap = HashMap<(AiTool, AiGuardScope, Option<String>), CachedAssessment>;
 
 /// One parser's last emitted state, kept in `StateMap` for change-detection
 /// and IPC introspection. The `reasons_blake3` field is what
@@ -161,7 +163,11 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
     let score = rubric_snapshot.score(&reasons);
     let bucket = rubric::bucket(score);
     let reasons_hash = rubric::canonical_hash(&reasons);
-    let key = (parser.tool(), parser.scope());
+    let key = (
+        parser.tool(),
+        parser.scope(),
+        parser.rule_pack_id().map(|s| s.to_string()),
+    );
     let prev = ctx.state.read().get(&key).cloned();
     let changed = prev
         .as_ref()
@@ -196,12 +202,12 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
         subject: Subject::Self_,
         evidence: Evidence::AiGuardRiskAssessed {
             tool: key.0,
-            scope: key.1,
+            scope: key.1.clone(),
             score,
             bucket,
             reasons,
             is_reattestation,
-            rule_pack_id: None,
+            rule_pack_id: key.2.clone(),
         },
         target_id: None,
     };
@@ -231,6 +237,8 @@ mod tests {
     /// Test parser whose `assess()` returns scripted reason sets in order.
     struct ScriptedParser {
         tool: AiTool,
+        scope: AiGuardScope,
+        pack_id: Option<String>,
         scripts: StdMutex<Vec<Vec<AiGuardReason>>>,
         watched: Vec<PathBuf>,
     }
@@ -240,7 +248,10 @@ mod tests {
             self.tool
         }
         fn scope(&self) -> AiGuardScope {
-            AiGuardScope::UserGlobal
+            self.scope.clone()
+        }
+        fn rule_pack_id(&self) -> Option<&str> {
+            self.pack_id.as_deref()
         }
         fn watched_paths(&self, _home: &std::path::Path) -> Vec<PathBuf> {
             self.watched.clone()
@@ -284,6 +295,8 @@ mod tests {
         let (_tx, fc_rx) = broadcast::channel(8);
         let parser = ScriptedParser {
             tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
             scripts: StdMutex::new(vec![vec![]]),
             watched: vec![PathBuf::from("/tmp/test-home/.claude/settings.json")],
         };
@@ -320,6 +333,8 @@ mod tests {
         let watched = PathBuf::from("/tmp/test-home/.claude/settings.json");
         let parser = ScriptedParser {
             tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty], // boot
                 vec![AiGuardReason::PermissionsDenyEmpty], // identical → no emit
@@ -345,6 +360,8 @@ mod tests {
         let watched = PathBuf::from("/tmp/test-home/.claude/settings.json");
         let parser = ScriptedParser {
             tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty],
                 vec![AiGuardReason::SandboxDisabled],
@@ -373,6 +390,8 @@ mod tests {
         let (_tx, fc_rx) = broadcast::channel(8);
         let parser = ScriptedParser {
             tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty],
                 vec![AiGuardReason::PermissionsDenyEmpty], // heartbeat — same
@@ -446,6 +465,8 @@ mod tests {
         let (_tx, fc_rx) = broadcast::channel(8);
         let parser = ScriptedParser {
             tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty], // boot
                 vec![AiGuardReason::SandboxDisabled],      // heartbeat — different
@@ -469,5 +490,48 @@ mod tests {
             other => panic!("got {other:?}"),
         }
         h.abort();
+    }
+
+    #[tokio::test]
+    async fn distinct_pack_ids_do_not_collide_in_state() {
+        let (_fc_tx, fc_rx) = broadcast::channel(8);
+        let (event_tx, _events) = mpsc::channel(16);
+        let state: Arc<RwLock<StateMap>> = Arc::new(RwLock::new(HashMap::new()));
+        let ctx = TaskCtx {
+            parsers: Arc::new(RwLock::new(vec![])),
+            fc_rx,
+            event_tx,
+            state: state.clone(),
+            heartbeat_interval: Duration::from_secs(24 * 3600),
+            home_dir: PathBuf::from("/tmp/test-home"),
+            host_id: "test-host".into(),
+            ext_scripts: crate::ai_guard::empty_ext_script_registry(),
+            rubric: crate::ai_guard::default_rubric_handle(),
+        };
+        // Parser A: tool=Gemini, scope=Project{path:"/r"}, pack_id=Some("pack-a"),
+        //   scripts=[vec![AiGuardReason::SandboxDisabled]]
+        let a = ScriptedParser {
+            tool: AiTool::Gemini,
+            scope: AiGuardScope::Project { path: "/r".into() },
+            pack_id: Some("pack-a".to_string()),
+            scripts: StdMutex::new(vec![vec![AiGuardReason::SandboxDisabled]]),
+            watched: vec![],
+        };
+        // Parser B: tool=Gemini, scope=Project{path:"/r"}, pack_id=Some("pack-b"),
+        //   scripts=[vec![]]  (clean)
+        let b = ScriptedParser {
+            tool: AiTool::Gemini,
+            scope: AiGuardScope::Project { path: "/r".into() },
+            pack_id: Some("pack-b".to_string()),
+            scripts: StdMutex::new(vec![vec![]]),
+            watched: vec![],
+        };
+        eval_and_maybe_emit(&a, &ctx, true).await;
+        eval_and_maybe_emit(&b, &ctx, true).await;
+        let scope = AiGuardScope::Project { path: "/r".into() };
+        let s = ctx.state.read();
+        assert!(s.contains_key(&(AiTool::Gemini, scope.clone(), Some("pack-a".to_string()))));
+        assert!(s.contains_key(&(AiTool::Gemini, scope.clone(), Some("pack-b".to_string()))));
+        assert_eq!(s.len(), 2);
     }
 }

--- a/crates/sigil-agent/src/ai_guard/task.rs
+++ b/crates/sigil-agent/src/ai_guard/task.rs
@@ -201,6 +201,7 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
             bucket,
             reasons,
             is_reattestation,
+            rule_pack_id: None,
         },
         target_id: None,
     };

--- a/crates/sigil-agent/src/control.rs
+++ b/crates/sigil-agent/src/control.rs
@@ -224,11 +224,11 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
             let snapshot = ctx.ai_guard_state.read();
             let mut assessments: Vec<RiskSummary> = snapshot
                 .iter()
-                .filter(|((t, _scope), _)| match tool {
+                .filter(|((t, _scope, _pid), _)| match tool {
                     Some(filter) => *t == filter,
                     None => true,
                 })
-                .map(|((t, scope), cached)| {
+                .map(|((t, scope, _pid), cached)| {
                     let last = cached
                         .last_assessed_ts
                         .format(&time::format_description::well_known::Rfc3339)
@@ -326,7 +326,7 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
             let snapshot = ctx.ai_guard_state.read();
             let mut latest_risk: Vec<RiskSummary> = snapshot
                 .iter()
-                .map(|((t, scope), cached)| {
+                .map(|((t, scope, _pid), cached)| {
                     let last = cached
                         .last_assessed_ts
                         .format(&time::format_description::well_known::Rfc3339)

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -80,6 +80,7 @@ fn reconcile_rule_packs(
     state: &Arc<parking_lot::RwLock<crate::ai_guard::task::StateMap>>,
     new_packs: &[sigil_core::policy::RulePack],
 ) -> (Vec<String>, Vec<String>) {
+    use crate::ai_guard::parser::AiGuardParser;
     use std::collections::HashSet;
 
     let new_ids: HashSet<String> = new_packs
@@ -102,7 +103,7 @@ fn reconcile_rule_packs(
             if new_ids.contains(&id) {
                 true
             } else {
-                removed_scopes.push((rpp.pack.tool, rpp.pack.scope.clone()));
+                removed_scopes.push((rpp.pack.tool, rpp.scope()));
                 false
             }
         } else {

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -42,6 +42,15 @@ where
 {
     let mut old_repos: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
     guard.retain(|p| {
+        // Task 6 — rule-pack parsers (also Project-scoped) are owned by
+        // `reconcile_rule_packs`; never reconcile them here or this built-in
+        // reconcile would drop them and miss their `Some(pack_id)` state keys.
+        if p.as_any()
+            .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
+            .is_some()
+        {
+            return true;
+        }
         if p.tool() == tool {
             if let sigil_core::event::AiGuardScope::Project { path } = p.scope() {
                 old_repos.insert(path.clone());
@@ -70,78 +79,71 @@ where
     (added, removed)
 }
 
-/// Phase 3b.7 — reconcile rule pack parsers during hot-reload. Downcasts
-/// existing parsers via `as_any()` to identify rule pack parsers by id, diffs
-/// the old id set against the new (loadable) one, drops removed packs (and
-/// cleans up their (tool, scope) entries from the ai_guard state map), and
-/// pushes freshly-compiled parsers for newly-added packs. Returns
-/// (added_ids, removed_ids) for tracing + observability.
+/// Phase 3b.7 + Task 6 — reconcile rule pack parsers during hot-reload via a
+/// full rebuild. Every rule-pack parser (UserGlobal and per-repo Project) is
+/// dropped and re-expanded from the new loadable pack set through
+/// `expand_pack_parsers`, so Project packs correctly add/drop one parser per
+/// discovered repo. State-map entries whose `(tool, scope, Some(id))` identity
+/// no longer exists are evicted. Returns `(added_ids, removed_ids)` — diffed at
+/// PACK-ID granularity for tracing + observability.
 fn reconcile_rule_packs(
     guard: &mut parking_lot::RwLockWriteGuard<Vec<Arc<dyn crate::ai_guard::parser::AiGuardParser>>>,
     state: &Arc<parking_lot::RwLock<crate::ai_guard::task::StateMap>>,
     new_packs: &[sigil_core::policy::RulePack],
+    repos_for_tool: &dyn Fn(sigil_core::event::AiTool) -> Vec<PathBuf>,
 ) -> (Vec<String>, Vec<String>) {
     use crate::ai_guard::parser::AiGuardParser;
     use std::collections::HashSet;
-
-    let new_ids: HashSet<String> = new_packs
-        .iter()
-        .filter(|p| crate::ai_guard::rule_pack::pack_is_loadable(p))
-        .map(|p| p.id.clone())
-        .collect();
-
-    let mut old_ids: HashSet<String> = HashSet::new();
-    let mut removed_scopes: Vec<(
+    type Ident = (
         sigil_core::event::AiTool,
         sigil_core::event::AiGuardScope,
-        Option<String>,
-    )> = Vec::new();
+        String,
+    );
 
+    // 1. Record old identities + old pack-id set; drop all rule-pack parsers
+    //    (keep built-ins).
+    let mut old_keys: HashSet<Ident> = HashSet::new();
+    let mut old_pack_ids: HashSet<String> = HashSet::new();
     guard.retain(|p| {
         if let Some(rpp) = p
             .as_any()
             .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
         {
-            let id = rpp.pack.id.clone();
-            old_ids.insert(id.clone());
-            if new_ids.contains(&id) {
-                true
-            } else {
-                removed_scopes.push((
-                    rpp.pack.tool,
-                    rpp.scope(),
-                    rpp.rule_pack_id().map(|s| s.to_string()),
-                ));
-                false
-            }
+            old_pack_ids.insert(rpp.pack.id.clone());
+            old_keys.insert((p.tool(), p.scope(), rpp.pack.id.clone()));
+            false
         } else {
             true
         }
     });
 
-    let added: Vec<String> = new_ids.difference(&old_ids).cloned().collect();
-    let removed: Vec<String> = old_ids.difference(&new_ids).cloned().collect();
-
-    for pack in new_packs.iter().filter(|p| added.contains(&p.id)) {
+    // 2. Re-expand loadable packs; record new identities + pack-id set.
+    let mut new_keys: HashSet<Ident> = HashSet::new();
+    let mut new_pack_ids: HashSet<String> = HashSet::new();
+    for pack in new_packs {
         if !crate::ai_guard::rule_pack::pack_is_loadable(pack) {
             continue;
         }
-        match crate::ai_guard::rule_pack::parser::RulePackParser::new(pack.clone()) {
-            Ok(p) => guard.push(Arc::new(p)),
-            Err(e) => tracing::warn!(
-                id = %pack.id, error = ?e,
-                "rule_pack: reload load failed; skipping"
-            ),
+        new_pack_ids.insert(pack.id.clone());
+        let repos = repos_for_tool(pack.tool);
+        for parser in crate::ai_guard::rule_pack::expand::expand_pack_parsers(pack, &repos) {
+            new_keys.insert((parser.tool(), parser.scope(), pack.id.clone()));
+            guard.push(Arc::new(parser));
         }
     }
 
-    if !removed_scopes.is_empty() {
+    // 3. Prune vanished state identities (old − new).
+    let gone: Vec<Ident> = old_keys.difference(&new_keys).cloned().collect();
+    if !gone.is_empty() {
         let mut s = state.write();
-        for (tool, scope, pack_id) in &removed_scopes {
-            s.remove(&(*tool, scope.clone(), pack_id.clone()));
+        for (tool, scope, id) in gone {
+            s.remove(&(tool, scope, Some(id)));
         }
     }
 
+    // 4. Tracing diffs at pack-id granularity.
+    let added: Vec<String> = new_pack_ids.difference(&old_pack_ids).cloned().collect();
+    let removed: Vec<String> = old_pack_ids.difference(&new_pack_ids).cloned().collect();
     (added, removed)
 }
 
@@ -270,6 +272,30 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
         )
         .into_iter()
         .collect();
+    // Task 6 — discovered ONLY for rule-pack expansion below (no built-in
+    // AntigravityProjectParser reconcile here; that gap is pre-existing).
+    let new_antigravity: std::collections::BTreeSet<PathBuf> =
+        crate::ai_guard::workspace_discovery::discover_per_repo(
+            &effective.antigravity_workspaces,
+            ".antigravity/settings.json",
+        )
+        .into_iter()
+        .collect();
+
+    // Task 6 — exhaustive AiTool -> repos lookup for Project rule-pack
+    // expansion (used by reconcile_rule_packs and the synthetic-target loop).
+    let repos_for_tool = |tool: sigil_core::event::AiTool| -> Vec<PathBuf> {
+        use sigil_core::event::AiTool::*;
+        match tool {
+            ContinueDev => new_continue.iter().cloned().collect(),
+            ClaudeCode => new_claude.iter().cloned().collect(),
+            Codex => new_codex.iter().cloned().collect(),
+            Gemini => new_gemini.iter().cloned().collect(),
+            Cursor => new_cursor.iter().cloned().collect(),
+            Antigravity => new_antigravity.iter().cloned().collect(),
+            ClaudeDesktop => Vec::new(),
+        }
+    };
 
     let (
         continue_added,
@@ -321,8 +347,12 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
             &new_cursor,
             |p| crate::ai_guard::CursorProjectParser { repo_root: p },
         );
-        let (rp_added, rp_removed) =
-            reconcile_rule_packs(&mut guard, &ctx.ai_guard_state, &effective.rule_packs);
+        let (rp_added, rp_removed) = reconcile_rule_packs(
+            &mut guard,
+            &ctx.ai_guard_state,
+            &effective.rule_packs,
+            &repos_for_tool,
+        );
         (a1, r1, a2, r2, a3, r3, a4, r4, a5, r5, rp_added, rp_removed)
     };
 
@@ -341,6 +371,24 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
     }
     for repo_root in &new_cursor {
         crate::runtime::push_cursor_synthetic_target(&mut effective, repo_root);
+    }
+    // Task 6 — synthetic WatchTargets for Project-scoped rule packs, one per
+    // discovered repo for the pack's tool (mirrors boot-time instantiation).
+    // Clone the relevant packs first so the loop doesn't hold an immutable
+    // borrow of `effective` while `push_rule_pack_synthetic_targets` mutates it.
+    let project_packs: Vec<sigil_core::policy::RulePack> = effective
+        .rule_packs
+        .iter()
+        .filter(|p| {
+            crate::ai_guard::rule_pack::pack_is_loadable(p)
+                && matches!(p.scope, sigil_core::policy::RulePackScope::Project)
+        })
+        .cloned()
+        .collect();
+    for pack in &project_packs {
+        for repo in repos_for_tool(pack.tool) {
+            crate::runtime::push_rule_pack_synthetic_targets(&mut effective, pack, &repo);
+        }
     }
 
     tracing::info!(
@@ -990,5 +1038,134 @@ mod tests {
             })
             .count();
         assert_eq!(default_count, 0);
+    }
+
+    // Task 6 — Project-scoped rule pack hot-reload reconciliation: when a repo
+    // is removed from disk, the per-repo RulePackParser AND its state entry are
+    // pruned.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reload_project_pack_prunes_removed_repo() {
+        use crate::ai_guard::parser::AiGuardParser;
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("ws");
+        let repo_a = workspace.join("repoA");
+        let repo_b = workspace.join("repoB");
+        std::fs::create_dir_all(repo_a.join(".gemini")).unwrap();
+        std::fs::create_dir_all(repo_b.join(".gemini")).unwrap();
+        std::fs::write(
+            repo_a.join(".gemini").join("settings.json"),
+            r#"{"sandbox": false}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            repo_b.join(".gemini").join("settings.json"),
+            r#"{"sandbox": false}"#,
+        )
+        .unwrap();
+        let canonical_a = dunce::canonicalize(&repo_a).unwrap();
+        let canonical_b = dunce::canonicalize(&repo_b).unwrap();
+
+        let pack_id = "proj-pack";
+        let policy = format!(
+            "version: 1\nhost_id_strategy: machine_id\ngemini_workspaces:\n  - '{}'\ntargets: []\nrule_packs:\n  - id: {pack_id}\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: project\n    watched_paths:\n      - '.gemini/settings.json'\n    rules:\n      - id: r1\n        on_file: '.gemini/settings.json'\n        format: json\n        selector: '$.sandbox'\n        matcher:\n          kind: exists\n        emit:\n          kind: sandbox_disabled\n",
+            workspace.display()
+        );
+        let (mut ctx, plat, _trx, parsers, state) = build_ctx_with_parsers(dir.path(), &policy);
+
+        // Initial reconcile: drive reload so both repoA and repoB get a
+        // Project-scoped RulePackParser.
+        reload(&mut ctx, &plat);
+        {
+            let guard = parsers.read();
+            let proj_packs: Vec<_> = guard
+                .iter()
+                .filter_map(|p| {
+                    p.as_any()
+                        .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
+                })
+                .filter(|rpp| rpp.pack.id == pack_id)
+                .map(|rpp| rpp.scope())
+                .collect();
+            assert_eq!(
+                proj_packs.len(),
+                2,
+                "expected 2 per-repo rule pack parsers (repoA, repoB), got {proj_packs:?}"
+            );
+        }
+
+        // Plant state entries for both repos to verify pruning of repoB.
+        {
+            let mut s = state.write();
+            for path in [&canonical_a, &canonical_b] {
+                s.insert(
+                    (
+                        sigil_core::event::AiTool::Gemini,
+                        sigil_core::event::AiGuardScope::Project { path: path.clone() },
+                        Some(pack_id.to_string()),
+                    ),
+                    crate::ai_guard::task::CachedAssessment {
+                        score: 5.0,
+                        bucket: sigil_core::event::AiGuardBucket::High,
+                        reasons_blake3: [0u8; 32],
+                        reasons_count: 1,
+                        last_assessed_ts: time::OffsetDateTime::now_utc(),
+                    },
+                );
+            }
+        }
+
+        // Remove repoB from disk and reload (policy unchanged).
+        std::fs::remove_dir_all(&repo_b).unwrap();
+        reload(&mut ctx, &plat);
+
+        {
+            let guard = parsers.read();
+            let proj_scopes: Vec<_> = guard
+                .iter()
+                .filter_map(|p| {
+                    p.as_any()
+                        .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
+                })
+                .filter(|rpp| rpp.pack.id == pack_id)
+                .map(|rpp| rpp.scope())
+                .collect();
+            assert_eq!(
+                proj_scopes.len(),
+                1,
+                "expected exactly 1 remaining rule pack parser after repoB removed, got {proj_scopes:?}"
+            );
+            assert_eq!(
+                proj_scopes[0],
+                sigil_core::event::AiGuardScope::Project {
+                    path: canonical_a.clone()
+                },
+                "remaining parser should be repoA"
+            );
+        }
+        {
+            let s = state.read();
+            let key_b = (
+                sigil_core::event::AiTool::Gemini,
+                sigil_core::event::AiGuardScope::Project {
+                    path: canonical_b.clone(),
+                },
+                Some(pack_id.to_string()),
+            );
+            assert!(
+                !s.contains_key(&key_b),
+                "state entry for removed repoB should be pruned"
+            );
+            let key_a = (
+                sigil_core::event::AiTool::Gemini,
+                sigil_core::event::AiGuardScope::Project {
+                    path: canonical_a.clone(),
+                },
+                Some(pack_id.to_string()),
+            );
+            assert!(
+                s.contains_key(&key_a),
+                "state entry for surviving repoA should remain"
+            );
+        }
     }
 }

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -63,6 +63,7 @@ where
                 sigil_core::event::AiGuardScope::Project {
                     path: repo_root.clone(),
                 },
+                None::<String>,
             ));
         }
     }
@@ -90,8 +91,11 @@ fn reconcile_rule_packs(
         .collect();
 
     let mut old_ids: HashSet<String> = HashSet::new();
-    let mut removed_scopes: Vec<(sigil_core::event::AiTool, sigil_core::event::AiGuardScope)> =
-        Vec::new();
+    let mut removed_scopes: Vec<(
+        sigil_core::event::AiTool,
+        sigil_core::event::AiGuardScope,
+        Option<String>,
+    )> = Vec::new();
 
     guard.retain(|p| {
         if let Some(rpp) = p
@@ -103,7 +107,11 @@ fn reconcile_rule_packs(
             if new_ids.contains(&id) {
                 true
             } else {
-                removed_scopes.push((rpp.pack.tool, rpp.scope()));
+                removed_scopes.push((
+                    rpp.pack.tool,
+                    rpp.scope(),
+                    rpp.rule_pack_id().map(|s| s.to_string()),
+                ));
                 false
             }
         } else {
@@ -129,8 +137,8 @@ fn reconcile_rule_packs(
 
     if !removed_scopes.is_empty() {
         let mut s = state.write();
-        for (tool, scope) in &removed_scopes {
-            s.remove(&(*tool, scope.clone()));
+        for (tool, scope, pack_id) in &removed_scopes {
+            s.remove(&(*tool, scope.clone(), pack_id.clone()));
         }
     }
 
@@ -713,6 +721,7 @@ mod tests {
                     sigil_core::event::AiGuardScope::Project {
                         path: canonical_a.clone(),
                     },
+                    None::<String>,
                 ),
                 crate::ai_guard::task::CachedAssessment {
                     score: 5.0,
@@ -747,6 +756,7 @@ mod tests {
                 sigil_core::event::AiGuardScope::Project {
                     path: canonical_a.clone(),
                 },
+                None::<String>,
             );
             assert!(
                 !s.contains_key(&key),

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -194,43 +194,72 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         Arc::new(crate::ai_guard::CursorParser),
         Arc::new(crate::ai_guard::AntigravityParser),
     ];
-    for repo_root in continue_repos {
+    for repo_root in &continue_repos {
         parsers_vec.push(Arc::new(crate::ai_guard::ContinueDevProjectParser {
-            repo_root,
+            repo_root: repo_root.clone(),
         }));
     }
-    for repo_root in claude_code_repos {
+    for repo_root in &claude_code_repos {
         parsers_vec.push(Arc::new(crate::ai_guard::ClaudeCodeProjectParser {
-            repo_root,
+            repo_root: repo_root.clone(),
         }));
     }
-    for repo_root in codex_repos {
-        parsers_vec.push(Arc::new(crate::ai_guard::CodexProjectParser { repo_root }));
+    for repo_root in &codex_repos {
+        parsers_vec.push(Arc::new(crate::ai_guard::CodexProjectParser {
+            repo_root: repo_root.clone(),
+        }));
     }
-    for repo_root in gemini_repos {
-        parsers_vec.push(Arc::new(crate::ai_guard::GeminiProjectParser { repo_root }));
+    for repo_root in &gemini_repos {
+        parsers_vec.push(Arc::new(crate::ai_guard::GeminiProjectParser {
+            repo_root: repo_root.clone(),
+        }));
     }
-    for repo_root in cursor_repos {
-        parsers_vec.push(Arc::new(crate::ai_guard::CursorProjectParser { repo_root }));
+    for repo_root in &cursor_repos {
+        parsers_vec.push(Arc::new(crate::ai_guard::CursorProjectParser {
+            repo_root: repo_root.clone(),
+        }));
     }
-    for repo_root in antigravity_repos {
+    for repo_root in &antigravity_repos {
         parsers_vec.push(Arc::new(crate::ai_guard::AntigravityProjectParser {
-            repo_root,
+            repo_root: repo_root.clone(),
         }));
     }
     // Phase 3b.7 — declarative rule packs (sigil-rules-basic defaults +
     // operator overlay from signed envelope, already merged into
     // effective.rule_packs by sigil_core::policy::merge).
-    for pack in &effective.rule_packs {
+    //
+    // Phase 3b.7.2 — Project-scoped packs expand to one parser per discovered
+    // repo (UserGlobal -> exactly one). `repos_for_tool` borrows the per-tool
+    // discovery vecs immutably; the loop separately borrows `&mut effective`
+    // to push synthetic targets (distinct variables, so the borrow checker is
+    // satisfied).
+    let repos_for_tool = |tool: sigil_core::event::AiTool| -> &[std::path::PathBuf] {
+        use sigil_core::event::AiTool::*;
+        match tool {
+            ContinueDev => &continue_repos,
+            ClaudeCode => &claude_code_repos,
+            Codex => &codex_repos,
+            Gemini => &gemini_repos,
+            Cursor => &cursor_repos,
+            Antigravity => &antigravity_repos,
+            ClaudeDesktop => &[],
+        }
+    };
+    // Clone the authored packs out so the loop can push synthetic targets into
+    // `effective.targets` without holding an immutable borrow of `effective`.
+    let authored_packs = effective.rule_packs.clone();
+    for pack in &authored_packs {
         if !crate::ai_guard::rule_pack::pack_is_loadable(pack) {
             continue;
         }
-        match crate::ai_guard::rule_pack::parser::RulePackParser::new(pack.clone()) {
-            Ok(p) => parsers_vec.push(Arc::new(p)),
-            Err(e) => tracing::warn!(
-                id = %pack.id, error = ?e,
-                "rule_pack: load failed; skipping"
-            ),
+        let repos = repos_for_tool(pack.tool);
+        for parser in crate::ai_guard::rule_pack::expand::expand_pack_parsers(pack, repos) {
+            if let sigil_core::event::AiGuardScope::Project { path } =
+                crate::ai_guard::parser::AiGuardParser::scope(&parser)
+            {
+                push_rule_pack_synthetic_targets(&mut effective, pack, &path);
+            }
+            parsers_vec.push(Arc::new(parser));
         }
     }
     let ai_guard_parsers: Arc<
@@ -1129,6 +1158,40 @@ pub(crate) fn push_gemini_synthetic_target(
         tier: sigil_core::policy::Tier::Critical,
         platform: sigil_core::policy::Platform::Any,
         paths: vec![config.to_string_lossy().to_string()],
+        recursive: false,
+        follow_symlinks: false,
+        disabled: false,
+    });
+}
+
+/// Phase 3b.7.2 — push ONE synthetic WatchTarget covering all of a Project-scoped
+/// rule pack's `watched_paths`, resolved under `repo_root`. Mirrors the built-in
+/// per-repo synthetic helpers so the OS watcher subscribes to the pack's files at
+/// boot. In-memory only — never written back to the signed envelope on disk.
+pub(crate) fn push_rule_pack_synthetic_targets(
+    effective: &mut sigil_core::policy::EffectivePolicy,
+    pack: &sigil_core::policy::RulePack,
+    repo_root: &std::path::Path,
+) {
+    let h = synthetic_target_id_suffix(repo_root);
+    let paths: Vec<String> = pack
+        .watched_paths
+        .iter()
+        .map(|w| repo_root.join(w).to_string_lossy().to_string())
+        .collect();
+    if paths.is_empty() {
+        return;
+    }
+    effective.targets.push(sigil_core::policy::WatchTarget {
+        id: format!("rulepack-{}-project-{h}", pack.id),
+        description: format!(
+            "Phase 3b.7.2 synthetic: pack {} @ {}",
+            pack.id,
+            repo_root.display()
+        ),
+        tier: sigil_core::policy::Tier::Critical,
+        platform: sigil_core::policy::Platform::Any,
+        paths,
         recursive: false,
         follow_symlinks: false,
         disabled: false,

--- a/crates/sigil-agent/tests/rule_pack_project_e2e.rs
+++ b/crates/sigil-agent/tests/rule_pack_project_e2e.rs
@@ -1,0 +1,263 @@
+//! e2e: Project-scope rule packs through the real agent.
+//!
+//! Phase 3b.7 Task 7 — proves that an operator-authored Project-scope rule
+//! pack (`scope: { kind: project }`) is expanded per-repo across a
+//! `gemini_workspaces` root, emits `AiGuardRiskAssessed` events carrying the
+//! pack's `rule_pack_id` for attribution, coexists with the built-in
+//! `GeminiProjectParser` (which emits NO `rule_pack_id`) without identity-key
+//! collision, and is reconciled on policy reload when a repo is added.
+//!
+//! Fixture note: the rule pack rule selects TOP-LEVEL `$.sandbox`, while the
+//! built-in `GeminiProjectParser` reads NESTED `tools.sandbox`. Tests 1 and 3
+//! therefore use `{"sandbox": false}` (rule-pack only). Test 2 uses
+//! `{"sandbox": false, "tools": {"sandbox": false}}` so BOTH parsers fire on
+//! the same repo, exercising the (tool, scope, rule_pack_id) identity key.
+//!
+//! Sandbox caveat: this repo's CI sandbox does not deliver FS-watcher events
+//! (issues #25/#66), so these tests — like the rest of the e2e suite
+//! (`ai_guard_e2e`, `basic_events`, `critical_tier`) — may time out locally on
+//! macOS. They are verified green on Linux CI (ubuntu/rocky).
+
+#![cfg(all(unix, feature = "operator-cli"))]
+
+mod common;
+use common::{fs_event_timeout, TestAgentBuilder};
+use serde_json::json;
+use std::time::Duration;
+
+/// Build a policy with a `gemini_workspaces` root and one Project-scope rule
+/// pack `proj-sbx` matching top-level `$.sandbox == "false"` → `sandbox_disabled`.
+fn project_pack_policy(workspace: &str) -> String {
+    format!(
+        r#"version: 1
+host_id_strategy: machine_id
+gemini_workspaces:
+  - '{workspace}'
+targets: []
+rule_packs:
+  - id: proj-sbx
+    pack_version: 1
+    tool: gemini
+    scope:
+      kind: project
+    watched_paths:
+      - '.gemini/settings.json'
+    rules:
+      - id: r1
+        on_file: '.gemini/settings.json'
+        format: json
+        selector: '$.sandbox'
+        matcher:
+          kind: equals
+          value: "false"
+        emit:
+          kind: sandbox_disabled
+"#
+    )
+}
+
+fn write_gemini_settings(repo: &std::path::Path, body: &str) {
+    let dir = repo.join(".gemini");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("settings.json"), body).unwrap();
+}
+
+/// Test 1 — a Project pack expands per-repo and attributes each finding with
+/// its `rule_pack_id`. repoA (sandbox:false) → a `sandbox_disabled` finding
+/// scoped to repoA with `rule_pack_id == "proj-sbx"`; repoB (sandbox:true)
+/// produces no such finding.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn project_pack_emits_per_repo_with_attribution() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(dir.path()).unwrap();
+    let repo_a = root.join("repoA");
+    let repo_b = root.join("repoB");
+    write_gemini_settings(&repo_a, r#"{"sandbox": false}"#);
+    write_gemini_settings(&repo_b, r#"{"sandbox": true}"#);
+
+    let policy = project_pack_policy(&root.display().to_string());
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    let canonical_a = dunce::canonicalize(&repo_a).unwrap().display().to_string();
+    let canonical_b = dunce::canonicalize(&repo_b).unwrap().display().to_string();
+
+    // repoA: rule-pack finding attributed to proj-sbx with sandbox_disabled.
+    let ev_a = agent
+        .wait_for_event(
+            |v| {
+                v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                    && v["evidence"]["tool"] == "gemini"
+                    && v["evidence"]["scope"]["kind"] == "project"
+                    && v["evidence"]["scope"]["path"] == canonical_a.as_str()
+                    && v["evidence"]["rule_pack_id"] == "proj-sbx"
+            },
+            fs_event_timeout(),
+        )
+        .await
+        .expect("expected proj-sbx AiGuardRiskAssessed for repoA");
+    let reasons_a = ev_a["evidence"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons_a.iter().any(|r| r["kind"] == "sandbox_disabled"),
+        "expected sandbox_disabled in repoA reasons: {reasons_a:?}"
+    );
+
+    // repoB (sandbox:true) must NOT produce a proj-sbx sandbox_disabled finding.
+    // Bounded re-scan of all events to date: if such an event ever appears it is
+    // a bug. (repoB may still emit a CLEAN assessment with empty reasons; we only
+    // forbid a sandbox_disabled reason attributed to proj-sbx.)
+    let bad_b = agent.read_all_events().into_iter().find(|v| {
+        v["evidence"]["kind"] == "ai_guard_risk_assessed"
+            && v["evidence"]["tool"] == "gemini"
+            && v["evidence"]["scope"]["path"] == canonical_b.as_str()
+            && v["evidence"]["rule_pack_id"] == "proj-sbx"
+            && v["evidence"]["reasons"]
+                .as_array()
+                .map(|rs| rs.iter().any(|r| r["kind"] == "sandbox_disabled"))
+                .unwrap_or(false)
+    });
+    assert!(
+        bad_b.is_none(),
+        "repoB (sandbox:true) must not yield a proj-sbx sandbox_disabled finding: {bad_b:?}"
+    );
+
+    agent.join.abort();
+}
+
+/// Test 2 — the Project pack coexists with the built-in `GeminiProjectParser`.
+/// Both watch `.gemini/settings.json` and both fire on repoA, yielding TWO
+/// distinct events: one with `rule_pack_id == "proj-sbx"` and one with NO
+/// `rule_pack_id` (built-in). This proves the (tool, scope, rule_pack_id)
+/// identity key prevents the two assessments from colliding.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn project_pack_coexists_with_builtin() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(dir.path()).unwrap();
+    let repo_a = root.join("repoA");
+    // Satisfy BOTH parsers: rule pack reads top-level $.sandbox; the built-in
+    // GeminiProjectParser reads nested tools.sandbox.
+    write_gemini_settings(
+        &repo_a,
+        r#"{"sandbox": false, "tools": {"sandbox": false}}"#,
+    );
+
+    let policy = project_pack_policy(&root.display().to_string());
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    let canonical_a = dunce::canonicalize(&repo_a).unwrap().display().to_string();
+
+    // Collect events until BOTH the rule-pack and built-in assessments for
+    // repoA are seen, or the deadline elapses.
+    let deadline = std::time::Instant::now() + fs_event_timeout();
+    let mut saw_pack = false;
+    let mut saw_builtin = false;
+    while std::time::Instant::now() < deadline && !(saw_pack && saw_builtin) {
+        for v in agent.read_all_events() {
+            let is_repo_a_gemini = v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                && v["evidence"]["tool"] == "gemini"
+                && v["evidence"]["scope"]["kind"] == "project"
+                && v["evidence"]["scope"]["path"] == canonical_a.as_str();
+            if !is_repo_a_gemini {
+                continue;
+            }
+            // sandbox_disabled must be present for either parser on this fixture.
+            let has_sbx = v["evidence"]["reasons"]
+                .as_array()
+                .map(|rs| rs.iter().any(|r| r["kind"] == "sandbox_disabled"))
+                .unwrap_or(false);
+            if !has_sbx {
+                continue;
+            }
+            if v["evidence"]["rule_pack_id"] == "proj-sbx" {
+                saw_pack = true;
+            } else if v["evidence"]["rule_pack_id"].is_null() {
+                // Built-in parser: rule_pack_id field absent/null.
+                saw_builtin = true;
+            }
+        }
+        if saw_pack && saw_builtin {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert!(
+        saw_pack,
+        "expected a repoA gemini event WITH rule_pack_id=proj-sbx (rule pack)"
+    );
+    assert!(
+        saw_builtin,
+        "expected a repoA gemini event WITHOUT rule_pack_id (built-in GeminiProjectParser)"
+    );
+
+    agent.join.abort();
+}
+
+/// Test 3 — reload reconciliation: boot with only repoA on disk, then add
+/// repoB and trigger a policy reload (rewrite policy.yaml + `reload_policy`).
+/// A proj-sbx finding for repoB must appear after the reload. (Prune-on-remove
+/// is covered by the Task 6 unit test
+/// `policy_reload_task::tests::reload_project_pack_prunes_removed_repo`, which
+/// can deterministically assert state-map removal without depending on the
+/// FS watcher; asserting absence here would be watcher-timing-flaky.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reload_adds_then_prunes_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(dir.path()).unwrap();
+    let repo_a = root.join("repoA");
+    let repo_b = root.join("repoB");
+    // Boot with only repoA present.
+    write_gemini_settings(&repo_a, r#"{"sandbox": false}"#);
+
+    let policy = project_pack_policy(&root.display().to_string());
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    let canonical_a = dunce::canonicalize(&repo_a).unwrap().display().to_string();
+
+    // Initial finding for repoA.
+    agent
+        .wait_for_event(
+            |v| {
+                v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                    && v["evidence"]["tool"] == "gemini"
+                    && v["evidence"]["scope"]["path"] == canonical_a.as_str()
+                    && v["evidence"]["rule_pack_id"] == "proj-sbx"
+            },
+            fs_event_timeout(),
+        )
+        .await
+        .expect("expected initial proj-sbx finding for repoA");
+
+    // Add repoB on disk, then rewrite policy.yaml (unchanged content is fine —
+    // reload re-discovers workspace repos) and nudge the reload task.
+    write_gemini_settings(&repo_b, r#"{"sandbox": false}"#);
+    std::fs::write(&agent.policy_file, &policy).unwrap();
+    let reload_resp = agent.control(&json!({"cmd": "reload_policy"})).await;
+    assert_eq!(
+        reload_resp["ok"], true,
+        "reload_policy failed: {reload_resp}"
+    );
+
+    let canonical_b = dunce::canonicalize(&repo_b).unwrap().display().to_string();
+
+    // A proj-sbx finding for the newly-added repoB must appear.
+    let ev_b = agent
+        .wait_for_event(
+            |v| {
+                v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                    && v["evidence"]["tool"] == "gemini"
+                    && v["evidence"]["scope"]["kind"] == "project"
+                    && v["evidence"]["scope"]["path"] == canonical_b.as_str()
+                    && v["evidence"]["rule_pack_id"] == "proj-sbx"
+            },
+            fs_event_timeout(),
+        )
+        .await
+        .expect("expected proj-sbx finding for repoB after reload added it");
+    let reasons_b = ev_b["evidence"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons_b.iter().any(|r| r["kind"] == "sandbox_disabled"),
+        "expected sandbox_disabled in repoB reasons after add+reload: {reasons_b:?}"
+    );
+
+    agent.join.abort();
+}

--- a/crates/sigil-agent/tests/rule_pack_project_e2e.rs
+++ b/crates/sigil-agent/tests/rule_pack_project_e2e.rs
@@ -227,8 +227,8 @@ async fn reload_adds_then_prunes_repo() {
         .await
         .expect("expected initial proj-sbx finding for repoA");
 
-    // Add repoB on disk, then rewrite policy.yaml (unchanged content is fine —
-    // reload re-discovers workspace repos) and nudge the reload task.
+    // repoB must exist on disk BEFORE reload so workspace discovery finds it
+    // (discover_per_repo requires the `.gemini/settings.json` marker to exist).
     write_gemini_settings(&repo_b, r#"{"sandbox": false}"#);
     std::fs::write(&agent.policy_file, &policy).unwrap();
     let reload_resp = agent.control(&json!({"cmd": "reload_policy"})).await;
@@ -238,21 +238,39 @@ async fn reload_adds_then_prunes_repo() {
     );
 
     let canonical_b = dunce::canonicalize(&repo_b).unwrap().display().to_string();
+    let repo_b_match = |v: &serde_json::Value| {
+        v["evidence"]["kind"] == "ai_guard_risk_assessed"
+            && v["evidence"]["tool"] == "gemini"
+            && v["evidence"]["scope"]["kind"] == "project"
+            && v["evidence"]["scope"]["path"] == canonical_b.as_str()
+            && v["evidence"]["rule_pack_id"] == "proj-sbx"
+    };
 
-    // A proj-sbx finding for the newly-added repoB must appear.
-    let ev_b = agent
-        .wait_for_event(
-            |v| {
-                v["evidence"]["kind"] == "ai_guard_risk_assessed"
-                    && v["evidence"]["tool"] == "gemini"
-                    && v["evidence"]["scope"]["kind"] == "project"
-                    && v["evidence"]["scope"]["path"] == canonical_b.as_str()
-                    && v["evidence"]["rule_pack_id"] == "proj-sbx"
-            },
-            fs_event_timeout(),
-        )
-        .await
-        .expect("expected proj-sbx finding for repoB after reload added it");
+    // The `reload_policy` IPC reply returns before reload finishes arming the
+    // watch, and repoB's settings were written before that watch existed — so the
+    // pre-reload write produced no inotify event for it. A reload-added parser is
+    // otherwise assessed only on the next file change to its watched path or the
+    // periodic heartbeat (the same behavior as built-in per-repo parsers). So
+    // re-touch repoB's settings (distinct bytes each iteration → a real change)
+    // until the now-watched proj-sbx parser assesses it.
+    let deadline = std::time::Instant::now() + fs_event_timeout();
+    let mut ev_b = None;
+    let mut nonce = 0;
+    while std::time::Instant::now() < deadline {
+        nonce += 1;
+        write_gemini_settings(
+            &repo_b,
+            &format!(r#"{{"sandbox": false, "nonce": {nonce}}}"#),
+        );
+        if let Some(ev) = agent
+            .wait_for_event(&repo_b_match, Duration::from_millis(500))
+            .await
+        {
+            ev_b = Some(ev);
+            break;
+        }
+    }
+    let ev_b = ev_b.expect("expected proj-sbx finding for repoB after reload added it");
     let reasons_b = ev_b["evidence"]["reasons"].as_array().expect("reasons");
     assert!(
         reasons_b.iter().any(|r| r["kind"] == "sandbox_disabled"),

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -427,6 +427,10 @@ pub enum Evidence {
         /// `true` iff this is the periodic re-attestation heartbeat (no
         /// reason set change since last emission). `false` = something changed.
         is_reattestation: bool,
+        /// Phase 3b.7.2 — Some(pack id) when emitted by an operator rule-pack
+        /// parser; None (omitted) for built-in structural parsers. Forward-compat.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rule_pack_id: Option<String>,
     },
     /// Phase 3b.4-pre — periodic snapshot of host identity + network + OS
     /// metadata. Emitted by host_meta_snapshot_task on boot, every 24h, and
@@ -757,6 +761,7 @@ mod tests {
                 },
             ],
             is_reattestation: false,
+            rule_pack_id: None,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(
@@ -807,6 +812,7 @@ mod tests {
             bucket: AiGuardBucket::Low,
             reasons: vec![],
             is_reattestation: false,
+            rule_pack_id: None,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains("\"reasons\":[]"), "got: {s}");
@@ -1061,5 +1067,37 @@ mod tests {
             }
             other => panic!("expected DestructiveInHookScript, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn ai_guard_risk_assessed_omits_rule_pack_id_when_none() {
+        let ev = Evidence::AiGuardRiskAssessed {
+            tool: AiTool::Gemini,
+            scope: AiGuardScope::UserGlobal,
+            score: 0.0,
+            bucket: AiGuardBucket::Low,
+            reasons: vec![],
+            is_reattestation: false,
+            rule_pack_id: None,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(!s.contains("rule_pack_id"));
+        let back: Evidence = serde_json::from_str(&s).unwrap();
+        assert_eq!(ev, back);
+    }
+    #[test]
+    fn ai_guard_risk_assessed_round_trips_rule_pack_id() {
+        let ev = Evidence::AiGuardRiskAssessed {
+            tool: AiTool::Gemini,
+            scope: AiGuardScope::Project { path: "/r".into() },
+            score: 1.0,
+            bucket: AiGuardBucket::Medium,
+            reasons: vec![],
+            is_reattestation: false,
+            rule_pack_id: Some("my-pack".into()),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains(r#""rule_pack_id":"my-pack""#));
+        assert_eq!(ev, serde_json::from_str::<Evidence>(&s).unwrap());
     }
 }

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -59,6 +59,16 @@ pub enum HostIdStrategy {
     Static(String),
 }
 
+/// Phase 3b.7.2 — authoring scope for a rule pack. Decoupled from the runtime
+/// `event::AiGuardScope`: the operator writes a tag with NO path; the engine
+/// stamps the concrete `AiGuardScope::Project { path: repo_root }` per repo.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RulePackScope {
+    UserGlobal,
+    Project,
+}
+
 /// Phase 3b.7 — declarative rule pack. See
 /// docs/superpowers/specs/2026-05-19-phase-3b7-declarative-rule-pack-architecture-design.html
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -66,7 +76,7 @@ pub struct RulePack {
     pub id: String,
     pub pack_version: u32,
     pub tool: crate::event::AiTool,
-    pub scope: crate::event::AiGuardScope,
+    pub scope: RulePackScope,
     pub watched_paths: Vec<String>,
     #[serde(default)]
     pub platforms: Option<Vec<Platform>>,
@@ -764,12 +774,27 @@ rules:
         assert_eq!(pack.id, "test-pack");
         assert_eq!(pack.pack_version, 1);
         assert_eq!(pack.tool, crate::event::AiTool::Gemini);
-        assert!(matches!(pack.scope, crate::event::AiGuardScope::UserGlobal));
+        assert!(matches!(pack.scope, RulePackScope::UserGlobal));
         assert_eq!(pack.rules.len(), 1);
         assert_eq!(pack.rules[0].format, RuleFormat::Json);
         let back = serde_yaml::to_string(&pack).unwrap();
         let again: RulePack = serde_yaml::from_str(&back).expect("re-parse");
         assert_eq!(again.id, pack.id);
+    }
+
+    #[test]
+    fn rule_pack_project_scope_yaml_deserializes() {
+        let yaml = r#"
+id: project-pack
+pack_version: 1
+tool: gemini
+scope:
+  kind: project
+watched_paths: []
+rules: []
+"#;
+        let pack: RulePack = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(pack.scope, RulePackScope::Project);
     }
 
     #[test]
@@ -941,6 +966,19 @@ host_id_strategy: hostname
         let doc = parse("version: 1\n").unwrap();
         assert!(doc.gemini_workspaces.is_empty());
         assert!(doc.cursor_workspaces.is_empty());
+    }
+
+    #[test]
+    fn rule_pack_scope_serde_round_trips() {
+        use super::RulePackScope;
+        let ug: RulePackScope = serde_json::from_str(r#"{"kind":"user_global"}"#).unwrap();
+        assert_eq!(ug, RulePackScope::UserGlobal);
+        let pj: RulePackScope = serde_json::from_str(r#"{"kind":"project"}"#).unwrap();
+        assert_eq!(pj, RulePackScope::Project);
+        assert_eq!(
+            serde_json::to_string(&RulePackScope::Project).unwrap(),
+            r#"{"kind":"project"}"#
+        );
     }
 
     #[test]

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -57,6 +57,7 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
             bucket,
             reasons,
             is_reattestation,
+            ..
         } => {
             host.current_risk.insert(
                 *tool,
@@ -167,6 +168,7 @@ mod tests {
                 bucket,
                 reasons: vec![],
                 is_reattestation: false,
+                rule_pack_id: None,
             }
         }
 
@@ -306,6 +308,7 @@ mod tests {
                 bucket: AiGuardBucket::Critical,
                 reasons: vec![],
                 is_reattestation: false,
+                rule_pack_id: None,
             },
             Severity::Warn,
             datetime!(2026-05-17 12:00 UTC),
@@ -435,6 +438,7 @@ mod tests {
                     bucket: AiGuardBucket::High,
                     reasons: vec![],
                     is_reattestation: false,
+                    rule_pack_id: None,
                 },
                 Severity::Warn,
                 t,
@@ -509,6 +513,7 @@ mod tests {
                     bucket: AiGuardBucket::Medium,
                     reasons: vec![],
                     is_reattestation: false,
+                    rule_pack_id: None,
                 },
                 Severity::Warn,
                 t,


### PR DESCRIPTION
Implements **#53 sub-item 3b.7.2** — operator-defined rule packs can now target a per-repo scope and ride the target tool's existing workspace discovery, getting one instance per discovered repo like the built-in `*ProjectParser`s.

## What

Previously the rule-pack engine rejected any `scope` other than `UserGlobal`. Now a pack can declare `scope: project` and the engine instantiates it once per repo discovered for the pack's `tool`.

## Design (locked spec in brainstorm)

- **D1 — repo binding:** reuse the target tool's existing `*_workspaces` discovery (no new config surface).
- **D2 — path resolution:** `on_file`/`watched_paths` are resolved **relative to each `repo_root`** (implicit join); absolute paths under Project are rejected at load.
- **D3 — identity:** the assessment key gains a pack-id dimension — `(AiTool, AiGuardScope, Option<String>)` — and the `AiGuardRiskAssessed` event gains an optional, forward-compat `rule_pack_id`. This prevents an operator Project pack from colliding with the built-in per-repo parser (or another pack) on the same `(tool, scope)`.
- **D4 — authoring:** a dedicated `RulePackScope { UserGlobal, Project }` enum decouples what the operator writes (no path) from the runtime `AiGuardScope::Project { path: repo_root }` stamped per instance.

## Commits (TDD, one per task)

1. `RulePackScope` authoring enum + `rule_pack_id` plumbing
2. `pack_is_loadable` accepts Project, rejects absolute `on_file`
3. `RulePackParser` per-repo Project resolution + `rule_pack_id`
4. Assessment identity keyed by `(tool, scope, pack_id)`
5. Instantiate Project packs per discovered repo at boot
6. Hot-reload rebuilds Project packs + prunes state (incl. a `reconcile_per_repo` skip-guard so built-in and rule-pack reconcilers own disjoint parser sets)
7. E2E: per-repo, coexistence with built-in, reload-add

## Forward-compat / honesty

- `rule_pack_id` uses `#[serde(default, skip_serializing_if = "Option::is_none")]` → byte-identical wire form for built-in parsers; `SCHEMA_VERSION` unchanged.
- Measurement-only — no enforcement, mechanism-only (public repo).

## Testing

- Unit: scope serde round-trip, Project-loadable/absolute-reject, per-repo resolution, no-collision keying, expand-per-repo, reload prune.
- E2E (`rule_pack_project_e2e.rs`): per-repo attribution, coexistence with the built-in `GeminiProjectParser` (genuinely fires both parsers), reload-add. Boot-scan-driven tests pass locally; the watcher-driven reload test is verified on Linux CI (the fs-watcher e2e suite times out in the sandbox env — pre-existing).
- `cargo fmt` + `clippy --workspace -D warnings` + `cargo test -p sigil-agent --lib` green.

## Follow-up (not in this PR)

Built-in `AntigravityProjectParser` is not reconciled on hot-reload (pre-existing gap, not widened here) — will file a separate tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)