### PR TITLE
[codex] Update release install docs

### DIFF
--- a/docs/install-macos-agent.md
+++ b/docs/install-macos-agent.md
@@ -20,8 +20,9 @@ curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/Ju571nK/sigil/main/install.sh | sh
 ```
 
-Installs `sigil`, `sigil-sender`, `sigil-server`, `sigil-sign` to
-`~/.local/bin` (verifies SHA-256). Make sure `~/.local/bin` is on your `PATH`.
+Installs `sigil`, `sigil-sender`, `sigil-server`, `sigil-sign`, `sigil-mcp`, and
+`sigil-hook` to `~/.local/bin` (verifies SHA-256). Make sure `~/.local/bin` is on
+your `PATH`.
 
 ### Option B — build from source
 

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -18,14 +18,22 @@ Debian/Ubuntu works via the `.deb` package; deltas are called out inline.
 
 ## 1. Topology & ports
 
-```
- agent host(s)                          server host
-┌───────────────────────┐    mTLS      ┌──────────────────────────┐
-│ sigil  ──► JSONL spool │   HTTPS      │ sigil-server             │
-│ sigil-sender  ─────────┼──── :8443 ──►│  POST /v1/events         │
-│                 ◄───────┼── /v1/policy │  GET  /v1/policy         │
-└───────────────────────┘              │  GET  /v1/fleet/* (bearer)│
-                                        └──────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph agent_host["agent host(s)"]
+        sigil["sigil<br/>host daemon"]
+        eventlog[("event log<br/>events-*.jsonl")]
+        sender["sigil-sender"]
+        sigil --> eventlog
+        eventlog --> sender
+    end
+
+    subgraph server_host["server host"]
+        server["sigil-server<br/>POST /v1/events<br/>GET /v1/policy<br/>GET /v1/fleet/* (bearer)"]
+    end
+
+    sender -- "mTLS HTTPS :8443<br/>POST /v1/events" --> server
+    server -- "GET /v1/policy" --> sender
 ```
 
 - **Server inbound:** exactly **one** port — `8443/tcp` (the `bind` value). All
@@ -72,8 +80,9 @@ curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/Ju571nK/sigil/main/install.sh | sh
 ```
 
-Installs all four binaries to `~/.local/bin`. You then wire up the systemd unit
-and config by hand (sections 4–6).
+Installs the six release binaries (`sigil`, `sigil-sender`, `sigil-server`,
+`sigil-sign`, `sigil-mcp`, `sigil-hook`) to `~/.local/bin`. You then wire up the
+systemd unit and config by hand (sections 4–6).
 
 ### Option C — build from source
 

--- a/packaging/selinux/README.md
+++ b/packaging/selinux/README.md
@@ -13,7 +13,7 @@ on RHEL-family systems (Rocky/RHEL/Fedora) instead of leaving them in
 State/log/runtime get dedicated file types (`sigil_var_lib_t`, `sigil_var_log_t`,
 `sigil_conf_t`, `sigil_*_var_lib_t`, …). The agent can read any file (it does
 file-integrity monitoring by design) but is otherwise tightly confined; the
-sender/server only touch their own state, the agent's spool/socket, and the
+sender/server only touch their own state, the agent's event log/socket, and the
 network they need.
 
 ## Why `init_nnp_daemon_domain`


### PR DESCRIPTION
## What changed

- Updated install docs to say `install.sh` installs all six release binaries, including `sigil-mcp` and `sigil-hook`.
- Adjusted the server topology and SELinux README wording from JSONL spool/spool to event log where it refers to the current agent event path.

## Why

PR #104 already corrected the main README architecture. The release-facing install docs still had older four-binary wording and spool terminology that users can see when following release/install instructions.

## Validation

- `git diff --check origin/main..HEAD`

## Authorship

This commit includes `Co-authored-by: Codex <codex@openai.com>`.