### PR TITLE
feat(ai-guard): DSL Tier 2 conditional rule blocks (#53)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/rule_pack/expand.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/expand.rs
@@ -49,6 +49,7 @@ mod tests {
                 selector: "$.x".into(),
                 matcher: Matcher::Exists,
                 emit: AiGuardReason::SandboxDisabled,
+                when: vec![],
             }],
         }
     }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/matcher.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/matcher.rs
@@ -47,6 +47,33 @@ pub fn compile_pack_regexes(
         .collect()
 }
 
+/// Compile the Regex matchers of every rule's `when` conditions. Returns a Vec
+/// parallel to `rules`; each element is a Vec parallel to that rule's `when`
+/// (Some iff the condition matcher is Regex). Errors at the first malformed
+/// pattern, carrying the offending rule id.
+pub fn compile_condition_regexes(
+    rules: &[sigil_core::policy::RuleEntry],
+) -> Result<Vec<Vec<Option<regex::Regex>>>, CompileError> {
+    rules
+        .iter()
+        .map(|r| {
+            r.when
+                .iter()
+                .map(|c| match &c.matcher {
+                    sigil_core::policy::Matcher::Regex { pattern } => regex::Regex::new(pattern)
+                        .map(Some)
+                        .map_err(|source| CompileError {
+                            rule_id: r.id.clone(),
+                            pattern: pattern.clone(),
+                            source,
+                        }),
+                    _ => Ok(None),
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect()
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("rule '{rule_id}': regex pattern '{pattern}' failed to compile: {source}")]
 pub struct CompileError {
@@ -172,6 +199,58 @@ mod tests {
             when: vec![],
         }];
         let err = compile_pack_regexes(&rules).unwrap_err();
+        assert_eq!(err.rule_id, "bad");
+    }
+
+    #[test]
+    fn compile_condition_regexes_collects_only_regex_conditions() {
+        let rules = vec![sigil_core::policy::RuleEntry {
+            id: "r1".into(),
+            on_file: "x".into(),
+            format: sigil_core::policy::RuleFormat::Json,
+            selector: "$.x".into(),
+            matcher: Matcher::Exists,
+            emit: sigil_core::event::AiGuardReason::SandboxDisabled,
+            when: vec![
+                sigil_core::policy::Condition {
+                    selector: "$.a".into(),
+                    matcher: Matcher::Regex {
+                        pattern: "^http".into(),
+                    },
+                    negate: false,
+                },
+                sigil_core::policy::Condition {
+                    selector: "$.b".into(),
+                    matcher: Matcher::Exists,
+                    negate: false,
+                },
+            ],
+        }];
+        let out = compile_condition_regexes(&rules).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), 2);
+        assert!(out[0][0].is_some());
+        assert!(out[0][1].is_none());
+    }
+
+    #[test]
+    fn compile_condition_regexes_fails_on_malformed_pattern() {
+        let rules = vec![sigil_core::policy::RuleEntry {
+            id: "bad".into(),
+            on_file: "x".into(),
+            format: sigil_core::policy::RuleFormat::Json,
+            selector: "$.x".into(),
+            matcher: Matcher::Exists,
+            emit: sigil_core::event::AiGuardReason::SandboxDisabled,
+            when: vec![sigil_core::policy::Condition {
+                selector: "$.a".into(),
+                matcher: Matcher::Regex {
+                    pattern: "[unclosed".into(),
+                },
+                negate: false,
+            }],
+        }];
+        let err = compile_condition_regexes(&rules).unwrap_err();
         assert_eq!(err.rule_id, "bad");
     }
 }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/matcher.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/matcher.rs
@@ -138,6 +138,7 @@ mod tests {
                 selector: "$.x".into(),
                 matcher: Matcher::Exists,
                 emit: sigil_core::event::AiGuardReason::SandboxDisabled,
+                when: vec![],
             },
             sigil_core::policy::RuleEntry {
                 id: "r2".into(),
@@ -148,6 +149,7 @@ mod tests {
                     pattern: "^http".into(),
                 },
                 emit: sigil_core::event::AiGuardReason::SandboxDisabled,
+                when: vec![],
             },
         ];
         let out = compile_pack_regexes(&rules).unwrap();
@@ -167,6 +169,7 @@ mod tests {
                 pattern: "[unclosed".into(),
             },
             emit: sigil_core::event::AiGuardReason::SandboxDisabled,
+            when: vec![],
         }];
         let err = compile_pack_regexes(&rules).unwrap_err();
         assert_eq!(err.rule_id, "bad");

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -92,6 +92,7 @@ mod tests {
                 selector: "$.x".into(),
                 matcher: Matcher::Exists,
                 emit: AiGuardReason::SandboxDisabled,
+                when: vec![],
             }],
         }
     }
@@ -112,6 +113,7 @@ mod tests {
                 selector: "$.x".into(),
                 matcher: Matcher::Exists,
                 emit: AiGuardReason::SandboxDisabled,
+                when: vec![],
             }],
         }
     }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/mod.rs
@@ -9,7 +9,7 @@ pub mod selector;
 
 /// Pack format version range this interpreter supports.
 pub const MIN_PACK_VERSION: u32 = 1;
-pub const MAX_PACK_VERSION: u32 = 1;
+pub const MAX_PACK_VERSION: u32 = 2;
 
 /// Cheap pre-flight check applied at boot + reload time. Heavier checks
 /// (regex compile, selector syntax) happen inside RulePackParser::new.
@@ -20,6 +20,18 @@ pub fn pack_is_loadable(pack: &sigil_core::policy::RulePack) -> bool {
             "rule_pack: incompatible pack_version; skipping"
         );
         return false;
+    }
+    // `when` conditions are a Tier-2 (pack_version 2) capability. A v1 pack that
+    // carries them is an authoring error — older engines would silently ignore the
+    // gate and over-emit. Reject so the version is an honest capability gate.
+    if pack.pack_version < 2 {
+        if let Some(bad) = pack.rules.iter().find(|r| !r.when.is_empty()) {
+            tracing::warn!(
+                id = %pack.id, rule = %bad.id,
+                "rule_pack: 'when' conditions require pack_version 2; skipping pack"
+            );
+            return false;
+        }
     }
     match pack.scope {
         sigil_core::policy::RulePackScope::UserGlobal => {}
@@ -181,5 +193,48 @@ mod tests {
             RulePackScope::UserGlobal,
             "/abs/x.json"
         )));
+    }
+
+    fn pack_with_when(pack_version: u32) -> RulePack {
+        use sigil_core::policy::Condition;
+        RulePack {
+            id: "p".into(),
+            pack_version,
+            tool: AiTool::Gemini,
+            tool_label: None,
+            scope: RulePackScope::UserGlobal,
+            watched_paths: vec![],
+            platforms: None,
+            rules: vec![RuleEntry {
+                id: "r".into(),
+                on_file: ".x/c.json".into(),
+                format: RuleFormat::Json,
+                selector: "$.a".into(),
+                matcher: Matcher::Exists,
+                emit: AiGuardReason::SandboxDisabled,
+                when: vec![Condition {
+                    selector: "$.b".into(),
+                    matcher: Matcher::Exists,
+                    negate: false,
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn pack_version_2_with_when_is_loadable() {
+        assert!(pack_is_loadable(&pack_with_when(2)));
+    }
+
+    #[test]
+    fn pack_version_1_with_when_is_rejected() {
+        assert!(!pack_is_loadable(&pack_with_when(1)));
+    }
+
+    #[test]
+    fn pack_version_1_without_when_still_loadable() {
+        let mut p = pack_with_when(1);
+        p.rules[0].when.clear();
+        assert!(pack_is_loadable(&p));
     }
 }

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -287,6 +287,47 @@ mod tests {
     }
 
     #[test]
+    fn interpolation_draws_from_primary_not_a_gate() {
+        // A holding `when` gate must NOT affect interpolation — the emitted
+        // reason still interpolates from the PRIMARY selector's matched value.
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("mcp.json");
+        std::fs::write(
+            &file,
+            r#"{"mcpServers": {"alpha": {"url": "https://a"}}, "gate": "go"}"#,
+        )
+        .unwrap();
+        let mut pack = pack_with_one_rule(
+            file.to_str().unwrap(),
+            "$.mcpServers.*.url",
+            Matcher::Exists,
+            AiGuardReason::McpServerRemote {
+                server_name: "<selector-key>".into(),
+                url: "<selector-value>".into(),
+            },
+        );
+        pack.pack_version = 2;
+        pack.rules[0].when = vec![sigil_core::policy::Condition {
+            selector: "$.gate".into(),
+            matcher: Matcher::Equals { value: "go".into() },
+            negate: false,
+        }];
+        let out = RulePackParser::new(pack)
+            .unwrap()
+            .assess(Path::new("/unused"))
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            // alpha / https://a come from the PRIMARY, not the gate's `$.gate`.
+            AiGuardReason::McpServerRemote { server_name, url } => {
+                assert_eq!(server_name, "alpha");
+                assert_eq!(url, "https://a");
+            }
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
     fn corrupt_json_returns_parse_error() {
         let dir = tempdir().unwrap();
         let file = dir.path().join("bad.json");

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -179,6 +179,7 @@ mod tests {
                 selector: selector.into(),
                 matcher,
                 emit,
+                when: vec![],
             }],
         }
     }
@@ -283,6 +284,7 @@ mod tests {
                     pattern: "[unclosed".into(),
                 },
                 emit: AiGuardReason::SandboxDisabled,
+                when: vec![],
             }],
         };
         assert!(RulePackParser::new(pack).is_err());

--- a/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
+++ b/crates/sigil-agent/src/ai_guard/rule_pack/parser.rs
@@ -1,7 +1,9 @@
 //! Phase 3b.7 — RulePackParser: generic AiGuardParser driven by a RulePack.
 
 use crate::ai_guard::parser::{AiGuardParser, AssessError};
-use crate::ai_guard::rule_pack::matcher::{compile_pack_regexes, matches_value, CompileError};
+use crate::ai_guard::rule_pack::matcher::{
+    compile_condition_regexes, compile_pack_regexes, matches_value, CompileError,
+};
 use crate::ai_guard::rule_pack::selector::{eval_json, eval_toml, MatchedValue};
 use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
 use sigil_core::policy::{RuleFormat, RulePack, RulePackScope};
@@ -11,6 +13,9 @@ pub struct RulePackParser {
     pub pack: RulePack,
     /// Compiled regexes parallel to pack.rules (None when matcher != Regex).
     compiled_regexes: Vec<Option<regex::Regex>>,
+    /// Compiled regexes for each rule's `when` conditions, parallel to
+    /// pack.rules then to that rule's `when` (None when matcher != Regex).
+    compiled_condition_regexes: Vec<Vec<Option<regex::Regex>>>,
     pub(crate) repo_root: Option<std::path::PathBuf>,
 }
 
@@ -27,9 +32,15 @@ impl RulePackParser {
                 id: pack.id.clone(),
                 source: e,
             })?;
+        let compiled_condition_regexes =
+            compile_condition_regexes(&pack.rules).map_err(|e| PackLoadError::Regex {
+                id: pack.id.clone(),
+                source: e,
+            })?;
         Ok(Self {
             pack,
             compiled_regexes,
+            compiled_condition_regexes,
             repo_root: None,
         })
     }
@@ -108,6 +119,32 @@ impl AiGuardParser for RulePackParser {
                 }
             };
 
+            // Tier-2 gates: every `when` condition must hold (its selector finds
+            // >=1 value matching its matcher, XOR negate). Any failing gate skips
+            // this rule's emits. Empty `when` => zero gates => Tier-1 behavior.
+            let mut gates_pass = true;
+            for (cidx, cond) in rule.when.iter().enumerate() {
+                let cond_matches = match rule.format {
+                    RuleFormat::Json => eval_json(&text, &cond.selector, &file_path)?,
+                    RuleFormat::Toml => eval_toml(&text, &cond.selector, &file_path)?,
+                };
+                let holds = cond_matches.iter().any(|mv| {
+                    matches_value(
+                        &cond.matcher,
+                        mv,
+                        self.compiled_condition_regexes[idx][cidx].as_ref(),
+                    )
+                });
+                // passes iff (holds XOR negate); fails iff holds == negate
+                if holds == cond.negate {
+                    gates_pass = false;
+                    break;
+                }
+            }
+            if !gates_pass {
+                continue;
+            }
+
             let matches = match rule.format {
                 RuleFormat::Json => eval_json(&text, &rule.selector, &file_path)?,
                 RuleFormat::Toml => eval_toml(&text, &rule.selector, &file_path)?,
@@ -155,7 +192,7 @@ fn interpolate_reason(reason: &AiGuardReason, matched: &MatchedValue) -> AiGuard
 mod tests {
     use super::*;
     use sigil_core::event::AiGuardReason;
-    use sigil_core::policy::{Matcher, RuleEntry, RuleFormat, RulePack, RulePackScope};
+    use sigil_core::policy::{Condition, Matcher, RuleEntry, RuleFormat, RulePack, RulePackScope};
     use tempfile::tempdir;
 
     fn pack_with_one_rule(
@@ -316,6 +353,117 @@ mod tests {
         let p = RulePackParser::new(pack).unwrap();
         assert_eq!(p.tool(), AiTool::Gemini);
         assert!(matches!(p.scope(), AiGuardScope::UserGlobal));
+    }
+
+    fn rule_with_when(on_file: &str, when: Vec<Condition>) -> RulePack {
+        let mut p = pack_with_one_rule(
+            on_file,
+            "$.sandbox",
+            Matcher::Equals {
+                value: "false".into(),
+            },
+            AiGuardReason::SandboxDisabled,
+        );
+        p.pack_version = 2;
+        p.rules[0].when = when;
+        p
+    }
+
+    #[test]
+    fn when_gate_holds_emits() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("c.json");
+        std::fs::write(&f, r#"{"sandbox": false, "autoApprove": true}"#).unwrap();
+        let p = rule_with_when(
+            f.to_str().unwrap(),
+            vec![Condition {
+                selector: "$.autoApprove".into(),
+                matcher: Matcher::Equals {
+                    value: "true".into(),
+                },
+                negate: false,
+            }],
+        );
+        let out = RulePackParser::new(p)
+            .unwrap()
+            .assess(Path::new("/unused"))
+            .unwrap();
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn when_gate_fails_suppresses() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("c.json");
+        std::fs::write(&f, r#"{"sandbox": false, "autoApprove": false}"#).unwrap();
+        let p = rule_with_when(
+            f.to_str().unwrap(),
+            vec![Condition {
+                selector: "$.autoApprove".into(),
+                matcher: Matcher::Equals {
+                    value: "true".into(),
+                },
+                negate: false,
+            }],
+        );
+        let out = RulePackParser::new(p)
+            .unwrap()
+            .assess(Path::new("/unused"))
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn when_negate_inverts() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("c.json");
+        std::fs::write(&f, r#"{"sandbox": false}"#).unwrap();
+        let p = rule_with_when(
+            f.to_str().unwrap(),
+            vec![Condition {
+                selector: "$.allowlist".into(),
+                matcher: Matcher::Exists,
+                negate: true,
+            }],
+        );
+        let out = RulePackParser::new(p)
+            .unwrap()
+            .assess(Path::new("/unused"))
+            .unwrap();
+        assert_eq!(out.len(), 1); // NOT exists(allowlist) holds → emit
+    }
+
+    #[test]
+    fn multiple_gates_all_anded() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("c.json");
+        std::fs::write(
+            &f,
+            r#"{"sandbox": false, "autoApprove": true, "allowlist": ["x"]}"#,
+        )
+        .unwrap();
+        let p = rule_with_when(
+            f.to_str().unwrap(),
+            vec![
+                Condition {
+                    selector: "$.autoApprove".into(),
+                    matcher: Matcher::Equals {
+                        value: "true".into(),
+                    },
+                    negate: false,
+                },
+                Condition {
+                    selector: "$.allowlist".into(),
+                    matcher: Matcher::Exists,
+                    negate: true,
+                },
+            ],
+        );
+        let out = RulePackParser::new(p)
+            .unwrap()
+            .assess(Path::new("/unused"))
+            .unwrap();
+        assert!(out.is_empty()); // second gate (NOT allowlist) fails → suppressed
     }
 
     #[test]

--- a/crates/sigil-agent/tests/rule_pack_conditional_e2e.rs
+++ b/crates/sigil-agent/tests/rule_pack_conditional_e2e.rs
@@ -1,0 +1,178 @@
+//! e2e: a Tier-2 conditional-block (`when` gate) UserGlobal rule pack through
+//! the real agent.
+//!
+//! Phase 3b.7 (#53) — proves that an operator-authored UserGlobal rule pack with
+//! `pack_version: 2` and a `when:` gate is expanded into a runtime parser,
+//! assessed by the agent's boot scan, and emits its `sandbox_disabled` reason
+//! ONLY when the gate holds:
+//!   * Fixture A — `autoApprove == "true"` → gate holds → `sandbox_disabled` IS
+//!     emitted in the `AiGuardRiskAssessed` reasons.
+//!   * Fixture B — `autoApprove == "false"` → gate fails → `sandbox_disabled` is
+//!     SUPPRESSED (absent from reasons), while an ungated control rule still
+//!     fires so we know the boot scan actually ran.
+//!
+//! Why this is robust in the sandbox: a UserGlobal pack expands to exactly one
+//! parser bound to an ABSOLUTE `on_file` (repo-independent). The agent's boot
+//! scan synchronously assesses every parser at startup, so these events are
+//! produced WITHOUT relying on FS-watcher delivery (issues #25/#66), which is
+//! unreliable on macOS under `cargo test --workspace`.
+//!
+//! pack_version MUST be 2: `pack_is_loadable` rejects a v1 pack carrying any
+//! non-empty `when` block (over-emit guard), so a v1 pack here would silently
+//! refuse to load and never emit — a false failure.
+
+#![cfg(all(unix, feature = "operator-cli"))]
+
+mod common;
+use common::{fs_event_timeout, TestAgentBuilder};
+
+/// Build a policy with one UserGlobal Tier-2 (`pack_version: 2`) rule pack
+/// `cond-pack` (`tool: other` + `tool_label: acme-ai`, mirroring the
+/// generic-tool e2e), watching the absolute `config_path`.
+///
+/// `r1` matches top-level `$.sandbox == "false"` → `sandbox_disabled`, but only
+/// `when` `$.autoApprove == "true"`. `r0` is an ungated control rule that always
+/// emits `permissions_deny_empty` whenever `$.sandbox` exists — a deterministic
+/// "boot scan ran" marker that does NOT depend on the gate, so the suppression
+/// case can assert absence against a known-complete scan (no racy wait).
+fn conditional_pack_policy(config_path: &str) -> String {
+    format!(
+        r#"version: 1
+host_id_strategy: machine_id
+targets: []
+rule_packs:
+  - id: cond-pack
+    pack_version: 2
+    tool: other
+    tool_label: "acme-ai"
+    scope:
+      kind: user_global
+    watched_paths:
+      - '{config_path}'
+    rules:
+      - id: r0
+        on_file: '{config_path}'
+        format: json
+        selector: '$.sandbox'
+        matcher:
+          kind: exists
+        emit:
+          kind: permissions_deny_empty
+      - id: r1
+        on_file: '{config_path}'
+        format: json
+        selector: '$.sandbox'
+        matcher:
+          kind: equals
+          value: "false"
+        emit:
+          kind: sandbox_disabled
+        when:
+          - selector: '$.autoApprove'
+            matcher:
+              kind: equals
+              value: "true"
+"#
+    )
+}
+
+/// Write `<tmp>/acme/config.json` with the given body and return `(tempdir,
+/// absolute config path string)`. The tempdir guard must outlive the agent.
+fn fixture(body: &str) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(dir.path()).unwrap();
+    let config_dir = root.join("acme");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.json");
+    std::fs::write(&config_path, body).unwrap();
+    let config_str = config_path.display().to_string();
+    (dir, config_str)
+}
+
+/// Fixture A: `autoApprove == true` → the `when` gate holds → `sandbox_disabled`
+/// IS emitted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn conditional_pack_emits_when_gate_holds() {
+    let (_dir, config_str) = fixture(r#"{"sandbox": false, "autoApprove": true}"#);
+    let policy = conditional_pack_policy(&config_str);
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    let ev = agent
+        .wait_for_event(
+            |v| {
+                v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                    && v["evidence"]["tool"] == "other"
+                    && v["evidence"]["tool_label"] == "acme-ai"
+                    && v["evidence"]["rule_pack_id"] == "cond-pack"
+            },
+            fs_event_timeout(),
+        )
+        .await
+        .expect("expected cond-pack AiGuardRiskAssessed (gate holds)");
+
+    let reasons = ev["evidence"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons.iter().any(|r| r["kind"] == "sandbox_disabled"),
+        "gate holds → expected sandbox_disabled in reasons: {reasons:?}"
+    );
+
+    agent.join.abort();
+}
+
+/// Fixture B: `autoApprove == false` → the `when` gate fails → `sandbox_disabled`
+/// is SUPPRESSED. The ungated control rule still emits `permissions_deny_empty`,
+/// giving us a deterministic boot-scan-complete marker; once that event has
+/// arrived we snapshot all events and assert NO `sandbox_disabled` is present
+/// (non-racy absence assertion — not a wait-for-absence).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn conditional_pack_suppressed_when_gate_fails() {
+    let (_dir, config_str) = fixture(r#"{"sandbox": false, "autoApprove": false}"#);
+    let policy = conditional_pack_policy(&config_str);
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    // Wait for the ungated control reason — proves the boot scan assessed this
+    // pack to completion, so any (suppressed) sandbox_disabled would already be
+    // on disk by now.
+    let ev = agent
+        .wait_for_event(
+            |v| {
+                v["evidence"]["kind"] == "ai_guard_risk_assessed"
+                    && v["evidence"]["rule_pack_id"] == "cond-pack"
+                    && v["evidence"]["reasons"]
+                        .as_array()
+                        .map(|rs| rs.iter().any(|r| r["kind"] == "permissions_deny_empty"))
+                        .unwrap_or(false)
+            },
+            fs_event_timeout(),
+        )
+        .await
+        .expect("expected cond-pack control event (permissions_deny_empty)");
+
+    // Sanity: the control marker is present...
+    let reasons = ev["evidence"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons
+            .iter()
+            .any(|r| r["kind"] == "permissions_deny_empty"),
+        "expected control reason permissions_deny_empty: {reasons:?}"
+    );
+
+    // ...and across the full event snapshot, the gated reason never emitted.
+    let suppressed = agent.read_all_events().into_iter().all(|v| {
+        if v["evidence"]["kind"] != "ai_guard_risk_assessed"
+            || v["evidence"]["rule_pack_id"] != "cond-pack"
+        {
+            return true;
+        }
+        v["evidence"]["reasons"]
+            .as_array()
+            .map(|rs| rs.iter().all(|r| r["kind"] != "sandbox_disabled"))
+            .unwrap_or(true)
+    });
+    assert!(
+        suppressed,
+        "gate fails (autoApprove=false) → sandbox_disabled must be suppressed"
+    );
+
+    agent.join.abort();
+}

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -87,6 +87,17 @@ pub struct RulePack {
     pub rules: Vec<RuleEntry>,
 }
 
+/// Phase 3b.7.1 (Tier 2) — a gate condition on a rule. The rule emits only when
+/// every condition holds; a condition holds iff its selector finds at least one
+/// value matching its matcher, XOR `negate`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Condition {
+    pub selector: String,
+    pub matcher: Matcher,
+    #[serde(default)]
+    pub negate: bool,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct RuleEntry {
     pub id: String,
@@ -95,6 +106,10 @@ pub struct RuleEntry {
     pub selector: String,
     pub matcher: Matcher,
     pub emit: crate::event::AiGuardReason,
+    /// Phase 3b.7.1 (Tier 2) — gate conditions (AND). Empty (default) = the flat
+    /// Tier-1 rule (no gating). Requires pack_version 2.
+    #[serde(default)]
+    pub when: Vec<Condition>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -1018,6 +1033,22 @@ host_id_strategy: hostname
         let doc = parse("version: 1\n").unwrap();
         assert!(doc.gemini_workspaces.is_empty());
         assert!(doc.cursor_workspaces.is_empty());
+    }
+
+    #[test]
+    fn rule_entry_when_defaults_empty_and_round_trips() {
+        // a rule WITHOUT `when` parses to an empty when (back-compat)
+        let r: RuleEntry = serde_yaml::from_str(
+            "id: r1\non_file: /x\nformat: json\nselector: \"$.a\"\nmatcher: { kind: exists }\nemit: { kind: sandbox_disabled }\n",
+        ).unwrap();
+        assert!(r.when.is_empty());
+
+        // a rule WITH when conditions (incl. negate default) round-trips
+        let y = "id: r2\non_file: /x\nformat: json\nselector: \"$.a\"\nmatcher: { kind: exists }\nemit: { kind: sandbox_disabled }\nwhen:\n  - selector: \"$.b\"\n    matcher: { kind: equals, value: \"true\" }\n  - selector: \"$.c\"\n    matcher: { kind: exists }\n    negate: true\n";
+        let r2: RuleEntry = serde_yaml::from_str(y).unwrap();
+        assert_eq!(r2.when.len(), 2);
+        assert!(!r2.when[0].negate);
+        assert!(r2.when[1].negate);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds **Tier 2** to the declarative rule-pack DSL (#53 / 3b.7.1): a rule may now carry a set of **gate conditions** (`when`) that must all hold for it to emit. This gives operator-authored packs real compound detection — "risky only when A *and* B (and *not* C)" — which the flat Tier-1 grammar (one selector + matcher → one emit) cannot express.

## What changed

- **`sigil-core`** — `RuleEntry.when: Vec<Condition>` (`#[serde(default)]`) + `Condition { selector, matcher, negate }`. Reuses the existing `Matcher` enum verbatim.
- **Version gate** — `MAX_PACK_VERSION` 1 → 2. A pack using `when` must declare `pack_version: 2`; a `pack_version: 1` pack carrying `when` is rejected at load (honest capability gate). An older agent (still MAX=1) rejects a v2 pack via the existing version-range check — fleets mid-upgrade degrade safely.
- **Engine** (`RulePackParser`) — condition `Regex` matchers are pre-compiled at load alongside the primary's; `assess` evaluates every `when` gate (each: its selector finds ≥1 value matching its matcher, XOR `negate`; all ANDed, short-circuit) against the **same** parsed `on_file` document *before* pushing any emit.

## Semantics & back-compat

- An absent/empty `when` is **byte-identical** to today's Tier-1 behavior — `sigil-rules-basic` defaults and existing operator packs are unchanged.
- The **primary** `selector + matcher + emit` still drives per-match iteration and `<selector-key>`/`<selector-value>` interpolation, unchanged. A regression test guards that interpolation draws from the primary, never a gate.
- Conditions reference the **same file** as the rule. Cross-file gates, OR / nested boolean trees, recursive-descent selectors, and `Contains`/`InSet` matchers are intentionally out of scope (YAGNI — author two rules for OR).

## Out of scope

Built-in parser migration (**3b.7.3**) is **not** in this PR. A capability survey showed only ~70% of the hardcoded logic is declaratively expressible; that migration is a separate future decision. Tier 2's value stands on its own for operator packs.

## Tests

- `sigil-core`: `Condition` serde round-trip (incl. default `negate`); v1-pack-with-no-`when` round-trips unchanged.
- `sigil-agent` lib: version gating (v2 loads, v1+`when` rejected, malformed condition regex fails the pack), single/multiple/negated gates, empty-`when` == Tier-1, interpolation-from-primary.
- E2E: a UserGlobal operator pack with a compound rule emits only on the AND-satisfying fixture, suppressed otherwise.

Public repo — mechanism-only (measurement, no enforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)