### PR TITLE
fix: doctor --state-db + sender optional mTLS (E2E findings, #97 #98)

### DIFF
--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -140,7 +140,7 @@ pub(crate) fn verify_self_impl(
     }
 }
 
-pub fn run(policy_override: Option<PathBuf>) -> i32 {
+pub fn run(policy_override: Option<PathBuf>, state_db_override: Option<PathBuf>) -> i32 {
     let plat = ActivePlatform::new();
     let mut warn_count = 0;
     let mut error_count = 0;
@@ -227,8 +227,9 @@ pub fn run(policy_override: Option<PathBuf>) -> i32 {
     }
     println!("[OK]   total expanded paths: {total_paths}");
 
-    // Phase 2: show persisted host_id from state.db.
-    let state_db_path = default_state_db_path();
+    // Phase 2: show persisted host_id from state.db. Honor the `--state-db`
+    // override (matching `sigil show`); fall back to the default path.
+    let state_db_path = state_db_override.unwrap_or_else(default_state_db_path);
     match sigil_core::state::HashCache::open(&state_db_path) {
         Ok(cache) => match cache.host_meta_get() {
             Ok(meta) => {

--- a/crates/sigil-agent/src/main.rs
+++ b/crates/sigil-agent/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
             let code = if verify_self {
                 doctor::verify_self(manifest)
             } else {
-                doctor::run(cli.policy)
+                doctor::run(cli.policy, cli.state_db)
             };
             std::process::exit(code);
         }

--- a/crates/sigil-sender/src/config.rs
+++ b/crates/sigil-sender/src/config.rs
@@ -11,12 +11,19 @@ use thiserror::Error;
 pub struct SenderConfig {
     /// HTTPS URL of `sigil-server-gateway`. e.g., `https://sigil.example.com`.
     pub server_base_url: String,
-    /// Path to client cert (PEM).
-    pub client_cert_path: PathBuf,
-    /// Path to client private key (PEM).
-    pub client_key_path: PathBuf,
-    /// Path to CA bundle that signs the server cert (PEM).
-    pub server_ca_path: PathBuf,
+    /// Path to client cert (PEM). Optional: omit (with `client_key_path`) to
+    /// run without an mTLS client identity — e.g. against a plain-HTTP dev
+    /// server. mTLS is the recommended production posture.
+    #[serde(default)]
+    pub client_cert_path: Option<PathBuf>,
+    /// Path to client private key (PEM). Required iff `client_cert_path` is set.
+    #[serde(default)]
+    pub client_key_path: Option<PathBuf>,
+    /// Path to CA bundle that signs the server cert (PEM). Optional: when set,
+    /// the server cert is pinned to this CA (built-in roots disabled);
+    /// otherwise the platform's built-in roots are used.
+    #[serde(default)]
+    pub server_ca_path: Option<PathBuf>,
     /// Path to the agent's events directory (where JSONL spool lives). The
     /// sender only *reads* this (the agent owns it `root:sigil`), so it is
     /// reachable by the `sigil` group.
@@ -191,6 +198,27 @@ policy_poll_interval: 30
         assert_eq!(cfg.max_batch_events, 64);
         assert_eq!(cfg.max_batch_bytes, 65536);
         assert_eq!(cfg.policy_poll_interval.as_secs(), 30);
+    }
+
+    #[test]
+    fn certs_absent_parses_to_none() {
+        // A plain-HTTP / no-mTLS config: the three cert paths may be omitted.
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("sender.yaml");
+        write(
+            &p,
+            r#"
+server_base_url: "http://127.0.0.1:8443"
+events_dir: "/d"
+offset_path: "/e"
+agent_control: "/f"
+dead_letter_dir: "/g"
+"#,
+        );
+        let cfg = SenderConfig::load(&p).unwrap();
+        assert!(cfg.client_cert_path.is_none());
+        assert!(cfg.client_key_path.is_none());
+        assert!(cfg.server_ca_path.is_none());
     }
 
     #[test]

--- a/crates/sigil-sender/src/runtime.rs
+++ b/crates/sigil-sender/src/runtime.rs
@@ -31,10 +31,16 @@ pub struct RuntimeCtx {
 }
 
 pub async fn run(ctx: RuntimeCtx) -> Result<()> {
+    if ctx.config.client_cert_path.is_none() {
+        tracing::warn!(
+            "sigil-sender: no client_cert_path configured — running WITHOUT an mTLS \
+             client identity. mTLS is the recommended production posture."
+        );
+    }
     let client = build_client(
-        &ctx.config.client_cert_path,
-        &ctx.config.client_key_path,
-        &ctx.config.server_ca_path,
+        ctx.config.client_cert_path.as_deref(),
+        ctx.config.client_key_path.as_deref(),
+        ctx.config.server_ca_path.as_deref(),
     )?;
     let stats = heartbeat::shared();
     let etag_path = etag_path_for(&ctx.config.offset_path);

--- a/crates/sigil-sender/src/transport.rs
+++ b/crates/sigil-sender/src/transport.rs
@@ -17,45 +17,58 @@ pub enum TransportError {
     Identity(reqwest::Error),
     #[error("invalid root CA bundle")]
     InvalidCa,
+    #[error("incomplete mTLS config: client_cert_path and client_key_path must be set together")]
+    IncompleteMtls,
     #[error("client build: {0}")]
     Build(reqwest::Error),
 }
 
-/// Build a reqwest client preconfigured with mTLS using the supplied
-/// PEM-encoded client cert chain + private key, validating server certs
-/// against the supplied PEM-encoded CA bundle.
+/// Build a reqwest client. mTLS is applied when both `client_cert_pem` and
+/// `client_key_pem` are supplied; a `server_ca_pem` pins the server cert to
+/// that CA (built-in roots disabled). With all three `None`, a plain client is
+/// returned (built-in roots, no client identity) — e.g. for a plain-HTTP dev
+/// server. Supplying exactly one of cert/key is rejected as `IncompleteMtls`.
 pub fn build_client(
-    client_cert_pem: &Path,
-    client_key_pem: &Path,
-    server_ca_pem: &Path,
+    client_cert_pem: Option<&Path>,
+    client_key_pem: Option<&Path>,
+    server_ca_pem: Option<&Path>,
 ) -> Result<Client, TransportError> {
-    let cert_pem = std::fs::read(client_cert_pem).map_err(|source| TransportError::Read {
-        path: client_cert_pem.to_path_buf(),
-        source,
-    })?;
-    let key_pem = std::fs::read(client_key_pem).map_err(|source| TransportError::Read {
-        path: client_key_pem.to_path_buf(),
-        source,
-    })?;
-    let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
-    combined.extend_from_slice(&cert_pem);
-    combined.push(b'\n');
-    combined.extend_from_slice(&key_pem);
-    let identity = Identity::from_pem(&combined).map_err(TransportError::Identity)?;
+    let mut builder = ClientBuilder::new().use_rustls_tls();
 
-    let ca_pem = std::fs::read(server_ca_pem).map_err(|source| TransportError::Read {
-        path: server_ca_pem.to_path_buf(),
-        source,
-    })?;
-    let ca_cert = reqwest::Certificate::from_pem(&ca_pem).map_err(|_| TransportError::InvalidCa)?;
+    match (client_cert_pem, client_key_pem) {
+        (Some(cert_path), Some(key_path)) => {
+            let cert_pem = std::fs::read(cert_path).map_err(|source| TransportError::Read {
+                path: cert_path.to_path_buf(),
+                source,
+            })?;
+            let key_pem = std::fs::read(key_path).map_err(|source| TransportError::Read {
+                path: key_path.to_path_buf(),
+                source,
+            })?;
+            let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
+            combined.extend_from_slice(&cert_pem);
+            combined.push(b'\n');
+            combined.extend_from_slice(&key_pem);
+            let identity = Identity::from_pem(&combined).map_err(TransportError::Identity)?;
+            builder = builder.identity(identity);
+        }
+        (None, None) => {}
+        _ => return Err(TransportError::IncompleteMtls),
+    }
 
-    ClientBuilder::new()
-        .use_rustls_tls()
-        .identity(identity)
-        .add_root_certificate(ca_cert)
-        .tls_built_in_root_certs(false)
-        .build()
-        .map_err(TransportError::Build)
+    if let Some(ca_path) = server_ca_pem {
+        let ca_pem = std::fs::read(ca_path).map_err(|source| TransportError::Read {
+            path: ca_path.to_path_buf(),
+            source,
+        })?;
+        let ca_cert =
+            reqwest::Certificate::from_pem(&ca_pem).map_err(|_| TransportError::InvalidCa)?;
+        builder = builder
+            .add_root_certificate(ca_cert)
+            .tls_built_in_root_certs(false);
+    }
+
+    builder.build().map_err(TransportError::Build)
 }
 
 /// High-level outcome of an HTTP send. The data_task uses this to decide
@@ -128,9 +141,9 @@ mod tests {
     fn missing_cert_returns_read_error() {
         let dir = tempdir().unwrap();
         let err = build_client(
-            &dir.path().join("missing.crt"),
-            &dir.path().join("missing.key"),
-            &dir.path().join("missing-ca.pem"),
+            Some(&dir.path().join("missing.crt")),
+            Some(&dir.path().join("missing.key")),
+            Some(&dir.path().join("missing-ca.pem")),
         )
         .unwrap_err();
         assert!(matches!(err, TransportError::Read { .. }));
@@ -145,8 +158,30 @@ mod tests {
         std::fs::write(&cert, b"not a pem").unwrap();
         std::fs::write(&key, b"not a pem either").unwrap();
         std::fs::write(&ca, b"definitely not pem").unwrap();
-        let err = build_client(&cert, &key, &ca).unwrap_err();
+        let err = build_client(Some(&cert), Some(&key), Some(&ca)).unwrap_err();
         assert!(matches!(err, TransportError::Identity(_)));
+    }
+
+    #[test]
+    fn no_certs_builds_plain_client() {
+        // Plain-HTTP / no-mTLS path: all None → a usable client, no error.
+        assert!(build_client(None, None, None).is_ok());
+    }
+
+    #[test]
+    fn partial_mtls_is_rejected() {
+        let dir = tempdir().unwrap();
+        let cert = dir.path().join("c.crt");
+        std::fs::write(&cert, b"x").unwrap();
+        // cert without key (and vice versa) → IncompleteMtls, before any read.
+        assert!(matches!(
+            build_client(Some(&cert), None, None).unwrap_err(),
+            TransportError::IncompleteMtls
+        ));
+        assert!(matches!(
+            build_client(None, Some(&cert), None).unwrap_err(),
+            TransportError::IncompleteMtls
+        ));
     }
 
     #[test]

--- a/crates/sigil-sender/tests/data_task_loop_e2e.rs
+++ b/crates/sigil-sender/tests/data_task_loop_e2e.rs
@@ -25,9 +25,9 @@ fn write_jsonl(dir: &std::path::Path, name: &str, lines: &[(Uuid, &str)]) {
 fn cfg(events_dir: &std::path::Path, state_dir: &std::path::Path, addr: &str) -> SenderConfig {
     SenderConfig {
         server_base_url: format!("http://{addr}"),
-        client_cert_path: state_dir.join("client.crt"),
-        client_key_path: state_dir.join("client.key"),
-        server_ca_path: state_dir.join("server-ca.pem"),
+        client_cert_path: Some(state_dir.join("client.crt")),
+        client_key_path: Some(state_dir.join("client.key")),
+        server_ca_path: Some(state_dir.join("server-ca.pem")),
         events_dir: events_dir.to_path_buf(),
         offset_path: state_dir.join("sender-offset.json"),
         agent_control: state_dir.join("control.sock"),


### PR DESCRIPTION
Two fixes for bugs found during the 3b.7.4 real-machine E2E.

## #97 — `sigil doctor` ignores `--state-db`
`doctor::run` only received the policy override, not `--state-db`, and hardcoded `default_state_db_path()` for the host_id read — so a non-default state.db produced a spurious `state.db unavailable for host_id read` warning. Thread the override through (matching how `sigil show` already does it).

## #98 — sender required mTLS even for a plain-HTTP server
`sigil-server` supports plain HTTP (no TLS cert → `axum::serve`), but the sender's three cert paths were mandatory and the client always built an mTLS `Identity`, so it couldn't connect. Now:
- `client_cert_path` / `client_key_path` / `server_ca_path` are `Option` (`#[serde(default)]`);
- `build_client` attaches the client identity + pinned CA only when present, else a plain client (built-in roots);
- supplying exactly one of cert/key → `IncompleteMtls` error;
- a `warn` fires when running without a client cert.
mTLS behavior is unchanged when certs are configured.

## Testing
New unit tests: `no_certs_builds_plain_client`, `partial_mtls_is_rejected`, `certs_absent_parses_to_none`; existing transport/config tests updated. `cargo fmt` + `clippy --workspace -D warnings` + `cargo test --workspace` green.

Fixes #97
Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)