### PR TITLE
feat(ai-guard): generic AiTool::Other for operator rule packs (#53)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mod.rs
@@ -65,6 +65,12 @@ pub trait AiGuardParser: Send + Sync {
     fn rule_pack_id(&self) -> Option<&str> {
         None
     }
+
+    /// Phase 3b.7.5 — human label for an `AiTool::Other` parser; None for built-ins
+    /// and for Other parsers without a label. Stamped onto the emitted event.
+    fn tool_label(&self) -> Option<&str> {
+        None
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sigil-agent/src/ai_guard/rule_pack/expand.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/expand.rs
@@ -41,6 +41,7 @@ mod tests {
             scope,
             watched_paths: vec![".gemini/s.json".into()],
             platforms: None,
+            tool_label: None,
             rules: vec![RuleEntry {
                 id: "r".into(),
                 on_file: ".gemini/s.json".into(),

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -44,6 +44,24 @@ pub fn pack_is_loadable(pack: &sigil_core::policy::RulePack) -> bool {
             }
         }
     }
+    if matches!(pack.tool, sigil_core::event::AiTool::Other) {
+        // Generic tools must name themselves, and are UserGlobal-only: there is no
+        // built-in per-repo discovery for an unknown tool, and per-repo generic
+        // packs need pack-declared discovery (out of scope — 3b.7.5 non-goal).
+        let labelled = pack
+            .tool_label
+            .as_deref()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        if !labelled {
+            tracing::warn!(id = %pack.id, "rule_pack: tool=other requires a non-empty tool_label; skipping");
+            return false;
+        }
+        if matches!(pack.scope, sigil_core::policy::RulePackScope::Project) {
+            tracing::warn!(id = %pack.id, "rule_pack: tool=other supports UserGlobal scope only; skipping");
+            return false;
+        }
+    }
     if let Some(plats) = &pack.platforms {
         if !plats.is_empty() && !plats.contains(&sigil_core::policy::current_platform()) {
             return false;
@@ -76,6 +94,67 @@ mod tests {
                 emit: AiGuardReason::SandboxDisabled,
             }],
         }
+    }
+
+    fn pack_tool(tool: AiTool, label: Option<&str>, scope: RulePackScope) -> RulePack {
+        RulePack {
+            id: "p".into(),
+            pack_version: 1,
+            tool,
+            tool_label: label.map(|s| s.to_string()),
+            scope,
+            watched_paths: vec![],
+            platforms: None,
+            rules: vec![RuleEntry {
+                id: "r".into(),
+                on_file: ".x/c.json".into(),
+                format: RuleFormat::Json,
+                selector: "$.x".into(),
+                matcher: Matcher::Exists,
+                emit: AiGuardReason::SandboxDisabled,
+            }],
+        }
+    }
+
+    #[test]
+    fn other_tool_with_label_is_loadable() {
+        assert!(pack_is_loadable(&pack_tool(
+            AiTool::Other,
+            Some("acme-ai"),
+            RulePackScope::UserGlobal
+        )));
+    }
+
+    #[test]
+    fn other_tool_without_label_rejected() {
+        assert!(!pack_is_loadable(&pack_tool(
+            AiTool::Other,
+            None,
+            RulePackScope::UserGlobal
+        )));
+        assert!(!pack_is_loadable(&pack_tool(
+            AiTool::Other,
+            Some("   "),
+            RulePackScope::UserGlobal
+        )));
+    }
+
+    #[test]
+    fn other_tool_with_project_scope_rejected() {
+        assert!(!pack_is_loadable(&pack_tool(
+            AiTool::Other,
+            Some("acme-ai"),
+            RulePackScope::Project
+        )));
+    }
+
+    #[test]
+    fn builtin_tool_with_stray_label_still_loadable() {
+        assert!(pack_is_loadable(&pack_tool(
+            AiTool::Gemini,
+            Some("ignored"),
+            RulePackScope::UserGlobal
+        )));
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -66,6 +66,7 @@ mod tests {
             scope,
             watched_paths: vec![],
             platforms: None,
+            tool_label: None,
             rules: vec![RuleEntry {
                 id: "r".into(),
                 on_file: on_file.into(),

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -167,6 +167,7 @@ mod tests {
             scope: RulePackScope::UserGlobal,
             watched_paths: vec![on_file_abs.into()],
             platforms: None,
+            tool_label: None,
             rules: vec![RuleEntry {
                 id: "r1".into(),
                 on_file: on_file_abs.into(),
@@ -268,6 +269,7 @@ mod tests {
             scope: RulePackScope::UserGlobal,
             watched_paths: vec![],
             platforms: None,
+            tool_label: None,
             rules: vec![RuleEntry {
                 id: "r1".into(),
                 on_file: "/tmp/x".into(),

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -75,6 +75,10 @@ impl AiGuardParser for RulePackParser {
         Some(&self.pack.id)
     }
 
+    fn tool_label(&self) -> Option<&str> {
+        self.pack.tool_label.as_deref()
+    }
+
     fn watched_paths(&self, _home: &Path) -> Vec<PathBuf> {
         self.pack
             .watched_paths
@@ -282,6 +286,21 @@ mod tests {
             }],
         };
         assert!(RulePackParser::new(pack).is_err());
+    }
+
+    #[test]
+    fn rule_pack_parser_reports_tool_label() {
+        let mut pack = pack_with_one_rule(
+            "/abs/c.json",
+            "$.x",
+            Matcher::Exists,
+            AiGuardReason::SandboxDisabled,
+        );
+        pack.tool = AiTool::Other;
+        pack.tool_label = Some("acme-ai".into());
+        let p = RulePackParser::new(pack).unwrap();
+        assert_eq!(p.tool(), AiTool::Other);
+        assert_eq!(p.tool_label(), Some("acme-ai"));
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/task.rs
+++ b/crates/sigil-agent/src/ai_guard/task.rs
@@ -208,7 +208,7 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
             reasons,
             is_reattestation,
             rule_pack_id: key.2.clone(),
-            tool_label: None,
+            tool_label: parser.tool_label().map(|s| s.to_string()),
         },
         target_id: None,
     };
@@ -240,6 +240,7 @@ mod tests {
         tool: AiTool,
         scope: AiGuardScope,
         pack_id: Option<String>,
+        tool_label: Option<String>,
         scripts: StdMutex<Vec<Vec<AiGuardReason>>>,
         watched: Vec<PathBuf>,
     }
@@ -253,6 +254,9 @@ mod tests {
         }
         fn rule_pack_id(&self) -> Option<&str> {
             self.pack_id.as_deref()
+        }
+        fn tool_label(&self) -> Option<&str> {
+            self.tool_label.as_deref()
         }
         fn watched_paths(&self, _home: &std::path::Path) -> Vec<PathBuf> {
             self.watched.clone()
@@ -298,6 +302,7 @@ mod tests {
             tool: AiTool::ClaudeCode,
             scope: AiGuardScope::UserGlobal,
             pack_id: None,
+            tool_label: None,
             scripts: StdMutex::new(vec![vec![]]),
             watched: vec![PathBuf::from("/tmp/test-home/.claude/settings.json")],
         };
@@ -336,6 +341,7 @@ mod tests {
             tool: AiTool::ClaudeCode,
             scope: AiGuardScope::UserGlobal,
             pack_id: None,
+            tool_label: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty], // boot
                 vec![AiGuardReason::PermissionsDenyEmpty], // identical → no emit
@@ -363,6 +369,7 @@ mod tests {
             tool: AiTool::ClaudeCode,
             scope: AiGuardScope::UserGlobal,
             pack_id: None,
+            tool_label: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty],
                 vec![AiGuardReason::SandboxDisabled],
@@ -393,6 +400,7 @@ mod tests {
             tool: AiTool::ClaudeCode,
             scope: AiGuardScope::UserGlobal,
             pack_id: None,
+            tool_label: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty],
                 vec![AiGuardReason::PermissionsDenyEmpty], // heartbeat — same
@@ -468,6 +476,7 @@ mod tests {
             tool: AiTool::ClaudeCode,
             scope: AiGuardScope::UserGlobal,
             pack_id: None,
+            tool_label: None,
             scripts: StdMutex::new(vec![
                 vec![AiGuardReason::PermissionsDenyEmpty], // boot
                 vec![AiGuardReason::SandboxDisabled],      // heartbeat — different
@@ -494,6 +503,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn emit_carries_tool_label_from_parser() {
+        let (_fc_tx, fc_rx) = broadcast::channel(8);
+        let (event_tx, mut events) = mpsc::channel(16);
+        let state: Arc<RwLock<StateMap>> = Arc::new(RwLock::new(HashMap::new()));
+        let ctx = TaskCtx {
+            parsers: Arc::new(RwLock::new(vec![])),
+            fc_rx,
+            event_tx,
+            state: state.clone(),
+            heartbeat_interval: Duration::from_secs(24 * 3600),
+            home_dir: PathBuf::from("/tmp/test-home"),
+            host_id: "test-host".into(),
+            ext_scripts: crate::ai_guard::empty_ext_script_registry(),
+            rubric: crate::ai_guard::default_rubric_handle(),
+        };
+        let parser = ScriptedParser {
+            tool: AiTool::Other,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: Some("p".to_string()),
+            tool_label: Some("acme-ai".to_string()),
+            scripts: StdMutex::new(vec![vec![AiGuardReason::SandboxDisabled]]),
+            watched: vec![],
+        };
+        eval_and_maybe_emit(&parser, &ctx, true).await;
+        let ev = events.recv().await.expect("tool_label event");
+        let j = serde_json::to_value(&ev.event).unwrap();
+        assert_eq!(j["evidence"]["tool"], "other");
+        assert_eq!(j["evidence"]["tool_label"], "acme-ai");
+    }
+
+    #[tokio::test]
     async fn distinct_pack_ids_do_not_collide_in_state() {
         let (_fc_tx, fc_rx) = broadcast::channel(8);
         let (event_tx, _events) = mpsc::channel(16);
@@ -515,6 +555,7 @@ mod tests {
             tool: AiTool::Gemini,
             scope: AiGuardScope::Project { path: "/r".into() },
             pack_id: Some("pack-a".to_string()),
+            tool_label: None,
             scripts: StdMutex::new(vec![vec![AiGuardReason::SandboxDisabled]]),
             watched: vec![],
         };
@@ -524,6 +565,7 @@ mod tests {
             tool: AiTool::Gemini,
             scope: AiGuardScope::Project { path: "/r".into() },
             pack_id: Some("pack-b".to_string()),
+            tool_label: None,
             scripts: StdMutex::new(vec![vec![]]),
             watched: vec![],
         };

--- a/crates/sigil-agent/src/ai_guard/task.rs
+++ b/crates/sigil-agent/src/ai_guard/task.rs
@@ -208,6 +208,7 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
             reasons,
             is_reattestation,
             rule_pack_id: key.2.clone(),
+            tool_label: None,
         },
         target_id: None,
     };

--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -380,6 +380,7 @@ fn print_ai_guard_live(rep: &crate::control::DoctorAiGuardReport) {
                 sigil_core::event::AiTool::Gemini => "gemini",
                 sigil_core::event::AiTool::Cursor => "cursor",
                 sigil_core::event::AiTool::Antigravity => "antigravity",
+                sigil_core::event::AiTool::Other => "other",
             };
             let scope_str = match &r.scope {
                 sigil_core::event::AiGuardScope::UserGlobal => "user_global".to_string(),
@@ -424,6 +425,7 @@ fn format_parsers_summary(parsers: &[crate::control::ParserInfo]) -> String {
             sigil_core::event::AiTool::Gemini => "gemini",
             sigil_core::event::AiTool::Cursor => "cursor",
             sigil_core::event::AiTool::Antigravity => "antigravity",
+            sigil_core::event::AiTool::Other => "other",
         };
         *counts.entry(key.to_string()).or_insert(0) += 1;
     }

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -294,6 +294,7 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
             Cursor => new_cursor.iter().cloned().collect(),
             Antigravity => new_antigravity.iter().cloned().collect(),
             ClaudeDesktop => Vec::new(),
+            Other => Vec::new(),
         }
     };
 

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -243,6 +243,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
             Cursor => &cursor_repos,
             Antigravity => &antigravity_repos,
             ClaudeDesktop => &[],
+            Other => &[],
         }
     };
     // Clone the authored packs out so the loop can push synthetic targets into
@@ -1273,6 +1274,7 @@ pub(crate) fn tool_display_for_extscript(tool: sigil_core::event::AiTool) -> &'s
         AiTool::Gemini => "gemini",
         AiTool::Cursor => "cursor",
         AiTool::Antigravity => "antigravity",
+        AiTool::Other => "other",
     }
 }
 

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -559,6 +559,7 @@ fn show_risk(tool: Option<String>, pretty: bool) -> anyhow::Result<i32> {
         Some("codex") => Some(sigil_core::event::AiTool::Codex),
         Some("gemini") => Some(sigil_core::event::AiTool::Gemini),
         Some("cursor") => Some(sigil_core::event::AiTool::Cursor),
+        Some("other") => Some(sigil_core::event::AiTool::Other),
         Some(other) => {
             eprintln!("sigil show risk: unknown --tool '{other}' (expected: claude-code, codex, gemini, cursor)");
             return Ok(2);
@@ -615,6 +616,7 @@ fn write_risk_pretty(w: &mut impl Write, p: &RiskPayload) -> io::Result<()> {
             sigil_core::event::AiTool::Gemini => "gemini",
             sigil_core::event::AiTool::Cursor => "cursor",
             sigil_core::event::AiTool::Antigravity => "antigravity",
+            sigil_core::event::AiTool::Other => "other",
         };
         // Use the serde wire string (snake_case) rather than Debug. Robust
         // against future multi-word AiGuardBucket variants (e.g., "very_high")

--- a/crates/sigil-agent/tests/rule_pack_generic_tool_e2e.rs
+++ b/crates/sigil-agent/tests/rule_pack_generic_tool_e2e.rs
@@ -1,0 +1,87 @@
+//! e2e: a generic (`tool: other`) UserGlobal rule pack through the real agent.
+//!
+//! Phase 3b.7.5 (#53) — proves that an operator-authored UserGlobal rule pack
+//! naming an unknown tool via `tool: other` + `tool_label` is expanded into a
+//! runtime parser, assessed by the agent's boot scan, and emits an
+//! `AiGuardRiskAssessed` event whose wire `tool` is the bare string `"other"`,
+//! whose `tool_label` carries the human name, and whose `reasons` include the
+//! built-in `sandbox_disabled` reason the rule emitted.
+//!
+//! Why this is robust in the sandbox: a UserGlobal pack expands to exactly one
+//! parser bound to an ABSOLUTE `on_file` (env-expanded, repo-independent). The
+//! agent's boot scan synchronously assesses every parser at startup, so this
+//! event is produced WITHOUT relying on FS-watcher delivery (issues #25/#66),
+//! which is unreliable on macOS under `cargo test --workspace`.
+
+#![cfg(all(unix, feature = "operator-cli"))]
+
+mod common;
+use common::{fs_event_timeout, TestAgentBuilder};
+
+/// Build a policy with one UserGlobal generic-tool rule pack `gen-acme`:
+/// `tool: other` + `tool_label: acme-ai`, watching the absolute `config_path`
+/// and matching top-level `$.sandbox == "false"` → `sandbox_disabled`.
+fn generic_tool_pack_policy(config_path: &str) -> String {
+    format!(
+        r#"version: 1
+host_id_strategy: machine_id
+targets: []
+rule_packs:
+  - id: gen-acme
+    pack_version: 1
+    tool: other
+    tool_label: "acme-ai"
+    scope:
+      kind: user_global
+    watched_paths:
+      - '{config_path}'
+    rules:
+      - id: r1
+        on_file: '{config_path}'
+        format: json
+        selector: '$.sandbox'
+        matcher:
+          kind: equals
+          value: "false"
+        emit:
+          kind: sandbox_disabled
+"#
+    )
+}
+
+/// A `tool: other` UserGlobal pack emits `AiGuardRiskAssessed` with the bare
+/// wire `tool == "other"`, the `tool_label`, and the rule's built-in reason.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn generic_tool_pack_emits_other_with_label() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(dir.path()).unwrap();
+    let config_dir = root.join("acme");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.json");
+    std::fs::write(&config_path, r#"{"sandbox": false}"#).unwrap();
+
+    let config_str = config_path.display().to_string();
+    let policy = generic_tool_pack_policy(&config_str);
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    let ev = agent
+        .wait_for_event(
+            |v| {
+                v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                    && v["evidence"]["tool"] == "other"
+                    && v["evidence"]["tool_label"] == "acme-ai"
+                    && v["evidence"]["rule_pack_id"] == "gen-acme"
+            },
+            fs_event_timeout(),
+        )
+        .await
+        .expect("expected gen-acme AiGuardRiskAssessed with tool=other + label");
+
+    let reasons = ev["evidence"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons.iter().any(|r| r["kind"] == "sandbox_disabled"),
+        "expected sandbox_disabled in reasons: {reasons:?}"
+    );
+
+    agent.join.abort();
+}

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -109,6 +109,10 @@ pub enum AiTool {
     /// Antigravity (Google) — successor to Gemini CLI (Gemini CLI sunset
     /// 2026-06-18). Config reuses the `~/.gemini/` tree. Wire string: "antigravity".
     Antigravity,
+    /// Phase 3b.7.5 — an operator-defined tool with no built-in parser. Wire
+    /// string: "other". The human name rides `tool_label` (rule pack + event),
+    /// never inside the enum, so AiTool stays Copy + a bare-string wire value.
+    Other,
 }
 
 /// Phase 3b.1 — where the assessment applies on the host.
@@ -431,6 +435,10 @@ pub enum Evidence {
         /// parser; None (omitted) for built-in structural parsers. Forward-compat.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         rule_pack_id: Option<String>,
+        /// Phase 3b.7.5 — human-readable name of an `AiTool::Other` tool, from the
+        /// rule pack's `tool_label`. None (omitted) for built-in tools. Forward-compat.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_label: Option<String>,
     },
     /// Phase 3b.4-pre — periodic snapshot of host identity + network + OS
     /// metadata. Emitted by host_meta_snapshot_task on boot, every 24h, and
@@ -762,6 +770,7 @@ mod tests {
             ],
             is_reattestation: false,
             rule_pack_id: None,
+            tool_label: None,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(
@@ -776,6 +785,49 @@ mod tests {
         assert!(s.contains("\"executor\":\"host_shell\""));
         let back: Evidence = serde_json::from_str(&s).unwrap();
         assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn ai_tool_other_serde_round_trips_to_other_string() {
+        assert_eq!(serde_json::to_string(&AiTool::Other).unwrap(), r#""other""#);
+        assert_eq!(
+            serde_json::from_str::<AiTool>(r#""other""#).unwrap(),
+            AiTool::Other
+        );
+    }
+
+    #[test]
+    fn ai_guard_risk_assessed_omits_tool_label_when_none() {
+        let ev = Evidence::AiGuardRiskAssessed {
+            tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            score: 0.0,
+            bucket: AiGuardBucket::Low,
+            reasons: vec![],
+            is_reattestation: false,
+            rule_pack_id: None,
+            tool_label: None,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(!s.contains("tool_label"));
+        assert_eq!(ev, serde_json::from_str::<Evidence>(&s).unwrap());
+    }
+
+    #[test]
+    fn ai_guard_risk_assessed_round_trips_tool_label() {
+        let ev = Evidence::AiGuardRiskAssessed {
+            tool: AiTool::Other,
+            scope: AiGuardScope::UserGlobal,
+            score: 1.0,
+            bucket: AiGuardBucket::Medium,
+            reasons: vec![],
+            is_reattestation: false,
+            rule_pack_id: Some("p".into()),
+            tool_label: Some("acme-ai".into()),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains(r#""tool":"other""#) && s.contains(r#""tool_label":"acme-ai""#));
+        assert_eq!(ev, serde_json::from_str::<Evidence>(&s).unwrap());
     }
 
     #[test]
@@ -813,6 +865,7 @@ mod tests {
             reasons: vec![],
             is_reattestation: false,
             rule_pack_id: None,
+            tool_label: None,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains("\"reasons\":[]"), "got: {s}");
@@ -1079,6 +1132,7 @@ mod tests {
             reasons: vec![],
             is_reattestation: false,
             rule_pack_id: None,
+            tool_label: None,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(!s.contains("rule_pack_id"));
@@ -1095,6 +1149,7 @@ mod tests {
             reasons: vec![],
             is_reattestation: false,
             rule_pack_id: Some("my-pack".into()),
+            tool_label: None,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains(r#""rule_pack_id":"my-pack""#));

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -80,6 +80,10 @@ pub struct RulePack {
     pub watched_paths: Vec<String>,
     #[serde(default)]
     pub platforms: Option<Vec<Platform>>,
+    /// Phase 3b.7.5 — human name for a generic `tool: other` pack. Required when
+    /// `tool == AiTool::Other`; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_label: Option<String>,
     pub rules: Vec<RuleEntry>,
 }
 

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -169,6 +169,7 @@ mod tests {
                 reasons: vec![],
                 is_reattestation: false,
                 rule_pack_id: None,
+                tool_label: None,
             }
         }
 
@@ -309,6 +310,7 @@ mod tests {
                 reasons: vec![],
                 is_reattestation: false,
                 rule_pack_id: None,
+                tool_label: None,
             },
             Severity::Warn,
             datetime!(2026-05-17 12:00 UTC),
@@ -439,6 +441,7 @@ mod tests {
                     reasons: vec![],
                     is_reattestation: false,
                     rule_pack_id: None,
+                    tool_label: None,
                 },
                 Severity::Warn,
                 t,
@@ -514,6 +517,7 @@ mod tests {
                     reasons: vec![],
                     is_reattestation: false,
                     rule_pack_id: None,
+                    tool_label: None,
                 },
                 Severity::Warn,
                 t,


### PR DESCRIPTION
Implements **#53 sub-item 3b.7.5** — operators can point a rule pack at a tool sigil has **no built-in parser for** (a third-party or in-house AI agent), reusing the built-in reason kinds. No code change for operators.

## Scope (chosen)

Generic **tool** only — `AiGuardReason` and the rubric are untouched. A custom tool's risks map fine to existing reason kinds (no sandbox, broad permissions, remote MCP, auto-approval). A generic *reason* (custom finding + scoring) is a separate follow-up.

## Design

- **`AiTool::Other`** — a **unit** variant (wire `"other"`), so `AiTool` keeps `Copy/Hash/Ord` and its bare-string wire form. `Other(String)` would have forced dropping `Copy` (a wide ripple) — rejected.
- **`tool_label`** — the human tool name rides a separate `Option<String>` on the rule pack and on the `AiGuardRiskAssessed` event (`#[serde(default, skip_serializing_if = "Option::is_none")]` → byte-identical wire for built-ins; `SCHEMA_VERSION` unchanged). Exactly mirrors the `rule_pack_id` pattern from #92.
- **Identity** stays `pack_id`-based — two Other packs with different ids don't collide; `tool_label` is display/filter data, not identity.
- **UserGlobal only** — `tool: other` + `scope: project` is rejected at load (per-repo generic tools need pack-declared discovery — deferred).

## Commits (TDD)

1. `AiTool::Other` + `tool_label` plumbing + exhaustive-match ripple (behavior-preserving)
2. `pack_is_loadable`: Other requires a non-empty label; Other+Project rejected
3. `RulePackParser::tool_label()` override + emit wiring
4. E2E: UserGlobal `tool=other` pack → `tool:"other"` + `tool_label` + built-in reason

## Testing

- Unit: `Other` wire round-trip; event `tool_label` round-trip (omitted when None); validation (label required/non-empty, Other+Project rejected, built-in stray-label still loadable); parser `tool_label()`; emit carries it.
- E2E (`rule_pack_generic_tool_e2e.rs`): passes **locally** (boot-scan, no FS-watcher dependency).
- `cargo fmt` + `clippy --workspace -D warnings` + `cargo test -p sigil-agent --lib` (359/0) + `sigil-core` (218/0) green.

## Follow-ups (not in this PR)

- **Consumer sync:** the new `tool: "other"` wire value + `tool_label` field — filing a change-request issue against `sigil-manager` (the server's in-memory `current_risk` index keys on `AiTool` and would bucket multiple Other tools together; consumer-side concern).
- Pre-existing (not introduced here): `show.rs`'s unknown-tool error message lists a stale subset of tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)