### PR TITLE
feat: server-side rule-pack distribution (#53)

### DIFF
--- a/crates/sigil-agent/src/control.rs
+++ b/crates/sigil-agent/src/control.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::policy_apply::{apply, ApplyContext, ApplyOutcome};
+use crate::policy_apply::{apply, apply_rule_packs, ApplyContext, ApplyOutcome};
 
 // The control-socket wire protocol now lives in `sigil-core::control_proto`, so
 // `sigil-mcp` (local-mode client) can share the contract without depending on
@@ -113,6 +113,48 @@ async fn handle(ctx: &ControlContext, req: Request) -> Response {
         },
         Request::ApplyPolicy { response } => {
             let outcome = apply(&ctx.apply_ctx, &response).await;
+            match outcome {
+                ApplyOutcome::Accepted {
+                    applied_policy_version,
+                } => Response {
+                    ok: true,
+                    stats: None,
+                    apply_policy: Some(ApplyPolicyResult::Accepted {
+                        applied_policy_version,
+                    }),
+                    policy_status: None,
+                    targets: None,
+                    risk: None,
+                    doctor_ai_guard: None,
+                    error: None,
+                },
+                ApplyOutcome::Rejected { reason } => Response {
+                    ok: false,
+                    stats: None,
+                    apply_policy: Some(ApplyPolicyResult::Rejected { reason }),
+                    policy_status: None,
+                    targets: None,
+                    risk: None,
+                    doctor_ai_guard: None,
+                    error: None,
+                },
+                ApplyOutcome::Internal { detail } => Response {
+                    ok: false,
+                    stats: None,
+                    apply_policy: None,
+                    policy_status: None,
+                    targets: None,
+                    risk: None,
+                    doctor_ai_guard: None,
+                    error: Some(format!("internal: {detail}")),
+                },
+            }
+        }
+        Request::ApplyRulePacks { response } => {
+            // Mirror the ApplyPolicy response shaping so the sender's `resp.ok`
+            // check works identically. The rule-packs apply advances the
+            // SEPARATE watermark; it never touches policy.yaml.
+            let outcome = apply_rule_packs(&ctx.apply_ctx, &response).await;
             match outcome {
                 ApplyOutcome::Accepted {
                     applied_policy_version,

--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -175,7 +175,7 @@ pub fn run(policy_override: Option<PathBuf>) -> i32 {
         }
     };
 
-    let effective = match merge(defaults, user_doc, current_platform()) {
+    let effective = match merge(defaults, user_doc, None, current_platform()) {
         Ok(e) => e,
         Err(e) => {
             println!("[ERROR] policy merge failed: {e}");

--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -237,6 +237,8 @@ pub fn run(policy_override: Option<PathBuf>) -> i32 {
                     .clone()
                     .unwrap_or_else(|| "<not yet generated>".into());
                 println!("[OK]   host_id: {host_id_display} (UUIDv4, persisted in state.db)");
+                let rp_ver = meta.last_applied_rule_packs_version;
+                println!("[INFO] rule-pack bundle version: {rp_ver}");
             }
             Err(e) => {
                 println!("[WARN] host_meta_get failed: {e}");

--- a/crates/sigil-agent/src/policy_apply.rs
+++ b/crates/sigil-agent/src/policy_apply.rs
@@ -12,8 +12,8 @@ use sigil_core::event::{
     SCHEMA_VERSION,
 };
 use sigil_core::policy::{
-    atomic_write, pubkeys::Keystore, signed_envelope::SignedPolicyResponse, verify_envelope,
-    AtomicWriteError, VerifyError,
+    atomic_write, atomic_write_rule_packs, pubkeys::Keystore,
+    signed_envelope::SignedPolicyResponse, verify_envelope, AtomicWriteError, VerifyError,
 };
 use sigil_core::state::HashCache;
 use std::path::PathBuf;
@@ -51,6 +51,13 @@ pub struct ApplyContext {
     /// Shared cell — written by `apply` on every successful commit, read
     /// by `policy_expiry_task` and the IPC `PolicyStatus` handler.
     pub active_valid_until: Arc<RwLock<Option<OffsetDateTime>>>,
+    /// Destination for a verified rule-pack bundle. Sits beside `policy.yaml`
+    /// but is advanced by the SEPARATE rule-packs watermark.
+    pub rule_packs_yaml_path: PathBuf,
+    /// Broadcasts the new `last_applied_rule_packs_version` whenever a
+    /// rule-pack bundle commits. The reload task (Task 5) subscribes to
+    /// re-read `rule-packs.yaml` into the merge.
+    pub rule_packs_version_tx: watch::Sender<i64>,
 }
 
 /// Apply a freshly-received `SignedPolicyResponse`.
@@ -124,6 +131,70 @@ pub async fn apply(ctx: &ApplyContext, response: &SignedPolicyResponse) -> Apply
     }
 }
 
+/// Apply a freshly-received signed rule-pack bundle. Mirrors [`apply`] but uses
+/// the SEPARATE rule-packs watermark (`last_applied_rule_packs_version`) and
+/// `atomic_write_rule_packs`: it writes `rule-packs.yaml` and advances the
+/// rule-packs version. It NEVER touches policy.yaml or the policy version.
+pub async fn apply_rule_packs(ctx: &ApplyContext, response: &SignedPolicyResponse) -> ApplyOutcome {
+    let now = OffsetDateTime::now_utc();
+    let last_applied = {
+        let cache = ctx.cache.lock();
+        match cache.host_meta_get() {
+            Ok(m) => m.last_applied_rule_packs_version,
+            Err(e) => {
+                return ApplyOutcome::Internal {
+                    detail: format!("host_meta_get: {e}"),
+                };
+            }
+        }
+    };
+
+    let verified = match verify_envelope(&ctx.keystore, response, now, last_applied) {
+        Ok(v) => v,
+        Err(VerifyError::Internal(detail)) => {
+            // Internal — do NOT emit PolicySignatureInvalid; sender retries.
+            return ApplyOutcome::Internal { detail };
+        }
+        Err(other) => {
+            let reason = other
+                .reason()
+                .expect("non-Internal verify error has a reason");
+            emit_invalid(ctx, &reason, response, last_applied).await;
+            return ApplyOutcome::Rejected { reason };
+        }
+    };
+
+    // `verified.policy_bytes` is the bundle YAML (a PolicyDocument with only
+    // `rule_packs` meaningfully set). Write it verbatim to rule-packs.yaml; the
+    // reload (Task 5) reads only its `.rule_packs` (merge ignores the rest).
+    let write_result = {
+        let cache = ctx.cache.lock();
+        atomic_write_rule_packs(
+            &ctx.rule_packs_yaml_path,
+            &verified.policy_bytes,
+            &cache,
+            verified.policy_version,
+        )
+    };
+    match write_result {
+        Ok(()) => {
+            // Notify the reload task (Task 5) that the rule-packs version
+            // advanced. Best-effort; no live receiver is not an error.
+            let _ = ctx.rule_packs_version_tx.send(verified.policy_version);
+            emit_rule_packs_applied(ctx, verified.policy_version).await;
+            ApplyOutcome::Accepted {
+                applied_policy_version: verified.policy_version,
+            }
+        }
+        Err(AtomicWriteError::Io(e)) => ApplyOutcome::Internal {
+            detail: format!("rule-packs disk write: {e}"),
+        },
+        Err(AtomicWriteError::StateAfterDisk(e)) => ApplyOutcome::Internal {
+            detail: format!("state-after-disk: {e}"),
+        },
+    }
+}
+
 async fn emit_invalid(
     ctx: &ApplyContext,
     reason: &PolicySignatureInvalidReason,
@@ -184,6 +255,30 @@ async fn emit_reloaded(ctx: &ApplyContext, version: i64) {
         .await;
 }
 
+async fn emit_rule_packs_applied(ctx: &ApplyContext, version: i64) {
+    let ev = Event {
+        schema_version: SCHEMA_VERSION,
+        event_id: Uuid::now_v7(),
+        ts: OffsetDateTime::now_utc(),
+        host_id: ctx.host_id.clone(),
+        agent_version: AGENT_VERSION.to_string(),
+        severity: Severity::Info,
+        source: SourceKind::Agent,
+        subject: Subject::Self_,
+        evidence: Evidence::RulePackBundleApplied { version },
+        target_id: None,
+    };
+    let _ = ctx
+        .event_tx
+        .send(CommittableEvent {
+            event: ev,
+            new_hash: None,
+            path_for_db: PathBuf::new(),
+            target_id: String::new(),
+        })
+        .await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,6 +294,7 @@ mod tests {
         sk: SigningKey,
         rx_event: mpsc::Receiver<CommittableEvent>,
         rx_version: watch::Receiver<i64>,
+        rx_rule_packs_version: watch::Receiver<i64>,
         active_valid_until: Arc<RwLock<Option<OffsetDateTime>>>,
         _dir: tempfile::TempDir,
     }
@@ -224,6 +320,7 @@ mod tests {
 
         let (event_tx, rx_event) = mpsc::channel(16);
         let (policy_version_tx, rx_version) = watch::channel(last_applied);
+        let (rule_packs_version_tx, rx_rule_packs_version) = watch::channel(0i64);
         let active_valid_until = Arc::new(RwLock::new(None));
 
         Harness {
@@ -235,12 +332,43 @@ mod tests {
                 event_tx,
                 policy_version_tx,
                 active_valid_until: active_valid_until.clone(),
+                rule_packs_yaml_path: dir.path().join("rule-packs.yaml"),
+                rule_packs_version_tx,
             },
             sk,
             rx_event,
             rx_version,
+            rx_rule_packs_version,
             active_valid_until,
             _dir: dir,
+        }
+    }
+
+    /// Like [`build_harness`] but also seeds the SEPARATE rule-packs watermark
+    /// so the `apply_rule_packs` version-regression path can be exercised.
+    fn build_harness_with_rule_packs(
+        now: OffsetDateTime,
+        last_applied_policy: i64,
+        last_applied_rule_packs: i64,
+    ) -> Harness {
+        let h = build_harness(now, last_applied_policy);
+        h.ctx
+            .cache
+            .lock()
+            .set_last_applied_rule_packs_version(last_applied_rule_packs)
+            .unwrap();
+        h
+    }
+
+    /// A packs-only bundle: a PolicyDocument with `rule_packs` set and the rest
+    /// minimal. Written verbatim to rule-packs.yaml; the reload reads only
+    /// `.rule_packs`.
+    fn rule_packs_envelope(version: i64, now: OffsetDateTime) -> SignedEnvelope {
+        SignedEnvelope {
+            policy_version: version,
+            policy_bytes_b64: data_encoding::BASE64.encode(b"version: 1\nrule_packs: []\n"),
+            valid_until: now + time::Duration::hours(24),
+            issued_at: now,
         }
     }
 
@@ -380,5 +508,106 @@ mod tests {
             }
             other => panic!("expected PubkeyUnknown PolicySignatureInvalid, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn apply_rule_packs_accepts_writes_advances_separate_watermark() {
+        let now = OffsetDateTime::now_utc();
+        // policy watermark at 7, rule-packs watermark at 0 — a v1 bundle is
+        // ahead of the rule-packs watermark even though it's behind policy's.
+        let mut h = build_harness_with_rule_packs(now, 7, 0);
+        let resp = sign(&h.sk, rule_packs_envelope(1, now), now);
+
+        let outcome = apply_rule_packs(&h.ctx, &resp).await;
+        assert_eq!(
+            outcome,
+            ApplyOutcome::Accepted {
+                applied_policy_version: 1
+            }
+        );
+
+        // rule-packs.yaml written verbatim; policy.yaml untouched.
+        let written = std::fs::read(&h.ctx.rule_packs_yaml_path).unwrap();
+        assert_eq!(written, b"version: 1\nrule_packs: []\n");
+        assert!(!h.ctx.policy_yaml_path.exists());
+
+        // The SEPARATE rule-packs watermark advanced; the policy watermark
+        // (and active_valid_until) are untouched.
+        let meta = h.ctx.cache.lock().host_meta_get().unwrap();
+        assert_eq!(meta.last_applied_rule_packs_version, 1);
+        assert_eq!(meta.last_applied_policy_version, 7);
+        assert_eq!(*h.active_valid_until.read(), None);
+
+        // RulePackBundleApplied event emitted (NOT PolicyReloaded).
+        let ev = h.rx_event.recv().await.unwrap();
+        assert!(matches!(
+            ev.event.evidence,
+            Evidence::RulePackBundleApplied { version: 1 }
+        ));
+
+        // The rule-packs watch channel fired; the policy channel did not.
+        h.rx_rule_packs_version.changed().await.unwrap();
+        assert_eq!(*h.rx_rule_packs_version.borrow(), 1);
+        assert!(!h.rx_version.has_changed().unwrap());
+    }
+
+    #[tokio::test]
+    async fn apply_rule_packs_rejects_bad_signature_touches_nothing() {
+        let now = OffsetDateTime::now_utc();
+        let mut h = build_harness_with_rule_packs(now, 0, 0);
+        // Sign correctly, then corrupt the signature.
+        let mut resp = sign(&h.sk, rule_packs_envelope(1, now), now);
+        resp.signature = data_encoding::BASE64.encode(&[0u8; 64]);
+
+        let outcome = apply_rule_packs(&h.ctx, &resp).await;
+        assert_eq!(
+            outcome,
+            ApplyOutcome::Rejected {
+                reason: PolicySignatureInvalidReason::SignatureInvalid
+            }
+        );
+
+        // Nothing written; neither watermark moved.
+        assert!(!h.ctx.rule_packs_yaml_path.exists());
+        assert!(!h.ctx.policy_yaml_path.exists());
+        let meta = h.ctx.cache.lock().host_meta_get().unwrap();
+        assert_eq!(meta.last_applied_rule_packs_version, 0);
+        assert_eq!(meta.last_applied_policy_version, 0);
+
+        // The invalid event is emitted (reused PolicySignatureInvalid).
+        let ev = h.rx_event.recv().await.unwrap();
+        match ev.event.evidence {
+            Evidence::PolicySignatureInvalid { reason, .. } => {
+                assert_eq!(reason, PolicySignatureInvalidReason::SignatureInvalid);
+            }
+            other => panic!("expected PolicySignatureInvalid, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_rule_packs_version_regression_rejects_against_rule_packs_watermark() {
+        let now = OffsetDateTime::now_utc();
+        // rule-packs watermark already at 5; a v5 bundle is a regression even
+        // though the policy watermark is 0.
+        let mut h = build_harness_with_rule_packs(now, 0, 5);
+        let resp = sign(&h.sk, rule_packs_envelope(5, now), now);
+
+        let outcome = apply_rule_packs(&h.ctx, &resp).await;
+        assert_eq!(
+            outcome,
+            ApplyOutcome::Rejected {
+                reason: PolicySignatureInvalidReason::VersionRegression
+            }
+        );
+        assert!(!h.ctx.rule_packs_yaml_path.exists());
+
+        let ev = h.rx_event.recv().await.unwrap();
+        assert!(matches!(
+            ev.event.evidence,
+            Evidence::PolicySignatureInvalid {
+                reason: PolicySignatureInvalidReason::VersionRegression,
+                ..
+            }
+        ));
     }
 }

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -225,6 +225,7 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
     let mut effective = match sigil_core::policy::merge(
         defaults,
         Some(doc),
+        None,
         sigil_core::policy::current_platform(),
     ) {
         Ok(e) => e,
@@ -524,6 +525,7 @@ mod tests {
         sigil_core::policy::merge(
             sigil_core::policy::defaults().unwrap(),
             Some(sigil_core::policy::parse(yaml).unwrap()),
+            None,
             sigil_core::policy::current_platform(),
         )
         .unwrap()

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -147,12 +147,37 @@ fn reconcile_rule_packs(
     (added, removed)
 }
 
+/// Task 5 — read + parse the optional distributed rule-pack bundle
+/// (`rule-packs.yaml`, written beside `policy.yaml` by `apply_rule_packs`) into
+/// an `Option<PolicyDocument>`. Only its `.rule_packs` are consumed by `merge`
+/// as the 3rd (bundle) layer. Fail-open: a missing file → `None`; a corrupt
+/// file → warn + `None` (never crashes the agent).
+fn read_bundle_doc(path: &std::path::Path) -> Option<sigil_core::policy::PolicyDocument> {
+    let s = std::fs::read_to_string(path).ok()?;
+    match sigil_core::policy::parse(&s) {
+        Ok(d) => Some(d),
+        Err(e) => {
+            tracing::warn!(error = ?e, path = %path.display(),
+                "rule-packs.yaml parse failed; ignoring bundle layer");
+            None
+        }
+    }
+}
+
 /// Inputs for the reload task. The `WatcherHandle` lives here for the task's
 /// lifetime (so the OS watcher stays alive); `watched_roots` is the diff base
 /// for the next reconcile (start it equal to the roots `run` registered).
 pub struct ReloadCtx {
     pub policy_yaml_path: PathBuf,
     pub policy_version_rx: watch::Receiver<i64>,
+    /// Task 5 — bumped by `apply_rule_packs` whenever it commits a new
+    /// `rule-packs.yaml`. A change here re-runs `reload()` so the bundle's
+    /// rule packs are re-merged into the live parser set.
+    pub rule_packs_version_rx: watch::Receiver<i64>,
+    /// Task 5 — on-disk path of the distributed rule-pack bundle, beside
+    /// `policy.yaml`. IDENTICAL to `ApplyContext.rule_packs_yaml_path` so the
+    /// apply path writes exactly where boot/reload read.
+    pub rule_packs_yaml_path: PathBuf,
     pub targets_tx: watch::Sender<Arc<Vec<CompiledTarget>>>,
     pub watcher: WatcherHandle,
     pub watched_roots: Vec<(PathBuf, bool)>,
@@ -183,6 +208,13 @@ pub async fn run(mut ctx: ReloadCtx) {
             biased;
             _ = ctx.shutdown.cancelled() => break,
             changed = ctx.policy_version_rx.changed() => {
+                if changed.is_err() {
+                    // Sender (apply_ctx) dropped — agent is shutting down.
+                    break;
+                }
+                reload(&mut ctx, &plat);
+            }
+            changed = ctx.rule_packs_version_rx.changed() => {
                 if changed.is_err() {
                     // Sender (apply_ctx) dropped — agent is shutting down.
                     break;
@@ -222,10 +254,13 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
             return;
         }
     };
+    // Task 5 — read the distributed rule-pack bundle (3rd merge layer:
+    // defaults < policy < bundle). Missing/corrupt → None (fail-open).
+    let bundle = read_bundle_doc(&ctx.rule_packs_yaml_path);
     let mut effective = match sigil_core::policy::merge(
         defaults,
         Some(doc),
-        None,
+        bundle,
         sigil_core::policy::current_platform(),
     ) {
         Ok(e) => e,
@@ -563,6 +598,8 @@ mod tests {
         // duration (we drive `reload` directly, never `run`).
         std::mem::forget(_vtx);
         std::mem::forget(_rx);
+        let (_rptx, rule_packs_version_rx) = watch::channel(0i64);
+        std::mem::forget(_rptx);
 
         let cache = Arc::new(Mutex::new(HashCache::open(&dir.join("state.db")).unwrap()));
 
@@ -570,6 +607,8 @@ mod tests {
             ReloadCtx {
                 policy_yaml_path,
                 policy_version_rx,
+                rule_packs_version_rx,
+                rule_packs_yaml_path: dir.join("rule-packs.yaml"),
                 targets_tx,
                 watcher,
                 watched_roots: roots,
@@ -615,6 +654,8 @@ mod tests {
         let (_vtx, policy_version_rx) = watch::channel(1i64);
         std::mem::forget(_vtx);
         std::mem::forget(_rx);
+        let (_rptx, rule_packs_version_rx) = watch::channel(0i64);
+        std::mem::forget(_rptx);
 
         let cache = Arc::new(Mutex::new(HashCache::open(&dir.join("state.db")).unwrap()));
 
@@ -628,6 +669,8 @@ mod tests {
             ReloadCtx {
                 policy_yaml_path,
                 policy_version_rx,
+                rule_packs_version_rx,
+                rule_packs_yaml_path: dir.join("rule-packs.yaml"),
                 targets_tx,
                 watcher,
                 watched_roots: roots,
@@ -1225,5 +1268,64 @@ mod tests {
                 "state entry for surviving repoA should remain"
             );
         }
+    }
+
+    // Task 5 — distributed rule-pack bundle is merged as the 3rd layer at
+    // reload: a pack present only in `rule-packs.yaml` (not policy.yaml) shows
+    // up as a live RulePackParser after reload().
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reload_loads_rule_pack_from_distributed_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        // policy.yaml has no rule packs.
+        let initial = "version: 1\nhost_id_strategy: machine_id\ntargets:\n  - id: t1\n    description: x\n    tier: standard\n    platform: any\n    paths: [\"/tmp/x\"]\n";
+        let (mut ctx, plat, _trx, parsers, _state) = build_ctx_with_parsers(dir.path(), initial);
+
+        // Bundle (rule-packs.yaml) carries one UserGlobal pack.
+        let bundle = "version: 1\nrule_packs:\n  - id: bundle-pack\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: user_global\n    watched_paths: []\n    rules: []\n";
+        std::fs::write(&ctx.rule_packs_yaml_path, bundle).unwrap();
+
+        reload(&mut ctx, &plat);
+
+        let has_bundle = parsers.read().iter().any(|p| {
+            p.as_any()
+                .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
+                .map(|rpp| rpp.pack.id == "bundle-pack")
+                .unwrap_or(false)
+        });
+        assert!(
+            has_bundle,
+            "expected bundle-pack from rule-packs.yaml after reload"
+        );
+    }
+
+    // Task 5 — when policy.yaml and the distributed bundle both carry a pack
+    // with the SAME id, the bundle layer wins (merge order: defaults < policy
+    // < bundle). `pack_version` is a schema-compat field clamped to
+    // MAX_PACK_VERSION, so the observable discriminator here is `watched_paths`:
+    // the live pack must expose the BUNDLE's paths, not the policy's.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reload_bundle_pack_overrides_policy_pack_same_id() {
+        let dir = tempfile::tempdir().unwrap();
+        // policy.yaml authors pack `shared` with watched_paths ["from-policy"].
+        let initial = "version: 1\nhost_id_strategy: machine_id\ntargets:\n  - id: t1\n    description: x\n    tier: standard\n    platform: any\n    paths: [\"/tmp/x\"]\nrule_packs:\n  - id: shared\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: user_global\n    watched_paths: [\"from-policy\"]\n    rules: []\n";
+        let (mut ctx, plat, _trx, parsers, _state) = build_ctx_with_parsers(dir.path(), initial);
+
+        // Bundle authors the SAME id `shared` with watched_paths ["from-bundle"].
+        let bundle = "version: 1\nrule_packs:\n  - id: shared\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: user_global\n    watched_paths: [\"from-bundle\"]\n    rules: []\n";
+        std::fs::write(&ctx.rule_packs_yaml_path, bundle).unwrap();
+
+        reload(&mut ctx, &plat);
+
+        let live_paths = parsers.read().iter().find_map(|p| {
+            p.as_any()
+                .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
+                .filter(|rpp| rpp.pack.id == "shared")
+                .map(|rpp| rpp.pack.watched_paths.clone())
+        });
+        assert_eq!(
+            live_paths.as_deref(),
+            Some(["from-bundle".to_string()].as_slice()),
+            "bundle pack should override the policy pack with the same id"
+        );
     }
 }

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -398,6 +398,12 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
 
     // Phase 2: build ApplyContext (used by control IPC's apply_policy handler)
     // and ControlContext (used by control IPC dispatch).
+    // Rule-pack bundle destination sits beside policy.yaml. Task 5 wires the
+    // receiver of `rule_packs_version_tx` into the reload/merge; here we just
+    // create the channel so the apply path can broadcast. The receiver is
+    // dropped for now (Task 5 takes it).
+    let rule_packs_yaml_path = policy_path_for_apply.with_file_name("rule-packs.yaml");
+    let (rule_packs_version_tx, _rule_packs_version_rx) = watch::channel(0i64);
     let apply_ctx = Arc::new(crate::policy_apply::ApplyContext {
         keystore: keystore.clone(),
         cache: cache.clone(),
@@ -406,6 +412,8 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         event_tx: tx_sink.clone(),
         policy_version_tx: policy_version_tx.clone(),
         active_valid_until: active_valid_until.clone(),
+        rule_packs_yaml_path,
+        rule_packs_version_tx,
     });
     // The pipeline reads its matcher set from this watch channel; the
     // policy-reload task (spawned below) publishes new sets on `targets_tx`.

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -120,7 +120,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         Some(p) if p.exists() => Some(sigil_core::policy::parse(&std::fs::read_to_string(p)?)?),
         _ => None,
     };
-    let mut effective = merge(defaults()?, user_doc, current_platform())?;
+    let mut effective = merge(defaults()?, user_doc, None, current_platform())?;
     // (host_id resolution moved up above; effective.host_id_strategy is no longer consulted)
 
     // Phase 3b.6.2 — per-repo discovery for Continue / Claude Code / Codex.

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -120,7 +120,23 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         Some(p) if p.exists() => Some(sigil_core::policy::parse(&std::fs::read_to_string(p)?)?),
         _ => None,
     };
-    let mut effective = merge(defaults()?, user_doc, None, current_platform())?;
+    // Task 5 — distributed rule-pack bundle destination, beside policy.yaml.
+    // Defined here (not at the later ApplyContext) so the BOOT merge can read
+    // it as the 3rd layer (defaults < policy < bundle). MUST stay identical to
+    // `ApplyContext.rule_packs_yaml_path` so apply writes where boot/reload read.
+    let rule_packs_yaml_path = policy_path_for_apply.with_file_name("rule-packs.yaml");
+    // Fail-open: missing/corrupt rule-packs.yaml → None (no bundle packs).
+    let bundle_doc = std::fs::read_to_string(&rule_packs_yaml_path)
+        .ok()
+        .and_then(|s| match sigil_core::policy::parse(&s) {
+            Ok(d) => Some(d),
+            Err(e) => {
+                tracing::warn!(error = ?e, path = %rule_packs_yaml_path.display(),
+                    "rule-packs.yaml parse failed at boot; ignoring bundle layer");
+                None
+            }
+        });
+    let mut effective = merge(defaults()?, user_doc, bundle_doc, current_platform())?;
     // (host_id resolution moved up above; effective.host_id_strategy is no longer consulted)
 
     // Phase 3b.6.2 — per-repo discovery for Continue / Claude Code / Codex.
@@ -398,12 +414,11 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
 
     // Phase 2: build ApplyContext (used by control IPC's apply_policy handler)
     // and ControlContext (used by control IPC dispatch).
-    // Rule-pack bundle destination sits beside policy.yaml. Task 5 wires the
-    // receiver of `rule_packs_version_tx` into the reload/merge; here we just
-    // create the channel so the apply path can broadcast. The receiver is
-    // dropped for now (Task 5 takes it).
-    let rule_packs_yaml_path = policy_path_for_apply.with_file_name("rule-packs.yaml");
-    let (rule_packs_version_tx, _rule_packs_version_rx) = watch::channel(0i64);
+    // Rule-pack bundle destination sits beside policy.yaml (`rule_packs_yaml_path`
+    // defined above, shared with the boot merge). Task 5 wires the receiver of
+    // `rule_packs_version_tx` into the reload task below so an `apply_rule_packs`
+    // bump re-runs the 3-layer merge live.
+    let (rule_packs_version_tx, rule_packs_version_rx) = watch::channel(0i64);
     let apply_ctx = Arc::new(crate::policy_apply::ApplyContext {
         keystore: keystore.clone(),
         cache: cache.clone(),
@@ -412,7 +427,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         event_tx: tx_sink.clone(),
         policy_version_tx: policy_version_tx.clone(),
         active_valid_until: active_valid_until.clone(),
-        rule_packs_yaml_path,
+        rule_packs_yaml_path: rule_packs_yaml_path.clone(),
         rule_packs_version_tx,
     });
     // The pipeline reads its matcher set from this watch channel; the
@@ -526,6 +541,8 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
             crate::policy_reload_task::ReloadCtx {
                 policy_yaml_path: policy_path_for_apply.clone(),
                 policy_version_rx: policy_version_tx.subscribe(),
+                rule_packs_version_rx,
+                rule_packs_yaml_path,
                 targets_tx,
                 watcher: watcher_handle,
                 watched_roots: watch_roots,

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -57,7 +57,7 @@ pub fn run(
         Some(p) => Some(sigil_core::policy::parse(&std::fs::read_to_string(p)?)?),
         None => None,
     };
-    let effective = merge(defaults()?, user_doc, current_platform())?;
+    let effective = merge(defaults()?, user_doc, None, current_platform())?;
 
     match what {
         ShowWhat::Config => {

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -496,6 +496,9 @@ fn evidence_summary(e: &sigil_core::event::Evidence) -> (&'static str, String) {
             "policy_reloaded",
             format!("policy_version={policy_version}"),
         ),
+        Evidence::RulePackBundleApplied { version } => {
+            ("rule_pack_bundle_applied", format!("version={version}"))
+        }
         Evidence::PolicyExpiredActive { policy_version, .. } => (
             "policy_expired_active",
             format!("policy_version={policy_version}"),

--- a/crates/sigil-agent/src/sink_task.rs
+++ b/crates/sigil-agent/src/sink_task.rs
@@ -55,6 +55,7 @@ fn evidence_kind_str(e: &sigil_core::event::Evidence) -> &'static str {
         HostIdFingerprintDrift { .. } => "host_id_fingerprint_drift",
         PolicySignatureInvalid { .. } => "policy_signature_invalid",
         PolicyReloaded { .. } => "policy_reloaded",
+        RulePackBundleApplied { .. } => "rule_pack_bundle_applied",
         PolicyExpiredActive { .. } => "policy_expired_active",
         AgentJsonlForceGc { .. } => "agent_jsonl_force_gc",
         SenderSkippedSegment { .. } => "sender_skipped_segment",

--- a/crates/sigil-agent/tests/apply_policy_e2e.rs
+++ b/crates/sigil-agent/tests/apply_policy_e2e.rs
@@ -41,6 +41,7 @@ async fn apply_policy_writes_yaml_advances_version_emits_reloaded_and_no_expiry_
 
     let (event_tx, mut event_rx) = mpsc::channel(8);
     let (vtx, vrx) = watch::channel(0i64);
+    let (rp_vtx, _rp_vrx) = watch::channel(0i64);
     let active_vu = Arc::new(RwLock::new(None::<OffsetDateTime>));
     let policy_path = dir.path().join("policy.yaml");
     let apply_ctx = ApplyContext {
@@ -51,6 +52,8 @@ async fn apply_policy_writes_yaml_advances_version_emits_reloaded_and_no_expiry_
         event_tx: event_tx.clone(),
         policy_version_tx: vtx.clone(),
         active_valid_until: active_vu.clone(),
+        rule_packs_yaml_path: dir.path().join("rule-packs.yaml"),
+        rule_packs_version_tx: rp_vtx,
     };
 
     // Sign + send a v1 envelope.

--- a/crates/sigil-core/src/control_proto.rs
+++ b/crates/sigil-core/src/control_proto.rs
@@ -46,6 +46,14 @@ pub enum Request {
         /// The full server response — agent re-verifies independently.
         response: SignedPolicyResponse,
     },
+    /// `sigil-sender` hands a verified rule-pack bundle here for application.
+    /// Mirrors `ApplyPolicy` but advances the SEPARATE rule-packs watermark and
+    /// writes `rule-packs.yaml` — it never touches policy.yaml or the policy
+    /// version.
+    ApplyRulePacks {
+        /// The full server bundle response — agent re-verifies independently.
+        response: SignedPolicyResponse,
+    },
     /// Operator + sender introspection: returns the agent's current
     /// `last_applied_policy_version`, the active `valid_until`, and whether
     /// the active policy is currently expired.

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -377,6 +377,14 @@ pub enum Evidence {
         /// The new `last_applied_policy_version`.
         policy_version: i64,
     },
+    /// Emitted exactly once when a freshly-verified rule-pack bundle is
+    /// committed to disk + state.db. Sibling of `PolicyReloaded` for the
+    /// SEPARATE rule-packs watermark, so operators can distinguish a rule-pack
+    /// rollout from a policy rollout in the SIEM.
+    RulePackBundleApplied {
+        /// The new `last_applied_rule_packs_version`.
+        version: i64,
+    },
     /// Spec §3.10: emitted exactly once per "transition into expired".
     /// The agent continues to enforce the expired policy until a replacement
     /// arrives — `valid_until` is informational, not blocking. (Spec §1.4

--- a/crates/sigil-core/src/host_meta.rs
+++ b/crates/sigil-core/src/host_meta.rs
@@ -13,13 +13,17 @@ pub struct HostMeta {
     pub hw_fingerprint: Option<String>,
     /// Per-customer monotonic counter. Defaults to 0 on a fresh state.db.
     pub last_applied_policy_version: i64,
+    /// Per-customer monotonic counter for the applied rule-packs bundle.
+    /// Defaults to 0 on a fresh state.db.
+    pub last_applied_rule_packs_version: i64,
 }
 
 impl HashCache {
     /// Read the current host_meta row.
     pub fn host_meta_get(&self) -> Result<HostMeta, StateError> {
         let row = self.conn.query_row(
-            "SELECT host_id, hw_fingerprint, last_applied_policy_version
+            "SELECT host_id, hw_fingerprint, last_applied_policy_version,
+                    last_applied_rule_packs_version
              FROM host_meta WHERE id = 1",
             [],
             |r| {
@@ -27,6 +31,7 @@ impl HashCache {
                     host_id: r.get(0)?,
                     hw_fingerprint: r.get(1)?,
                     last_applied_policy_version: r.get(2)?,
+                    last_applied_rule_packs_version: r.get(3)?,
                 })
             },
         )?;
@@ -59,6 +64,18 @@ impl HashCache {
     pub fn host_meta_set_policy_version(&self, version: i64) -> Result<(), StateError> {
         self.conn.execute(
             "UPDATE host_meta SET last_applied_policy_version = ?1 WHERE id = 1",
+            rusqlite::params![version],
+        )?;
+        Ok(())
+    }
+
+    /// Set `last_applied_rule_packs_version` (advanced after a verified
+    /// rule-packs bundle is durably written). Mirrors
+    /// `host_meta_set_policy_version`; the monotonic check is enforced by the
+    /// caller's verify-chain, not here.
+    pub fn set_last_applied_rule_packs_version(&self, version: i64) -> Result<(), StateError> {
+        self.conn.execute(
+            "UPDATE host_meta SET last_applied_rule_packs_version = ?1 WHERE id = 1",
             rusqlite::params![version],
         )?;
         Ok(())
@@ -113,6 +130,20 @@ mod tests {
         cache.host_meta_set_policy_version(42).unwrap();
         let m = cache.host_meta_get().unwrap();
         assert_eq!(m.last_applied_policy_version, 42);
+    }
+
+    #[test]
+    fn rule_packs_version_round_trips_and_column_exists() {
+        let (_dir, c) = fresh_cache();
+        assert_eq!(
+            c.host_meta_get().unwrap().last_applied_rule_packs_version,
+            0
+        );
+        c.set_last_applied_rule_packs_version(7).unwrap();
+        assert_eq!(
+            c.host_meta_get().unwrap().last_applied_rule_packs_version,
+            7
+        );
     }
 
     #[test]

--- a/crates/sigil-core/src/policy/atomic_writer.rs
+++ b/crates/sigil-core/src/policy/atomic_writer.rs
@@ -37,6 +37,45 @@ pub fn atomic_write(
     cache: &HashCache,
     new_version: i64,
 ) -> Result<(), AtomicWriteError> {
+    // 1–3. Crash-safe file write (tmp + fsync + rename + dir fsync).
+    write_file_durably(target, policy_bytes)?;
+
+    // 4. Advance state.db. If THIS step fails, disk is ahead; boot
+    //    reconciliation handles it. We surface the error so the caller can
+    //    log it for operator triage.
+    cache
+        .host_meta_set_policy_version(new_version)
+        .map_err(AtomicWriteError::StateAfterDisk)?;
+
+    Ok(())
+}
+
+/// Sibling of [`atomic_write`] for a signed rule-packs bundle: the SAME
+/// crash-safe file write, but it advances the RULE-PACKS watermark
+/// (`last_applied_rule_packs_version`) instead of the policy version. Same
+/// `AtomicWriteError` semantics: a crash between the disk write and the state.db
+/// update leaves disk ahead, recovered by boot reconciliation.
+pub fn atomic_write_rule_packs(
+    target: &Path,
+    rule_packs_bytes: &[u8],
+    cache: &HashCache,
+    new_version: i64,
+) -> Result<(), AtomicWriteError> {
+    // 1–3. Crash-safe file write (tmp + fsync + rename + dir fsync).
+    write_file_durably(target, rule_packs_bytes)?;
+
+    // 4. Advance the rule-packs watermark in state.db.
+    cache
+        .set_last_applied_rule_packs_version(new_version)
+        .map_err(AtomicWriteError::StateAfterDisk)?;
+
+    Ok(())
+}
+
+/// Shared crash-safe file write (steps 1–3 of the atomic-write protocol):
+/// write `bytes` to a pid-scoped temp file, fsync it, rename it over `target`,
+/// then fsync the parent directory (POSIX only). Does NOT touch state.db.
+fn write_file_durably(target: &Path, bytes: &[u8]) -> Result<(), AtomicWriteError> {
     let parent = target
         .parent()
         .map(PathBuf::from)
@@ -60,7 +99,7 @@ pub fn atomic_write(
             .write(true)
             .truncate(true)
             .open(&tmp)?;
-        f.write_all(policy_bytes)?;
+        f.write_all(bytes)?;
         f.sync_all()?;
     }
 
@@ -74,13 +113,6 @@ pub fn atomic_write(
         let dir = std::fs::OpenOptions::new().read(true).open(&parent)?;
         dir.sync_all()?;
     }
-
-    // 4. Advance state.db. If THIS step fails, disk is ahead; boot
-    //    reconciliation handles it. We surface the error so the caller can
-    //    log it for operator triage.
-    cache
-        .host_meta_set_policy_version(new_version)
-        .map_err(AtomicWriteError::StateAfterDisk)?;
 
     Ok(())
 }
@@ -105,6 +137,31 @@ mod tests {
         assert_eq!(
             cache.host_meta_get().unwrap().last_applied_policy_version,
             5
+        );
+    }
+
+    #[test]
+    fn writes_rule_packs_and_advances_rule_packs_version() {
+        let dir = tempdir().unwrap();
+        let cache = fresh_cache(&dir);
+        let target = dir.path().join("rule_packs.yaml");
+        atomic_write_rule_packs(&target, b"version: 1\nrule_packs: []\n", &cache, 3).unwrap();
+
+        assert_eq!(
+            std::fs::read(&target).unwrap(),
+            b"version: 1\nrule_packs: []\n"
+        );
+        assert_eq!(
+            cache
+                .host_meta_get()
+                .unwrap()
+                .last_applied_rule_packs_version,
+            3
+        );
+        // The policy watermark is untouched by the rule-packs writer.
+        assert_eq!(
+            cache.host_meta_get().unwrap().last_applied_policy_version,
+            0
         );
     }
 

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -13,7 +13,7 @@ pub mod pubkeys;
 pub mod signed_envelope;
 pub mod verify;
 
-pub use atomic_writer::{atomic_write, AtomicWriteError};
+pub use atomic_writer::{atomic_write, atomic_write_rule_packs, AtomicWriteError};
 pub use canonical::{to_canonical_bytes, CanonicalError};
 pub use pubkeys::{Keystore, KeystoreEntry, KeystoreError};
 pub use signed_envelope::{SignedEnvelope, SignedPolicyResponse};

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -245,6 +245,7 @@ pub struct EffectivePolicy {
 pub fn merge(
     defaults: PolicyDocument,
     user: Option<PolicyDocument>,
+    bundle: Option<PolicyDocument>,
     current: Platform,
 ) -> Result<EffectivePolicy, PolicyError> {
     let strategy = user
@@ -313,18 +314,27 @@ pub fn merge(
         .map(|u| u.antigravity_workspaces.clone())
         .unwrap_or_default();
 
-    // Phase 3b.7 — id-keyed reconciliation: start with defaults' packs;
-    // user packs replace by id or append.
+    // Phase 3b.7 — id-keyed reconciliation across three layers: start with
+    // defaults' packs; user packs replace by id or append; then bundle packs
+    // replace/append LAST (so a signed pack-set bundle wins on id collision).
+    // Only `bundle.rule_packs` is consulted — the bundle's other fields are
+    // ignored.
     let rule_packs: Vec<RulePack> = {
         let mut packs = defaults.rule_packs.clone();
-        if let Some(ref u) = user {
-            for upack in &u.rule_packs {
-                if let Some(idx) = packs.iter().position(|p| p.id == upack.id) {
-                    packs[idx] = upack.clone();
+        fn fold_packs(packs: &mut Vec<RulePack>, layer: &[RulePack]) {
+            for up in layer {
+                if let Some(i) = packs.iter().position(|p| p.id == up.id) {
+                    packs[i] = up.clone();
                 } else {
-                    packs.push(upack.clone());
+                    packs.push(up.clone());
                 }
             }
+        }
+        if let Some(ref u) = user {
+            fold_packs(&mut packs, &u.rule_packs);
+        }
+        if let Some(ref b) = bundle {
+            fold_packs(&mut packs, &b.rule_packs);
         }
         packs
     };
@@ -518,9 +528,47 @@ targets:
 
     #[test]
     fn merge_defaults_alone_filters_by_platform() {
-        let eff = merge(defaults_doc(), None, Platform::Macos).unwrap();
+        let eff = merge(defaults_doc(), None, None, Platform::Macos).unwrap();
         assert_eq!(eff.targets.len(), 1);
         assert_eq!(eff.targets[0].id, "d1");
+    }
+
+    #[test]
+    fn merge_bundle_packs_win_over_policy_and_defaults() {
+        fn pack(id: &str, ver: u32) -> RulePack {
+            RulePack {
+                id: id.into(),
+                pack_version: ver,
+                tool: crate::event::AiTool::Other,
+                tool_label: Some("x".into()),
+                scope: RulePackScope::UserGlobal,
+                watched_paths: vec![],
+                platforms: None,
+                rules: vec![],
+            }
+        }
+        let mut defaults = defaults_doc();
+        defaults.rule_packs = vec![pack("a", 1)];
+        // The user-policy and bundle layers carry only rule_packs here; clear
+        // their targets so the id-collision check on the target merge doesn't
+        // fire against the defaults' targets (we are exercising rule_packs).
+        let mut policy = defaults_doc();
+        policy.targets = vec![];
+        policy.rule_packs = vec![pack("a", 2), pack("b", 1)];
+        let mut bundle = defaults_doc();
+        bundle.targets = vec![];
+        bundle.rule_packs = vec![pack("b", 9)];
+        let eff = merge(defaults, Some(policy), Some(bundle), Platform::Macos).unwrap();
+        let by_id = |id: &str| {
+            eff.rule_packs
+                .iter()
+                .find(|p| p.id == id)
+                .unwrap()
+                .pack_version
+        };
+        assert_eq!(by_id("a"), 2); // policy beat defaults
+        assert_eq!(by_id("b"), 9); // bundle beat policy
+        assert_eq!(eff.rule_packs.len(), 2);
     }
 
     #[test]
@@ -543,7 +591,7 @@ targets:
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let eff = merge(defaults_doc(), Some(user), Platform::Macos).unwrap();
+        let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
         let ids: Vec<&str> = eff.targets.iter().map(|t| t.id.as_str()).collect();
         assert_eq!(ids, vec!["u1"]);
     }
@@ -568,7 +616,7 @@ targets:
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let eff = merge(defaults_doc(), Some(user), Platform::Macos).unwrap();
+        let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
         assert_eq!(eff.targets[0].tier, Tier::Standard);
     }
 
@@ -592,7 +640,7 @@ targets:
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let err = merge(defaults_doc(), Some(user), Platform::Macos).unwrap_err();
+        let err = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::UnknownOverrideId(_)));
     }
 
@@ -612,7 +660,7 @@ targets:
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let err = merge(defaults_doc(), Some(user), Platform::Macos).unwrap_err();
+        let err = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::DuplicateId(_)));
     }
 
@@ -636,7 +684,7 @@ targets:
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let err = merge(defaults, None, Platform::Macos).unwrap_err();
+        let err = merge(defaults, None, None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::EmptyTargets));
     }
 
@@ -667,7 +715,7 @@ targets:
             target_os = "windows",
             target_os = "linux"
         )) {
-            let eff = merge(defaults().unwrap(), None, current_platform()).unwrap();
+            let eff = merge(defaults().unwrap(), None, None, current_platform()).unwrap();
             assert!(!eff.targets.is_empty());
         }
     }
@@ -748,7 +796,7 @@ targets: []
             "version: 1\nhost_id_strategy: machine_id\nclaude_code_workspaces:\n  - '~/forks'\ncodex_workspaces:\n  - '~/work'\ntargets: []\n",
         )
         .unwrap();
-        let eff = merge(defaults().unwrap(), Some(user), current_platform()).unwrap();
+        let eff = merge(defaults().unwrap(), Some(user), None, current_platform()).unwrap();
         assert_eq!(eff.claude_code_workspaces, vec!["~/forks"]);
         assert_eq!(eff.codex_workspaces, vec!["~/work"]);
     }
@@ -848,7 +896,7 @@ rule_packs:
             "version: 1\nhost_id_strategy: machine_id\ntargets: []\nrule_packs:\n  - id: gemini-default\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: user_global\n    watched_paths: [\"~/override/path\"]\n    rules: []\n",
         )
         .unwrap();
-        let eff = merge(defaults_doc, Some(user), current_platform()).unwrap();
+        let eff = merge(defaults_doc, Some(user), None, current_platform()).unwrap();
         assert_eq!(eff.rule_packs.len(), 1);
         assert_eq!(eff.rule_packs[0].watched_paths, vec!["~/override/path"]);
     }
@@ -873,7 +921,7 @@ rule_packs:
             "version: 1\nhost_id_strategy: machine_id\ntargets: []\nrule_packs:\n  - id: mycorp-tool\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: user_global\n    watched_paths: []\n    rules: []\n",
         )
         .unwrap();
-        let eff = merge(defaults_doc, Some(user), current_platform()).unwrap();
+        let eff = merge(defaults_doc, Some(user), None, current_platform()).unwrap();
         assert_eq!(eff.rule_packs.len(), 2);
         assert!(eff.rule_packs.iter().any(|p| p.id == "mycorp-tool"));
         assert!(eff.rule_packs.iter().any(|p| p.id == "gemini-default"));
@@ -950,7 +998,7 @@ host_id_strategy: hostname
         };
         user.rubric_overrides
             .insert("destructive_in_hook_script".into(), 5.5);
-        let eff = merge(defaults, Some(user), current_platform()).unwrap();
+        let eff = merge(defaults, Some(user), None, current_platform()).unwrap();
         assert_eq!(
             eff.rubric_overrides.get("destructive_in_hook_script"),
             Some(&5.5_f32)
@@ -1003,7 +1051,7 @@ host_id_strategy: hostname
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let eff = merge(defaults().unwrap(), Some(user), current_platform()).unwrap();
+        let eff = merge(defaults().unwrap(), Some(user), None, current_platform()).unwrap();
         assert_eq!(eff.gemini_workspaces, vec!["~/src/a".to_string()]);
         assert_eq!(eff.cursor_workspaces, vec!["~/src/b".to_string()]);
         assert_eq!(eff.antigravity_workspaces, vec!["~/src/c".to_string()]);

--- a/crates/sigil-core/src/state.rs
+++ b/crates/sigil-core/src/state.rs
@@ -37,10 +37,18 @@ impl HashCache {
                 id INTEGER PRIMARY KEY CHECK (id = 1),
                 host_id TEXT,
                 hw_fingerprint TEXT,
-                last_applied_policy_version INTEGER NOT NULL DEFAULT 0
+                last_applied_policy_version INTEGER NOT NULL DEFAULT 0,
+                last_applied_rule_packs_version INTEGER NOT NULL DEFAULT 0
             )",
             [],
         )?;
+        // Idempotent migration for pre-existing state.db files created before the
+        // rule-packs watermark column existed. SQLite has no ADD COLUMN IF NOT
+        // EXISTS, so ignore the duplicate-column error on a fresh/already-migrated DB.
+        let _ = conn.execute(
+            "ALTER TABLE host_meta ADD COLUMN last_applied_rule_packs_version INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
         // Ensure singleton row 1 exists. Idempotent.
         conn.execute(
             "INSERT OR IGNORE INTO host_meta (id, host_id, hw_fingerprint, last_applied_policy_version)

--- a/crates/sigil-core/tests/properties.rs
+++ b/crates/sigil-core/tests/properties.rs
@@ -44,8 +44,8 @@ proptest! {
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let r1 = merge(defaults.clone(), None, Platform::Any).unwrap();
-        let r2 = merge(defaults, None, Platform::Any).unwrap();
+        let r1 = merge(defaults.clone(), None, None, Platform::Any).unwrap();
+        let r2 = merge(defaults, None, None, Platform::Any).unwrap();
         prop_assert_eq!(r1, r2);
     }
 
@@ -86,7 +86,7 @@ proptest! {
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
         };
-        let res = merge(defaults, Some(user), Platform::Any);
+        let res = merge(defaults, Some(user), None, Platform::Any);
         prop_assert!(res.is_err());
     }
 

--- a/crates/sigil-sender/src/agent_ipc.rs
+++ b/crates/sigil-sender/src/agent_ipc.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 #[serde(tag = "cmd", rename_all = "snake_case")]
 enum AgentRequest<'a> {
     ApplyPolicy { response: &'a SignedPolicyResponse },
+    ApplyRulePacks { response: &'a SignedPolicyResponse },
 }
 
 #[derive(Deserialize, Debug)]
@@ -64,6 +65,33 @@ pub async fn apply_policy(
     Ok(parsed)
 }
 
+/// Sends a fresh rule-pack bundle to the agent. Mirrors [`apply_policy`]:
+/// same socket protocol, just the `ApplyRulePacks` request variant.
+#[cfg(unix)]
+pub async fn apply_rule_packs(
+    socket_path: &Path,
+    response: &SignedPolicyResponse,
+) -> Result<AgentResponse, IpcError> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+    let stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(|source| IpcError::Connect {
+            path: socket_path.to_path_buf(),
+            source,
+        })?;
+    let (rd, mut wr) = stream.into_split();
+    let req = AgentRequest::ApplyRulePacks { response };
+    let mut req_bytes = serde_json::to_vec(&req)?;
+    req_bytes.push(b'\n');
+    wr.write_all(&req_bytes).await?;
+    wr.shutdown().await.ok();
+    let mut buf = String::new();
+    BufReader::new(rd).read_line(&mut buf).await?;
+    let parsed: AgentResponse = serde_json::from_str(buf.trim())?;
+    Ok(parsed)
+}
+
 #[cfg(windows)]
 pub async fn apply_policy(
     pipe_name: &Path,
@@ -79,6 +107,33 @@ pub async fn apply_policy(
             source,
         })?;
     let req = AgentRequest::ApplyPolicy { response };
+    let mut req_bytes = serde_json::to_vec(&req)?;
+    req_bytes.push(b'\n');
+    client.write_all(&req_bytes).await?;
+    client.flush().await?;
+    let mut buf = String::new();
+    BufReader::new(&mut client).read_line(&mut buf).await?;
+    let parsed: AgentResponse = serde_json::from_str(buf.trim())?;
+    Ok(parsed)
+}
+
+/// Sends a fresh rule-pack bundle to the agent. Mirrors [`apply_policy`]:
+/// same pipe protocol, just the `ApplyRulePacks` request variant.
+#[cfg(windows)]
+pub async fn apply_rule_packs(
+    pipe_name: &Path,
+    response: &SignedPolicyResponse,
+) -> Result<AgentResponse, IpcError> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::windows::named_pipe::ClientOptions;
+    let pipe_str = pipe_name.to_string_lossy().to_string();
+    let mut client = ClientOptions::new()
+        .open(pipe_str.as_str())
+        .map_err(|source| IpcError::Connect {
+            path: pipe_name.to_path_buf(),
+            source,
+        })?;
+    let req = AgentRequest::ApplyRulePacks { response };
     let mut req_bytes = serde_json::to_vec(&req)?;
     req_bytes.push(b'\n');
     client.write_all(&req_bytes).await?;

--- a/crates/sigil-sender/src/control_task.rs
+++ b/crates/sigil-sender/src/control_task.rs
@@ -11,6 +11,12 @@ pub enum PollOutcome {
         etag: String,
         response: SignedPolicyResponse,
     },
+    /// Server returned a fresh rule-pack bundle. Caller hands this to
+    /// apply_rule_packs IPC. Same response shape as a policy.
+    NewRulePacks {
+        etag: String,
+        response: SignedPolicyResponse,
+    },
     /// Server returned 304 — no work to do.
     Unmodified,
     /// 404 → host is not in inventory; emit local event.
@@ -69,6 +75,61 @@ pub async fn poll_policy(
     }
 }
 
+/// Polls `/v1/rule-packs`. Mirrors [`poll_policy`] but hits the rule-packs
+/// endpoint and maps success → [`PollOutcome::NewRulePacks`].
+///
+/// A 404 is BENIGN here: rule packs are opt-in, so a host without a
+/// configured bundle (or an unknown host) returns 404. The authoritative
+/// host-allowlist signal is the `/v1/policy` poll (which maps 404 →
+/// `HostUnknown`); to avoid double-signalling we treat the rule-packs 404 as
+/// `Unmodified` — there is simply nothing to apply.
+pub async fn poll_rule_packs(
+    client: &Client,
+    server_base_url: &str,
+    host_id: &str,
+    cached_etag: Option<&str>,
+) -> PollOutcome {
+    let url = format!(
+        "{}/v1/rule-packs?host_id={}",
+        server_base_url.trim_end_matches('/'),
+        urlencoding::encode(host_id)
+    );
+    let mut req = client.get(&url);
+    if let Some(etag) = cached_etag {
+        req = req.header("if-none-match", etag);
+    }
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => match classify_send_error::<()>(e) {
+            SendOutcome::TlsFailure(s) => return PollOutcome::TlsFailure(s),
+            SendOutcome::Network(s) => return PollOutcome::Network(s),
+            other => return PollOutcome::ProtocolViolation(format!("{other:?}")),
+        },
+    };
+    let status = resp.status().as_u16();
+    if status == 304 {
+        return PollOutcome::Unmodified;
+    }
+    if status == 404 {
+        // Benign: no bundle configured / not present. Not an error.
+        return PollOutcome::Unmodified;
+    }
+    if !(200..300).contains(&status) {
+        let body = resp.text().await.unwrap_or_default();
+        return PollOutcome::ProtocolViolation(format!("status {status}: {body}"));
+    }
+    let etag = resp
+        .headers()
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+    match resp.json::<SignedPolicyResponse>().await {
+        Ok(response) => PollOutcome::NewRulePacks { etag, response },
+        Err(e) => PollOutcome::ProtocolViolation(format!("rule-packs json: {e}")),
+    }
+}
+
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -86,7 +147,9 @@ pub struct ControlLoopCtx {
 /// ETag is held in-process (not persisted here — caller persists on
 /// agent ACK).
 pub async fn run(ctx: ControlLoopCtx) {
-    let mut cached_etag: Option<String> = None;
+    // Separate ETag caches: policy and rule packs version independently.
+    let mut policy_etag: Option<String> = None;
+    let mut packs_etag: Option<String> = None;
     let mut interval = tokio::time::interval(ctx.poll_interval);
     interval.tick().await; // skip immediate fire
     loop {
@@ -94,17 +157,29 @@ pub async fn run(ctx: ControlLoopCtx) {
             biased;
             _ = ctx.shutdown.cancelled() => break,
             _ = interval.tick() => {
-                let outcome = poll_policy(
+                let p = poll_policy(
                     &ctx.client,
                     &ctx.server_base_url,
                     &ctx.host_id,
-                    cached_etag.as_deref(),
+                    policy_etag.as_deref(),
                 ).await;
-                if let PollOutcome::NewPolicy { etag, .. } = &outcome {
-                    cached_etag = Some(etag.clone());
+                if let PollOutcome::NewPolicy { etag, .. } = &p {
+                    policy_etag = Some(etag.clone());
                 }
-                if ctx.outcomes.send(outcome).await.is_err() {
+                if ctx.outcomes.send(p).await.is_err() {
                     // Receiver dropped — exit loop.
+                    break;
+                }
+                let r = poll_rule_packs(
+                    &ctx.client,
+                    &ctx.server_base_url,
+                    &ctx.host_id,
+                    packs_etag.as_deref(),
+                ).await;
+                if let PollOutcome::NewRulePacks { etag, .. } = &r {
+                    packs_etag = Some(etag.clone());
+                }
+                if ctx.outcomes.send(r).await.is_err() {
                     break;
                 }
             }

--- a/crates/sigil-sender/src/control_task.rs
+++ b/crates/sigil-sender/src/control_task.rs
@@ -147,7 +147,7 @@ pub struct ControlLoopCtx {
 /// ETag is held in-process (not persisted here — caller persists on
 /// agent ACK).
 pub async fn run(ctx: ControlLoopCtx) {
-    // Separate ETag caches: policy and rule packs version independently.
+    // Separate ETag caches: policy and rule packs are versioned independently.
     let mut policy_etag: Option<String> = None;
     let mut packs_etag: Option<String> = None;
     let mut interval = tokio::time::interval(ctx.poll_interval);

--- a/crates/sigil-sender/src/runtime.rs
+++ b/crates/sigil-sender/src/runtime.rs
@@ -38,6 +38,7 @@ pub async fn run(ctx: RuntimeCtx) -> Result<()> {
     )?;
     let stats = heartbeat::shared();
     let etag_path = etag_path_for(&ctx.config.offset_path);
+    let packs_etag_path = packs_etag_path_for(&ctx.config.offset_path);
     let initial_etag = state::load_etag(&etag_path).ok().flatten();
 
     let (poll_tx, mut poll_rx) = mpsc::channel::<PollOutcome>(8);
@@ -65,6 +66,7 @@ pub async fn run(ctx: RuntimeCtx) -> Result<()> {
         let dead_letter_dir = ctx.config.dead_letter_dir.clone();
         let host_id = ctx.host_id.clone();
         let etag_path_c = etag_path.clone();
+        let packs_etag_path_c = packs_etag_path.clone();
         let cancel_r = ctx.shutdown.clone();
         // Seed the in-process etag with whatever boot recovery loaded so the
         // first successful apply_policy doesn't re-store an unchanged value.
@@ -90,6 +92,21 @@ pub async fn run(ctx: RuntimeCtx) -> Result<()> {
                                     }
                                     Err(e) => {
                                         tracing::warn!(error = ?e, "apply_policy IPC failed");
+                                    }
+                                }
+                            }
+                            Some(PollOutcome::NewRulePacks { etag, response }) => {
+                                match crate::agent_ipc::apply_rule_packs(&agent_socket, &response).await {
+                                    Ok(resp) if resp.ok => {
+                                        if let Err(e) = state::store_etag(&packs_etag_path_c, &etag) {
+                                            tracing::warn!(error = ?e, "store rule-packs etag failed");
+                                        }
+                                    }
+                                    Ok(resp) => {
+                                        tracing::warn!(?resp, "agent did not accept rule packs; not caching etag");
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = ?e, "apply_rule_packs IPC failed");
                                     }
                                 }
                             }
@@ -149,4 +166,14 @@ fn etag_path_for(offset_path: &std::path::Path) -> PathBuf {
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
     parent.join("policy-etag.txt")
+}
+
+/// Convention: `rule-packs-etag.txt` lives next to `sender-offset.json`,
+/// alongside `policy-etag.txt`. Kept separate so rule packs and policy
+/// version independently.
+fn packs_etag_path_for(offset_path: &std::path::Path) -> PathBuf {
+    let parent = offset_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."));
+    parent.join("rule-packs-etag.txt")
 }

--- a/crates/sigil-sender/src/runtime.rs
+++ b/crates/sigil-sender/src/runtime.rs
@@ -97,7 +97,9 @@ pub async fn run(ctx: RuntimeCtx) -> Result<()> {
                             }
                             Some(PollOutcome::NewRulePacks { etag, response }) => {
                                 match crate::agent_ipc::apply_rule_packs(&agent_socket, &response).await {
-                                    Ok(resp) if resp.ok => {
+                                    Ok(resp) if resp.ok
+                                        && matches!(resp.apply_policy, Some(ApplyPolicyResult::Accepted { .. })) =>
+                                    {
                                         if let Err(e) = state::store_etag(&packs_etag_path_c, &etag) {
                                             tracing::warn!(error = ?e, "store rule-packs etag failed");
                                         }
@@ -169,8 +171,8 @@ fn etag_path_for(offset_path: &std::path::Path) -> PathBuf {
 }
 
 /// Convention: `rule-packs-etag.txt` lives next to `sender-offset.json`,
-/// alongside `policy-etag.txt`. Kept separate so rule packs and policy
-/// version independently.
+/// alongside `policy-etag.txt`. Kept separate so rule packs and policy are
+/// versioned independently.
 fn packs_etag_path_for(offset_path: &std::path::Path) -> PathBuf {
     let parent = offset_path
         .parent()

--- a/crates/sigil-sender/tests/common/mod.rs
+++ b/crates/sigil-sender/tests/common/mod.rs
@@ -23,6 +23,10 @@ pub struct MockState {
     pub next_rejected: Vec<EventRejection>,
     pub policy_etag: String,
     pub policy_response: Option<sigil_sender::wire::SignedPolicyResponse>,
+    pub rule_packs_etag: String,
+    /// Rule-packs bundle. `None` → endpoint responds 404 (benign: not
+    /// configured). `Some` → 200 with the bundle (or 304 on etag match).
+    pub rule_packs_response: Option<sigil_sender::wire::SignedPolicyResponse>,
 }
 
 impl Default for MockState {
@@ -34,6 +38,8 @@ impl Default for MockState {
             next_rejected: Vec::new(),
             policy_etag: String::new(),
             policy_response: None,
+            rule_packs_etag: String::new(),
+            rule_packs_response: None,
         }
     }
 }
@@ -49,6 +55,7 @@ pub async fn spawn_mock() -> (SocketAddr, SharedMock) {
     let app = Router::new()
         .route("/v1/events", post(handle_events))
         .route("/v1/policy", get(handle_policy))
+        .route("/v1/rule-packs", get(handle_rule_packs))
         .with_state(state.clone());
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -125,4 +132,42 @@ async fn handle_policy(
         .map(|r| serde_json::to_value(r).unwrap())
         .unwrap_or(serde_json::json!(null));
     (axum::http::StatusCode::OK, out_headers, Json(body))
+}
+
+async fn handle_rule_packs(
+    State(state): State<SharedMock>,
+    headers: axum::http::HeaderMap,
+) -> (
+    axum::http::StatusCode,
+    axum::http::HeaderMap,
+    Json<serde_json::Value>,
+) {
+    let s = state.lock().await;
+    let mut out_headers = axum::http::HeaderMap::new();
+    // No bundle configured → 404 (benign).
+    let Some(resp) = s.rule_packs_response.as_ref() else {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            out_headers,
+            Json(serde_json::json!({"error": "no rule-pack bundle configured"})),
+        );
+    };
+    if let Some(etag) = headers.get("if-none-match") {
+        if etag.to_str().unwrap_or("") == s.rule_packs_etag {
+            return (
+                axum::http::StatusCode::NOT_MODIFIED,
+                out_headers,
+                Json(serde_json::json!(null)),
+            );
+        }
+    }
+    out_headers.insert(
+        "etag",
+        axum::http::HeaderValue::from_str(&s.rule_packs_etag).unwrap(),
+    );
+    (
+        axum::http::StatusCode::OK,
+        out_headers,
+        Json(serde_json::to_value(resp).unwrap()),
+    )
 }

--- a/crates/sigil-sender/tests/control_task_poll.rs
+++ b/crates/sigil-sender/tests/control_task_poll.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use sigil_core::policy::signed_envelope::{SignedEnvelope, SignedPolicyResponse};
-use sigil_sender::control_task::{poll_policy, PollOutcome};
+use sigil_sender::control_task::{poll_policy, poll_rule_packs, PollOutcome};
 use time::macros::datetime;
 
 fn sample_response(etag: &str) -> SignedPolicyResponse {
@@ -45,6 +45,48 @@ async fn matching_etag_returns_unmodified() {
     match poll_policy(&client, &format!("http://{addr}"), "h", Some("abc")).await {
         PollOutcome::Unmodified => {}
         other => panic!("expected Unmodified, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rule_packs_no_etag_returns_new_rule_packs() {
+    let (addr, state) = common::spawn_mock().await;
+    {
+        let mut s = state.lock().await;
+        s.rule_packs_etag = "packs-fresh".into();
+        s.rule_packs_response = Some(sample_response("packs-fresh"));
+    }
+    let client = reqwest::Client::new();
+    match poll_rule_packs(&client, &format!("http://{addr}"), "h", None).await {
+        PollOutcome::NewRulePacks { etag, .. } => assert_eq!(etag, "packs-fresh"),
+        other => panic!("expected NewRulePacks, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rule_packs_matching_etag_returns_unmodified() {
+    let (addr, state) = common::spawn_mock().await;
+    {
+        let mut s = state.lock().await;
+        s.rule_packs_etag = "p-abc".into();
+        s.rule_packs_response = Some(sample_response("p-abc"));
+    }
+    let client = reqwest::Client::new();
+    match poll_rule_packs(&client, &format!("http://{addr}"), "h", Some("p-abc")).await {
+        PollOutcome::Unmodified => {}
+        other => panic!("expected Unmodified, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rule_packs_404_is_benign_unmodified() {
+    // No bundle configured → server returns 404. This MUST be benign
+    // (Unmodified), not HostUnknown or a protocol violation.
+    let (addr, _state) = common::spawn_mock().await;
+    let client = reqwest::Client::new();
+    match poll_rule_packs(&client, &format!("http://{addr}"), "h", None).await {
+        PollOutcome::Unmodified => {}
+        other => panic!("expected Unmodified (benign 404), got {other:?}"),
     }
 }
 

--- a/crates/sigil-server/src/app.rs
+++ b/crates/sigil-server/src/app.rs
@@ -19,6 +19,8 @@ use std::sync::{Arc, Mutex};
 pub struct AppState {
     pub events_out_dir: PathBuf,
     pub policy_bundle_path: PathBuf,
+    /// Path to the signed pack-set bundle. `None` ⇒ `GET /v1/rule-packs` 404s.
+    pub rule_packs_bundle_path: Option<std::path::PathBuf>,
     pub high_water_path: PathBuf,
     /// `None` ⇒ every authenticated host is accepted.
     pub allowlist: Option<HashSet<String>>,
@@ -54,6 +56,10 @@ pub fn build_router(state: SharedState) -> Router {
     Router::new()
         .route("/v1/events", post(crate::events_route::post_events))
         .route("/v1/policy", get(crate::policy_route::get_policy))
+        .route(
+            "/v1/rule-packs",
+            get(crate::rule_packs_route::get_rule_packs),
+        )
         .route(HEALTHZ_PATH, get(crate::routes::healthz::get_healthz))
         .route(
             "/v1/meta",

--- a/crates/sigil-server/src/config.rs
+++ b/crates/sigil-server/src/config.rs
@@ -35,6 +35,10 @@ pub struct ServerConfig {
     /// Path to the operator-signed policy bundle (`SignedPolicyResponse` JSON,
     /// produced by `sigil-sign`). Absent file ⇒ `GET /v1/policy` returns 404.
     pub policy_bundle_path: PathBuf,
+    /// Path to the signed pack-set bundle (`SignedPolicyResponse`-shaped JSON,
+    /// produced by `sigil-sign`). Absent ⇒ `GET /v1/rule-packs` returns 404.
+    #[serde(default)]
+    pub rule_packs_bundle_path: Option<std::path::PathBuf>,
     /// Optional allowlist of `host_id`s. Absent ⇒ accept all authenticated hosts.
     #[serde(default)]
     pub host_allowlist_path: Option<PathBuf>,

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -136,7 +136,8 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
         | Evidence::CertExpired { .. }
         | Evidence::TlsFailure { .. }
         | Evidence::EventUnprocessableLocal { .. }
-        | Evidence::ServerProtocolViolation { .. } => { /* identity + severity only */ }
+        | Evidence::ServerProtocolViolation { .. }
+        | Evidence::RulePackBundleApplied { .. } => { /* identity + severity only */ }
         Evidence::HookInvocation(_) | Evidence::Unknown => { /* not indexed in Stage 1 */ }
     }
 }

--- a/crates/sigil-server/src/lib.rs
+++ b/crates/sigil-server/src/lib.rs
@@ -29,3 +29,4 @@ pub mod license_state;
 pub mod persist;
 pub mod policy_route;
 pub mod routes;
+pub mod rule_packs_route;

--- a/crates/sigil-server/src/main.rs
+++ b/crates/sigil-server/src/main.rs
@@ -68,6 +68,7 @@ fn build_state(cfg: &ServerConfig) -> Result<SharedState> {
     Ok(Arc::new(AppState {
         events_out_dir: cfg.events_out_dir.clone(),
         policy_bundle_path: cfg.policy_bundle_path.clone(),
+        rule_packs_bundle_path: cfg.rule_packs_bundle_path.clone(),
         high_water_path: cfg.high_water_path(),
         allowlist,
         high_water: Mutex::new(high_water),

--- a/crates/sigil-server/src/rule_packs_route.rs
+++ b/crates/sigil-server/src/rule_packs_route.rs
@@ -1,0 +1,76 @@
+//! `GET /v1/rule-packs?host_id=X` — serve the signed pack-set bundle with
+//! ETag-based 304. Mirrors policy_route; 404 when no bundle is configured.
+use crate::{allowlist, app::SharedState};
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+#[derive(serde::Deserialize)]
+pub struct RulePacksQuery {
+    pub host_id: String,
+}
+
+pub async fn get_rule_packs(
+    State(state): State<SharedState>,
+    Query(q): Query<RulePacksQuery>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if !allowlist::permits(&state.allowlist, &q.host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "host_unknown", "host_id": q.host_id})),
+        )
+            .into_response();
+    }
+    let Some(path) = state.rule_packs_bundle_path.as_ref() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "rule_packs_not_configured"})),
+        )
+            .into_response();
+    };
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "no_rule_packs"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = ?e, "read rule-packs bundle failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "bundle_read_failed"})),
+            )
+                .into_response();
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!(error = ?e, "rule-packs bundle is not valid JSON");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "bundle_parse_failed"})),
+            )
+                .into_response();
+        }
+    };
+    let etag = value
+        .get("etag")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if let Some(inm) = headers.get("if-none-match").and_then(|v| v.to_str().ok()) {
+        if inm == etag {
+            return (StatusCode::NOT_MODIFIED, [("etag", etag)]).into_response();
+        }
+    }
+    (StatusCode::OK, [("etag", etag)], Json(value)).into_response()
+}

--- a/crates/sigil-server/tests/audit.rs
+++ b/crates/sigil-server/tests/audit.rs
@@ -19,6 +19,7 @@ async fn meta_reports_audit_head_when_signing_enabled() {
     let state = Arc::new(AppState {
         events_out_dir: dir.path().to_path_buf(),
         policy_bundle_path: dir.path().join("p.json"),
+        rule_packs_bundle_path: None,
         high_water_path: dir.path().join(".hw.json"),
         allowlist: None::<HashSet<String>>,
         high_water: Mutex::new(HighWater::default()),
@@ -69,6 +70,7 @@ async fn meta_reports_null_audit_head_when_disabled() {
     let state = Arc::new(AppState {
         events_out_dir: dir.path().to_path_buf(),
         policy_bundle_path: dir.path().join("p.json"),
+        rule_packs_bundle_path: None,
         high_water_path: dir.path().join(".hw.json"),
         allowlist: None::<HashSet<String>>,
         high_water: Mutex::new(HighWater::default()),

--- a/crates/sigil-server/tests/auth_e2e.rs
+++ b/crates/sigil-server/tests/auth_e2e.rs
@@ -21,6 +21,7 @@ fn state(dir: &std::path::Path, token: ReadToken) -> Arc<AppState> {
         license_state: sigil_core::license::status::LicenseState::Free,
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     })
 }

--- a/crates/sigil-server/tests/boot_rebuild_e2e.rs
+++ b/crates/sigil-server/tests/boot_rebuild_e2e.rs
@@ -64,6 +64,7 @@ async fn boot_rebuild_populates_fleet_hosts() {
         license_state: sigil_core::license::status::LicenseState::Free,
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     });
     let app = build_router(state);

--- a/crates/sigil-server/tests/events_pagination_e2e.rs
+++ b/crates/sigil-server/tests/events_pagination_e2e.rs
@@ -48,6 +48,7 @@ async fn events_pagination_walks_in_pages() {
         license_state: sigil_core::license::status::LicenseState::Free,
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     });
     let app = build_router(state);

--- a/crates/sigil-server/tests/host_meta_in_detail_e2e.rs
+++ b/crates/sigil-server/tests/host_meta_in_detail_e2e.rs
@@ -51,6 +51,7 @@ async fn ingested_host_meta_appears_in_detail_block() {
     let state = Arc::new(AppState {
         events_out_dir: dir.path().to_path_buf(),
         policy_bundle_path: dir.path().join("p.json"),
+        rule_packs_bundle_path: None,
         high_water_path: dir.path().join(".hw.json"),
         allowlist: None::<HashSet<String>>,
         high_water: Mutex::new(HighWater::default()),

--- a/crates/sigil-server/tests/http_routes.rs
+++ b/crates/sigil-server/tests/http_routes.rs
@@ -10,11 +10,20 @@ use std::sync::{Arc, Mutex};
 use tower::ServiceExt;
 
 fn state_in(dir: &std::path::Path, allowlist: Option<HashSet<String>>) -> Arc<AppState> {
+    state_in_with_rule_packs(dir, allowlist, None)
+}
+
+fn state_in_with_rule_packs(
+    dir: &std::path::Path,
+    allowlist: Option<HashSet<String>>,
+    rule_packs_bundle_path: Option<std::path::PathBuf>,
+) -> Arc<AppState> {
     use sigil_server::auth::ReadToken;
     use sigil_server::fleet_index::FleetIndex;
     Arc::new(AppState {
         events_out_dir: dir.to_path_buf(),
         policy_bundle_path: dir.join("signed-policy.json"),
+        rule_packs_bundle_path,
         high_water_path: dir.join(".high-water.json"),
         allowlist,
         high_water: Mutex::new(HighWater::default()),
@@ -262,4 +271,93 @@ async fn allowlist_blocks_unknown_host_on_policy() {
     let app = build_router(state_in(dir.path(), Some(set)));
     let (status, _, _) = get_policy(&app, "stranger", None).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+async fn get_rule_packs(
+    app: &axum::Router,
+    host_id: &str,
+    if_none_match: Option<&str>,
+) -> (StatusCode, Option<String>, serde_json::Value) {
+    let mut b = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/rule-packs?host_id={host_id}"));
+    if let Some(inm) = if_none_match {
+        b = b.header("if-none-match", inm);
+    }
+    let resp = app
+        .clone()
+        .oneshot(b.body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let etag = resp
+        .headers()
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, etag, json)
+}
+
+#[tokio::test]
+async fn rule_packs_404_when_not_configured() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state_in(dir.path(), None));
+    let (status, _, body) = get_rule_packs(&app, "h-1", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "rule_packs_not_configured");
+}
+
+#[tokio::test]
+async fn rule_packs_200_then_304_with_matching_etag() {
+    let dir = tempfile::tempdir().unwrap();
+    // Write a minimal SignedPolicyResponse-shaped pack-set bundle.
+    let bundle = serde_json::json!({
+        "etag": "cafef00d",
+        "signed_envelope": {
+            "policy_version": 1,
+            "policy_bytes_b64": "cGFja3M6IFtdCg==",
+            "valid_until": "2027-01-01T00:00:00Z",
+            "issued_at": "2026-05-11T00:00:00Z"
+        },
+        "signature": "AAAA",
+        "signing_pubkey_id": "k1",
+        "applied_at": "2026-05-11T00:00:01Z"
+    });
+    let bundle_path = dir.path().join("signed-rule-packs.json");
+    std::fs::write(&bundle_path, serde_json::to_vec(&bundle).unwrap()).unwrap();
+    let app = build_router(state_in_with_rule_packs(
+        dir.path(),
+        None,
+        Some(bundle_path),
+    ));
+
+    let (status, etag, body) = get_rule_packs(&app, "h-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(etag.as_deref(), Some("cafef00d"));
+    assert_eq!(body["signing_pubkey_id"], "k1");
+
+    let (status, _, _) = get_rule_packs(&app, "h-1", Some("cafef00d")).await;
+    assert_eq!(status, StatusCode::NOT_MODIFIED);
+
+    let (status, _, _) = get_rule_packs(&app, "h-1", Some("stale-etag")).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn allowlist_blocks_unknown_host_on_rule_packs() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut set = HashSet::new();
+    set.insert("known-host".to_string());
+    let app = build_router(state_in_with_rule_packs(
+        dir.path(),
+        Some(set),
+        Some(dir.path().join("signed-rule-packs.json")),
+    ));
+    let (status, _, body) = get_rule_packs(&app, "stranger", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "host_unknown");
 }

--- a/crates/sigil-server/tests/license.rs
+++ b/crates/sigil-server/tests/license.rs
@@ -39,6 +39,7 @@ async fn meta_reports_over_limit_for_free_tier_above_200_active_hosts() {
         license_state: LicenseState::Free,
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     });
 
@@ -102,6 +103,7 @@ async fn meta_reports_ok_for_valid_license_under_its_limit() {
         license_state: LicenseState::Valid(doc),
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     });
 
@@ -166,6 +168,7 @@ async fn meta_reports_expired_falls_back_to_free_tier() {
         license_state: LicenseState::Expired(doc),
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     });
 

--- a/crates/sigil-server/tests/read_api_e2e.rs
+++ b/crates/sigil-server/tests/read_api_e2e.rs
@@ -21,6 +21,7 @@ fn state_with_token(dir: &std::path::Path, token: &str) -> Arc<AppState> {
         license_state: sigil_core::license::status::LicenseState::Free,
         active_window_days: 7,
         audit_key: None,
+        rule_packs_bundle_path: None,
         audit_head: Mutex::new(None),
     })
 }


### PR DESCRIPTION
Implements **#53 sub-item 3b.7.4** — a dedicated, independently-signed channel to distribute rule packs to the fleet, separate from the base policy.

## Key insight (drives the design)

A pack-set bundle is just a **signed `PolicyDocument` whose only meaningful field is `rule_packs`** — so the signer, `SignedPolicyResponse` wire type, `verify_envelope` (5-check), and YAML parse are reused **verbatim**. The only genuinely new pieces are a parallel route, a parallel version watermark, and a 3rd merge layer.

## Decisions

- **D1** dedicated channel (`GET /v1/rule-packs`), not server-side composition into `/v1/policy`.
- **D2** one pack-set bundle (single `SignedEnvelope` over the whole set), not per-pack/catalog.
- **D3** merge precedence `defaults < policy < bundle` — the dedicated channel wins on a pack-id collision.
- **D4** bundle = signed `PolicyDocument` with only `rule_packs`.

## Data flow

`GET /v1/rule-packs` (server) → sender `poll_rule_packs` (same loop, **separate etag**) → `ApplyRulePacks` IPC → agent `apply_rule_packs` (**separate watermark** `last_applied_rule_packs_version`, `verify_envelope` reused) → atomic-write `rule-packs.yaml` → reload reads it as the **3rd merge layer** → existing `reconcile_rule_packs`.

## Commits (TDD, per layer)

1. core — 3-layer merge + rule-packs version watermark (idempotent DB migration) + `atomic_write_rule_packs`
2. server — `GET /v1/rule-packs` (404 when unset, ETag/304, unauthenticated like `/v1/policy`)
3. sender — poll `/v1/rule-packs` alongside policy (separate etag; 404 benign)
4. agent — `apply_rule_packs` (separate watermark, `RulePackBundleApplied` event)
5. agent — merge the bundle at boot + reload (path-identity: apply writes where boot/reload read)
6. doctor — show the applied bundle version
7. polish — mirror the policy accept-gate for the rule-packs etag cache

## Independence / fail-safe

The rule-packs watermark, etag, file, and reload trigger are all fully independent of the policy path. A failed/absent/corrupt bundle (404, bad sig, unparseable `rule-packs.yaml`) never disturbs the policy path or crashes the agent (404→benign, `read_bundle_doc` fail-open, reject leaves state intact).

## Reuse (unmodified)

`sigil-signer`, `verify_envelope`, the keystore, `SignedEnvelope`/`SignedPolicyResponse`, and `reconcile_rule_packs` are all untouched.

## Testing

Unit + integration across all 4 crates (merge precedence, route 200/304/404/allowlist, poll mapping, apply accept/reject with watermark isolation, reload 3-layer + override-by-id). `cargo fmt` + `clippy --workspace -D warnings` + `cargo test --workspace` green.

A **real-machine E2E** (sign a bundle on sigil-server001 → Windows agent fetch/verify/apply) is planned as a separate operational verification (not in CI).

Mechanism-only (public repo) — this is the open distribution mechanism; what content rides it is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)