### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-04
+
+### Added
+
+- **`sigil-hook` — runtime observe at the agent tool boundary** (#64). A new
+  in-tree crate that AI coding agents invoke as a `PreToolUse` hook to *observe*
+  each command at the moment it is about to run, complementing the static config
+  scanning of the AI Guard. Stage 1 is measurement-only (no blocking) and runs
+  as a separate process over IPC, keeping the hook surface decoupled from the
+  agent binary. Ships adapters and install/uninstall for **Claude Code, Codex,
+  Cursor, and Antigravity** (#83, #85, #88, #89) — Antigravity installs through
+  its native `agy plugin` bundle (#91). Architecture is documented in the README
+  (#84).
+- **Antigravity AI Guard support** (#86, #87). A static parser for Antigravity's
+  global config plus a per-repo parser wired into `workspace_discovery`, with a
+  new `antigravity_workspaces` policy field — so Antigravity is scored like the
+  other built-in tools, per-repo included.
+- **Rule-pack `scope = Project { path }` + per-repo discovery** (#92, 3b.7.2).
+  Operator-defined rule packs can now target per-repo scopes and hook into the
+  existing `workspace_discovery`, getting per-repo instances like the built-ins.
+  Events carry a `rule_pack_id` (forward-compatible) and the agent keys parser
+  state by `(tool, scope, pack_id)`.
+- **Generic `AiTool::Other` for operator rule packs** (#95, 3b.7.5). In-house and
+  third-party AI tools can be scored without a code change, via the `Other` tool
+  variant plus a `tool_label` carried on the pack and emitted on events
+  (UserGlobal scope).
+- **Server-side signed rule-pack distribution** (#96, 3b.7.4). `sigil-server`
+  serves a signed rule-pack-set bundle over `GET /v1/rule-packs`, versioned
+  independently from policy; the agent fetches, verifies the signed envelope,
+  and merges in three layers (defaults < policy < bundle). Operators push packs
+  centrally instead of editing each host.
+- **DSL Tier 2 — conditional rule blocks** (#101, 3b.7.1). A rule-pack rule may
+  carry `when` gate conditions (`selector` + `matcher` + optional `negate`,
+  ANDed) that must all hold for it to emit — giving operator packs compound
+  detection the flat Tier-1 grammar could not express. Gated behind
+  `pack_version: 2`; an empty `when` is byte-identical to prior behavior.
+
+### Fixed
+
+- **Antigravity approval key is `toolPermission`** (#90), corrected against
+  on-hardware behavior so the static parser reads the right setting.
+- **`AntigravityProjectParser` now reconciles on hot-reload** (#94, fixes #93) —
+  a per-repo Antigravity parser added by a policy reload is assessed without
+  waiting for the next file change.
+- **`sigil doctor --state-db` override and optional sender mTLS** (#99, fixes
+  #97/#98). `doctor` accepts a state-db path override, and the sender's mTLS
+  client identity is now optional (the three cert paths may be omitted to run
+  against a plain-HTTP dev server) — both surfaced by two-machine E2E testing.
+
 ## [0.2.1] - 2026-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.2.1"
+version = "0.3.0"
 
 [[package]]
 name = "sigil-sender"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Release prep for **v0.3.0** — workspace SemVer bump `0.2.1 → 0.3.0` + CHANGELOG.

## Why minor

15 commits since v0.2.1, all backward-compatible additions across two epics:

- **#64 sigil-hook** — new in-tree crate: runtime *observe* at the agent tool boundary (Stage 1, measurement-only), adapters + install for Claude Code / Codex / Cursor / Antigravity.
- **#53 rule-pack follow-ups (all shipped)** — Project scope (#92), generic `AiTool::Other` (#95), server-side signed distribution (#96), DSL Tier 2 conditional `when` blocks (#101).
- **Antigravity AI Guard** — static + per-repo parsers, `antigravity_workspaces` policy field.
- Fixes: Antigravity approval key (#90), project-parser hot-reload (#94), `doctor --state-db` + optional sender mTLS (#99).

## Contents

- `Cargo.toml` workspace version → `0.3.0`; `Cargo.lock` refreshed.
- `CHANGELOG.md`: new `[0.3.0]` section (Added / Fixed), Keep-a-Changelog format.

## Release mechanics

After merge, tag `v0.3.0` on `main` and push it — `release.yml` builds the x86_64 + aarch64 prebuilts / `.deb` / `.rpm`, attaches provenance, and emits the ed25519-signed build manifest (`sigil doctor --verify-self` anchor).

CI gate green locally: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)