### PR TITLE
feat(hook): sigil-hook Stage 2 — in-domain enforcement (slice 1, #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,17 @@ workspace libraries.
   (Claude Code `PreToolUse` first; the per-agent adapter shape generalizes to
   Codex/Gemini/Cursor). It normalizes and redacts the call (blake3 hash over
   the raw text + masked preview) and emits one event to `sigil-agent` over a
-  dedicated `hook.sock`, reusing the JSONL event log → sender pipeline. **Observe-only**
-  — never denies, always exits 0, latency-bounded; the agent stamps the kernel
-  peer-uid for attribution. The *runtime* companion to AI Guard's *static*
-  config scoring (#64, Stage 1).
+  dedicated `hook.sock`, reusing the JSONL event log → sender pipeline. The agent
+  stamps the kernel peer-uid for attribution. The *runtime* companion to AI Guard's
+  *static* config scoring (#64, Stage 1).
+- **Enforce (Stage 2, #100)** — the same Claude Code hook can also **deny** a tool
+  call when an agent-local deny rule matches, over a synchronous `hook-decide.sock`;
+  the agent records a `HookDecision` event and returns the verdict, which the hook
+  translates to a `permissionDecision: deny`. This is **in-domain, advisory
+  enforcement** — it blocks ordinary tool calls when the agent honors the registered
+  hook, **fails open by default**, and is *agent-intent policy + tamper-evidence*,
+  **not** tamper-resistant runtime command security (the agent owns the config that
+  registers its own hook). Always exits 0, latency-bounded.
 
 **Libraries**
 

--- a/crates/sigil-agent/src/hook_decide_listener.rs
+++ b/crates/sigil-agent/src/hook_decide_listener.rs
@@ -1,0 +1,301 @@
+//! Stage 2 (#100): hook-decide.sock request/response listener. Distinct from
+//! the one-way `hook_listener` — here the agent MUST answer, and a deny is
+//! recorded reliably (awaited) before the verdict is returned.
+use crate::hook_deny::DenyEvaluator;
+use crate::hook_listener::to_event;
+use crate::state_task::CommittableEvent;
+use sigil_core::event::{
+    Evidence, HookDecisionEvidence, Severity, SourceKind, Subject, AGENT_VERSION, SCHEMA_VERSION,
+};
+use sigil_core::hook_proto::{
+    Decision, EnforcementMode, HookAction, HookDecisionRequest, HookDecisionResponse, HookEnvelope,
+    HookMsgType, HookVerdict, HOOK_PROTOCOL_VERSION,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+use tokio::sync::{mpsc, Semaphore};
+
+// Half of hook_listener's 32: two-way tasks hold the permit longer (awaited deny send before responding).
+const MAX_INFLIGHT: usize = 16;
+const MAX_LINE: u64 = 1024 * 1024;
+
+#[cfg(unix)]
+pub async fn serve(
+    socket: PathBuf,
+    tx: mpsc::Sender<CommittableEvent>,
+    host_id: String,
+    evaluator: Arc<DenyEvaluator>,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if socket.exists() {
+        let _ = std::fs::remove_file(&socket);
+    }
+    if let Some(p) = socket.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+    let listener = UnixListener::bind(&socket)?;
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o660))?;
+    let sem = Arc::new(Semaphore::new(MAX_INFLIGHT));
+    tracing::info!(path = ?socket, "hook-decide IPC listening");
+
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = ?e, "hook-decide accept failed");
+                continue;
+            }
+        };
+        // Overload: drop the connection. The hook treats no-answer-within-deadline
+        // as the no-verdict case and applies its local on_failure (fail-open default).
+        let permit = match sem.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::debug!("hook-decide overload: dropping (fail-open at hook)");
+                drop(stream);
+                continue;
+            }
+        };
+        let peer_uid = stream.peer_cred().map(|c| c.uid()).unwrap_or(u32::MAX);
+        let tx = tx.clone();
+        let host_id = host_id.clone();
+        let evaluator = evaluator.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            let mut line = String::new();
+            // Use take() for bounded read then recover the stream via into_inner chain.
+            // BufReader<Take<UnixStream>> -> into_inner() -> Take<UnixStream> -> into_inner() -> UnixStream.
+            use tokio::io::AsyncReadExt;
+            let mut rd = BufReader::new(stream.take(MAX_LINE));
+            if rd.read_line(&mut line).await.is_err() {
+                return;
+            }
+            let req: HookDecisionRequest = match serde_json::from_str(line.trim()) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::debug!(error = ?e, "hook-decide: malformed request");
+                    return;
+                }
+            };
+            // Recover the raw stream to write the response.
+            let mut stream = rd.into_inner().into_inner();
+
+            // 1) Observe event (best-effort, like Stage 1's one-way path).
+            let action = req.invocation.action.clone();
+            let inv = req.invocation.clone();
+            let observe_env = HookEnvelope {
+                protocol_version: HOOK_PROTOCOL_VERSION,
+                msg_type: HookMsgType::HookInvocation,
+                request_id: req.request_id,
+                sent_at_unix_ms: req.sent_at_unix_ms,
+                payload: inv,
+            };
+            let observe_ev = to_event(observe_env, peer_uid, &host_id);
+            let _ = tx.try_send(CommittableEvent {
+                event: observe_ev,
+                new_hash: None,
+                path_for_db: PathBuf::new(),
+                target_id: String::new(),
+            });
+
+            // 2) Decide.
+            let verdict = match evaluator.evaluate(&action) {
+                Some((rule_id, reason)) => {
+                    // Record HookDecision(deny) RELIABLY before responding.
+                    let ev = decision_event(
+                        &req.invocation,
+                        peer_uid,
+                        &host_id,
+                        "deny",
+                        Some(rule_id.clone()),
+                        Some(reason.clone()),
+                    );
+                    let _ = tx
+                        .send(CommittableEvent {
+                            event: ev,
+                            new_hash: None,
+                            path_for_db: PathBuf::new(),
+                            target_id: String::new(),
+                        })
+                        .await;
+                    HookVerdict {
+                        decision: Decision::Deny { rule_id, reason },
+                        enforcement_mode: EnforcementMode::Enforce,
+                    }
+                }
+                None => HookVerdict {
+                    decision: Decision::Allow,
+                    enforcement_mode: EnforcementMode::Enforce,
+                },
+            };
+
+            let resp = HookDecisionResponse {
+                protocol_version: HOOK_PROTOCOL_VERSION,
+                request_id: req.request_id,
+                verdict,
+            };
+            if let Ok(mut s) = serde_json::to_string(&resp) {
+                s.push('\n');
+                let _ = stream.write_all(s.as_bytes()).await;
+                let _ = stream.flush().await;
+                // Signal EOF promptly so the client's read_line returns without
+                // waiting on drop.
+                let _ = stream.shutdown().await;
+            }
+        });
+    }
+}
+
+fn decision_event(
+    inv: &sigil_core::hook_proto::HookInvocation,
+    peer_uid: u32,
+    host_id: &str,
+    // decision is "deny" in slice 1; a typed enum can replace the &str if allow/degradation outcomes are ever recorded.
+    decision: &str,
+    rule_id: Option<String>,
+    deny_reason: Option<String>,
+) -> sigil_core::event::Event {
+    let (kind, hash, preview) = match &inv.action {
+        HookAction::Bash {
+            command_hash,
+            command_preview,
+        } => ("bash", command_hash.clone(), command_preview.clone()),
+        HookAction::FileEdit {
+            path_hash,
+            path_preview,
+            ..
+        } => ("file_edit", path_hash.clone(), path_preview.clone()),
+        HookAction::McpCall {
+            args_hash,
+            args_preview,
+            ..
+        } => ("mcp_call", args_hash.clone(), args_preview.clone()),
+        // slice 1: HookDecisionEvidence has no other_label; the tool name for Other actions is not recorded here (follow-on).
+        HookAction::Other {
+            detail_hash,
+            detail_preview,
+            ..
+        } => ("other", detail_hash.clone(), detail_preview.clone()),
+    };
+    sigil_core::event::Event {
+        schema_version: SCHEMA_VERSION,
+        event_id: uuid::Uuid::now_v7(),
+        ts: time::OffsetDateTime::now_utc(),
+        host_id: host_id.to_string(),
+        agent_version: AGENT_VERSION.to_string(),
+        severity: Severity::Warn,
+        source: SourceKind::AgentHook,
+        subject: Subject::Self_,
+        evidence: Evidence::HookDecision(HookDecisionEvidence {
+            agent: inv.agent,
+            peer_uid,
+            agent_session_id: inv.agent_session_id.clone(),
+            tool_use_id: inv.tool_use_id.clone(),
+            action_kind: kind.to_string(),
+            action_hash: hash,
+            action_preview: preview,
+            decision: decision.to_string(),
+            rule_id,
+            deny_reason,
+            enforcement_mode: "enforce".to_string(),
+            capture_level: crate::hook_listener::enum_str(&inv.capture_level),
+        }),
+        target_id: None,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use sigil_core::hook_proto::{CaptureLevel, CaptureStatus, HookInvocation};
+    use sigil_core::policy::{DenyRule, HookActionMatch, Matcher};
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    fn req(cmd: &str) -> HookDecisionRequest {
+        HookDecisionRequest {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            request_id: uuid::Uuid::now_v7(),
+            sent_at_unix_ms: 0,
+            invocation: HookInvocation {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: Some(cmd.into()),
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+            deadline_ms: 250,
+        }
+    }
+
+    async fn round_trip(
+        socket: &std::path::Path,
+        request: &HookDecisionRequest,
+    ) -> HookDecisionResponse {
+        let mut s = tokio::net::UnixStream::connect(socket).await.unwrap();
+        let mut line = serde_json::to_string(request).unwrap();
+        line.push('\n');
+        s.write_all(line.as_bytes()).await.unwrap();
+        let mut resp = String::new();
+        BufReader::new(s).read_line(&mut resp).await.unwrap();
+        serde_json::from_str(resp.trim()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn deny_matches_and_records_decision_then_allow_otherwise() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("hook-decide.sock");
+        let (tx, mut rx) = mpsc::channel(16);
+        let ev = Arc::new(
+            DenyEvaluator::new(&[DenyRule {
+                id: "no-rm".into(),
+                match_: HookActionMatch::Bash {
+                    command: Matcher::Regex {
+                        pattern: r"rm\s+-rf".into(),
+                    },
+                },
+            }])
+            .unwrap(),
+        );
+        let sock2 = socket.clone();
+        tokio::spawn(async move {
+            let _ = serve(sock2, tx, "host-x".into(), ev).await;
+        });
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // DENY
+        let r = round_trip(&socket, &req("rm -rf /")).await;
+        match r.verdict.decision {
+            Decision::Deny { rule_id, .. } => assert_eq!(rule_id, "no-rm"),
+            _ => panic!("expected deny"),
+        }
+        // Observe (try_send) happens before the awaited decision send, so the
+        // order is deterministic: invocation first, decision second.
+        let e1 = rx.recv().await.unwrap();
+        assert!(
+            matches!(e1.event.evidence, Evidence::HookInvocation(_)),
+            "observe recorded first"
+        );
+        let e2 = rx.recv().await.unwrap();
+        assert!(
+            matches!(e2.event.evidence, Evidence::HookDecision(_)),
+            "decision recorded second"
+        );
+
+        // ALLOW
+        let r = round_trip(&socket, &req("ls -la")).await;
+        assert!(matches!(r.verdict.decision, Decision::Allow));
+    }
+}

--- a/crates/sigil-agent/src/hook_deny.rs
+++ b/crates/sigil-agent/src/hook_deny.rs
@@ -1,0 +1,247 @@
+//! Stage 2 (#100): pure deny-rule evaluation over a runtime HookAction.
+//! Regexes are compiled once at construction. First matching rule wins.
+use sigil_core::hook_proto::HookAction;
+use sigil_core::policy::{DenyRule, HookActionMatch, Matcher};
+
+pub struct DenyEvaluator {
+    rules: Vec<CompiledRule>,
+}
+
+struct CompiledRule {
+    id: String,
+    matcher: CompiledMatch,
+}
+
+enum CompiledMatch {
+    Bash(FieldMatch),
+    FileEdit(FieldMatch),
+    McpCall {
+        server: FieldMatch,
+        tool: FieldMatch,
+    },
+    Other {
+        label: FieldMatch,
+        detail: FieldMatch,
+    },
+}
+
+/// A field test with any Regex pre-compiled.
+struct FieldMatch {
+    matcher: Matcher,
+    regex: Option<regex::Regex>,
+}
+
+impl FieldMatch {
+    fn compile(m: &Matcher) -> Result<Self, regex::Error> {
+        let regex = match m {
+            Matcher::Regex { pattern } => Some(regex::Regex::new(pattern)?),
+            _ => None,
+        };
+        Ok(FieldMatch {
+            matcher: m.clone(),
+            regex,
+        })
+    }
+
+    /// Test against an optional string. `None` (no preview / absent field) never
+    /// matches — capture-aware fail-open.
+    fn holds(&self, value: Option<&str>) -> bool {
+        let Some(v) = value else { return false };
+        match &self.matcher {
+            Matcher::Exists => true,
+            Matcher::Equals { value } => v == value,
+            Matcher::NotEquals { value } => v != value,
+            Matcher::Regex { .. } => self.regex.as_ref().map(|r| r.is_match(v)).unwrap_or(false),
+        }
+    }
+}
+
+impl DenyEvaluator {
+    /// Compile all rules; first malformed regex fails construction (caller logs
+    /// and treats deny rules as empty — fail-open).
+    pub fn new(rules: &[DenyRule]) -> Result<Self, regex::Error> {
+        let mut out = Vec::with_capacity(rules.len());
+        for r in rules {
+            let matcher = match &r.match_ {
+                HookActionMatch::Bash { command } => {
+                    CompiledMatch::Bash(FieldMatch::compile(command)?)
+                }
+                HookActionMatch::FileEdit { path } => {
+                    CompiledMatch::FileEdit(FieldMatch::compile(path)?)
+                }
+                HookActionMatch::McpCall { server, tool } => CompiledMatch::McpCall {
+                    server: FieldMatch::compile(server)?,
+                    tool: FieldMatch::compile(tool)?,
+                },
+                HookActionMatch::Other { label, detail } => CompiledMatch::Other {
+                    label: FieldMatch::compile(label)?,
+                    detail: FieldMatch::compile(detail)?,
+                },
+            };
+            out.push(CompiledRule {
+                id: r.id.clone(),
+                matcher,
+            });
+        }
+        Ok(DenyEvaluator { rules: out })
+    }
+
+    // used by runtime wiring (Task 7)
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// First matching rule → (rule_id, reason). Slice 1 reason = the rule id.
+    pub fn evaluate(&self, action: &HookAction) -> Option<(String, String)> {
+        for r in &self.rules {
+            if rule_matches(&r.matcher, action) {
+                return Some((r.id.clone(), format!("matched deny rule {}", r.id)));
+            }
+        }
+        None
+    }
+}
+
+fn rule_matches(m: &CompiledMatch, action: &HookAction) -> bool {
+    match (m, action) {
+        (
+            CompiledMatch::Bash(f),
+            HookAction::Bash {
+                command_preview, ..
+            },
+        ) => f.holds(command_preview.as_deref()),
+        (CompiledMatch::FileEdit(f), HookAction::FileEdit { path_preview, .. }) => {
+            f.holds(path_preview.as_deref())
+        }
+        // server/tool/label are non-optional in HookAction; wrap in Some to satisfy holds().
+        (
+            CompiledMatch::McpCall { server, tool },
+            HookAction::McpCall {
+                server: s, tool: t, ..
+            },
+        ) => server.holds(Some(s.as_str())) && tool.holds(Some(t.as_str())),
+        // server/tool/label are non-optional in HookAction; wrap in Some to satisfy holds().
+        (
+            CompiledMatch::Other { label, detail },
+            HookAction::Other {
+                label: l,
+                detail_preview,
+                ..
+            },
+        ) => label.holds(Some(l.as_str())) && detail.holds(detail_preview.as_deref()),
+        // shape mismatch: a bash rule never matches an mcp action, etc.
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigil_core::policy::{DenyRule, HookActionMatch, Matcher};
+
+    fn bash(preview: Option<&str>) -> HookAction {
+        HookAction::Bash {
+            command_hash: "ab".repeat(32),
+            command_preview: preview.map(String::from),
+        }
+    }
+
+    #[test]
+    fn regex_bash_rule_matches_preview() {
+        let ev = DenyEvaluator::new(&[DenyRule {
+            id: "no-rm".into(),
+            match_: HookActionMatch::Bash {
+                command: Matcher::Regex {
+                    pattern: r"rm\s+-rf\s+/".into(),
+                },
+            },
+        }])
+        .unwrap();
+        assert_eq!(ev.evaluate(&bash(Some("rm -rf /"))).unwrap().0, "no-rm");
+        assert!(ev.evaluate(&bash(Some("ls -la"))).is_none());
+    }
+
+    #[test]
+    fn hash_only_no_preview_never_matches() {
+        let ev = DenyEvaluator::new(&[DenyRule {
+            id: "no-rm".into(),
+            match_: HookActionMatch::Bash {
+                command: Matcher::Regex {
+                    pattern: "rm".into(),
+                },
+            },
+        }])
+        .unwrap();
+        assert!(
+            ev.evaluate(&bash(None)).is_none(),
+            "no preview → fail-open (allow)"
+        );
+    }
+
+    #[test]
+    fn mcp_equals_matches_server_and_tool() {
+        let ev = DenyEvaluator::new(&[DenyRule {
+            id: "no-deploy".into(),
+            match_: HookActionMatch::McpCall {
+                server: Matcher::Equals {
+                    value: "deploy".into(),
+                },
+                tool: Matcher::Equals {
+                    value: "promote".into(),
+                },
+            },
+        }])
+        .unwrap();
+        let act = HookAction::McpCall {
+            server: "deploy".into(),
+            tool: "promote".into(),
+            args_hash: "ab".repeat(32),
+            args_preview: None,
+        };
+        assert_eq!(ev.evaluate(&act).unwrap().0, "no-deploy");
+    }
+
+    #[test]
+    fn first_match_wins() {
+        let ev = DenyEvaluator::new(&[
+            DenyRule {
+                id: "a".into(),
+                match_: HookActionMatch::Bash {
+                    command: Matcher::Regex {
+                        pattern: "rm".into(),
+                    },
+                },
+            },
+            DenyRule {
+                id: "b".into(),
+                match_: HookActionMatch::Bash {
+                    command: Matcher::Regex {
+                        pattern: "rm".into(),
+                    },
+                },
+            },
+        ])
+        .unwrap();
+        assert_eq!(ev.evaluate(&bash(Some("rm x"))).unwrap().0, "a");
+    }
+
+    #[test]
+    fn not_equals_matches_when_different() {
+        let ev = DenyEvaluator::new(&[DenyRule {
+            id: "not-safe".into(),
+            match_: HookActionMatch::Bash {
+                command: Matcher::NotEquals {
+                    value: "safe".into(),
+                },
+            },
+        }])
+        .unwrap();
+        // Different from "safe" → matches.
+        assert_eq!(ev.evaluate(&bash(Some("rm -rf /"))).unwrap().0, "not-safe");
+        // Equal to "safe" → does not match.
+        assert!(ev.evaluate(&bash(Some("safe"))).is_none());
+        // No preview → fail-open (allow).
+        assert!(ev.evaluate(&bash(None)).is_none());
+    }
+}

--- a/crates/sigil-agent/src/hook_listener.rs
+++ b/crates/sigil-agent/src/hook_listener.rs
@@ -130,7 +130,11 @@ pub async fn serve(
 
 /// Convert a decoded `HookEnvelope` + kernel-verified `peer_uid` into an
 /// `Event` suitable for the sink pipeline.
-fn to_event(env: HookEnvelope, peer_uid: u32, host_id: &str) -> sigil_core::event::Event {
+pub(crate) fn to_event(
+    env: HookEnvelope,
+    peer_uid: u32,
+    host_id: &str,
+) -> sigil_core::event::Event {
     let inv = env.payload;
 
     // Decompose the action into normalized fields.
@@ -192,7 +196,7 @@ fn to_event(env: HookEnvelope, peer_uid: u32, host_id: &str) -> sigil_core::even
 /// persisted evidence schema must match the serde wire form exactly
 /// (`"hash_only"`, `"unsupported_agent_schema"`, …), NOT the Rust Debug form.
 /// Falls back to an empty string if the value somehow isn't a JSON string.
-fn enum_str<T: serde::Serialize>(v: &T) -> String {
+pub(crate) fn enum_str<T: serde::Serialize>(v: &T) -> String {
     serde_json::to_value(v)
         .ok()
         .and_then(|j| j.as_str().map(String::from))

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -14,6 +14,8 @@ pub mod hook_deny;
 // IPC is a named pipe (see control.rs) and a named-pipe hook listener is a
 // follow-up, so the module is unix-only for Stage 1.
 #[cfg(unix)]
+pub mod hook_decide_listener;
+#[cfg(unix)]
 pub mod hook_listener;
 pub mod host_meta_snapshot;
 pub mod host_meta_snapshot_task;

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -9,6 +9,7 @@ pub mod doctor;
 pub mod gc_config;
 pub mod hasher;
 pub mod heartbeat;
+pub mod hook_deny;
 // The hook listener uses Unix-domain sockets (tokio UnixListener); Windows agent
 // IPC is a named pipe (see control.rs) and a named-pipe hook listener is a
 // follow-up, so the module is unix-only for Stage 1.

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -784,6 +784,46 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         );
     }
 
+    // Hook decide listener (sigil-hook Stage 2): bidirectional socket at
+    // `hook-decide.sock`. Agents write HookDecideRequest JSON; server
+    // evaluates deny rules and replies with HookDecideResponse. Built from
+    // the loaded policy's hook_deny_rules at startup (no hot-reload in slice 1).
+    #[cfg(unix)]
+    {
+        let decide_sock = cfg.control_socket.with_file_name("hook-decide.sock");
+        let tx_decide = tx_sink.clone();
+        let host_id_decide = host_id.clone();
+        // Build the evaluator from policy deny rules; a malformed regex disables
+        // enforcement (empty evaluator) rather than crashing — fail-open.
+        let evaluator = match crate::hook_deny::DenyEvaluator::new(&effective.hook_deny_rules) {
+            Ok(e) => Arc::new(e),
+            Err(e) => {
+                tracing::warn!(error = ?e, "hook deny rules failed to compile; enforcement disabled (fail-open)");
+                // safe: empty rules compile infallibly (no regex to compile)
+                Arc::new(crate::hook_deny::DenyEvaluator::new(&[]).unwrap())
+            }
+        };
+        sup.track(
+            "hook_decide_listener",
+            tokio::spawn(async move {
+                if let Err(e) = crate::hook_decide_listener::serve(
+                    decide_sock.clone(),
+                    tx_decide,
+                    host_id_decide,
+                    evaluator,
+                )
+                .await
+                {
+                    tracing::error!(
+                        error = ?e,
+                        socket = %decide_sock.display(),
+                        "hook-decide listener exited"
+                    );
+                }
+            }),
+        );
+    }
+
     // Drop-report fan-in: forward DropReports to sink as RateLimitExceeded events.
     {
         let tx_sink_dr = tx_sink.clone();

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -522,6 +522,10 @@ fn evidence_summary(e: &sigil_core::event::Evidence) -> (&'static str, String) {
         ),
         Evidence::HostMetaSnapshot { .. } => ("host_meta_snapshot", String::new()),
         Evidence::HookInvocation(_) => ("hook_invocation", String::new()),
+        Evidence::HookDecision(d) => (
+            "hook_decision",
+            format!("kind={} decision={}", d.action_kind, d.decision),
+        ),
         Evidence::Unknown => ("unknown", String::new()),
     }
 }

--- a/crates/sigil-agent/src/sink_task.rs
+++ b/crates/sigil-agent/src/sink_task.rs
@@ -69,6 +69,7 @@ fn evidence_kind_str(e: &sigil_core::event::Evidence) -> &'static str {
         AiGuardRiskAssessed { .. } => "ai_guard_risk_assessed",
         HostMetaSnapshot { .. } => "host_meta_snapshot",
         HookInvocation(_) => "hook_invocation",
+        HookDecision(_) => "hook_decision",
         Unknown => "unknown",
     }
 }

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -225,6 +225,28 @@ pub struct HookInvocationEvidence {
     pub capture_status: String,
 }
 
+/// sigil-hook Stage 2 (#100). A consequential decision outcome — a deny, or a
+/// degradation where enforcement could not be evaluated. NOT emitted on allow
+/// (observe already records every invocation via HookInvocation).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct HookDecisionEvidence {
+    pub agent: AiTool,
+    pub peer_uid: u32,
+    pub agent_session_id: Option<String>,
+    pub tool_use_id: Option<String>,
+    /// Normalized action kind: "bash" | "file_edit" | "mcp_call" | "other".
+    pub action_kind: String,
+    pub action_hash: String,
+    pub action_preview: Option<String>,
+    /// "deny" | "fail_open_error" | "fail_closed_error".
+    pub decision: String,
+    pub rule_id: Option<String>,
+    pub deny_reason: Option<String>,
+    /// "observe" | "enforce".
+    pub enforcement_mode: String,
+    pub capture_level: String,
+}
+
 /// Phase 3b.4-pre — full host identity / OS / network snapshot, emitted by
 /// host_meta_snapshot_task. Surfaces hostname (so server-side fleet views
 /// can label hosts with something human-readable instead of UUIDs) plus
@@ -460,6 +482,8 @@ pub enum Evidence {
     },
     /// sigil-hook Stage 1 (#64). One observed agent tool call.
     HookInvocation(HookInvocationEvidence),
+    /// sigil-hook Stage 2 (#100). A deny / degradation decision outcome.
+    HookDecision(HookDecisionEvidence),
     /// Forward-compat: an evidence kind this build doesn't recognize. A newer
     /// producer's variant deserializes here instead of failing the whole event.
     #[serde(other)]
@@ -1162,5 +1186,28 @@ mod tests {
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains(r#""rule_pack_id":"my-pack""#));
         assert_eq!(ev, serde_json::from_str::<Evidence>(&s).unwrap());
+    }
+
+    #[test]
+    fn hook_decision_evidence_serializes_snake_case() {
+        let ev = Evidence::HookDecision(HookDecisionEvidence {
+            agent: AiTool::ClaudeCode,
+            peer_uid: 501,
+            agent_session_id: Some("s".into()),
+            tool_use_id: None,
+            action_kind: "bash".into(),
+            action_hash: "ab".repeat(32),
+            action_preview: Some("rm -rf /".into()),
+            decision: "deny".into(),
+            rule_id: Some("no-rm-rf-root".into()),
+            deny_reason: Some("destructive".into()),
+            enforcement_mode: "enforce".into(),
+            capture_level: "redacted".into(),
+        });
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"kind\":\"hook_decision\""));
+        assert!(s.contains("\"decision\":\"deny\""));
+        let back: Evidence = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ev);
     }
 }

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -239,6 +239,8 @@ pub struct HookDecisionEvidence {
     pub action_hash: String,
     pub action_preview: Option<String>,
     /// "deny" | "fail_open_error" | "fail_closed_error".
+    /// `fail_*_error` values are reserved for the daemon-reachable-but-failed
+    /// degradation path (follow-on); slice 1's pre-compiled evaluator emits only "deny".
     pub decision: String,
     pub rule_id: Option<String>,
     pub deny_reason: Option<String>,

--- a/crates/sigil-core/src/hook_proto.rs
+++ b/crates/sigil-core/src/hook_proto.rs
@@ -7,12 +7,14 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Hook IPC protocol version. Bump on any breaking wire change.
-pub const HOOK_PROTOCOL_VERSION: u16 = 1;
+pub const HOOK_PROTOCOL_VERSION: u16 = 2;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HookMsgType {
     HookInvocation,
+    DecisionRequest,
+    DecisionResponse,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -79,10 +81,128 @@ pub enum CaptureStatus {
     RedactionFailed,
 }
 
+/// Stage 2 (#100): a synchronous decision request on `hook-decide.sock`.
+/// Carries the SAME normalized invocation the observe path produces (so the
+/// agent records observe + decision from one message), plus the hook's local
+/// wait budget.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HookDecisionRequest {
+    pub protocol_version: u16,
+    pub request_id: Uuid,
+    pub sent_at_unix_ms: u64,
+    pub invocation: HookInvocation,
+    pub deadline_ms: u32,
+}
+
+/// Stage 2 (#100): the agent's synchronous reply on `hook-decide.sock`,
+/// correlated to a `HookDecisionRequest` by `request_id`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HookDecisionResponse {
+    pub protocol_version: u16,
+    pub request_id: Uuid,
+    pub verdict: HookVerdict,
+}
+
+/// Stage 2 (#100): the decision itself plus the mode under which it was made
+/// (so the hook knows whether a `Deny` should actually block or just observe).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HookVerdict {
+    pub decision: Decision,
+    pub enforcement_mode: EnforcementMode,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Decision {
+    Allow,
+    Deny { rule_id: String, reason: String },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum EnforcementMode {
+    Observe,
+    Enforce,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::event::AiTool;
+
+    #[test]
+    fn decision_request_round_trips() {
+        let req = HookDecisionRequest {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            request_id: uuid::Uuid::nil(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            invocation: HookInvocation {
+                agent: AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: Some("rm -rf /".into()),
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+            deadline_ms: 250,
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        let back: HookDecisionRequest = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, req);
+    }
+
+    #[test]
+    fn decision_response_deny_round_trips() {
+        let resp = HookDecisionResponse {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            request_id: uuid::Uuid::nil(),
+            verdict: HookVerdict {
+                decision: Decision::Deny {
+                    rule_id: "no-rm-rf-root".into(),
+                    reason: "destructive".into(),
+                },
+                enforcement_mode: EnforcementMode::Enforce,
+            },
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"kind\":\"deny\""));
+        assert!(s.contains("\"enforcement_mode\":\"enforce\""));
+        let back: HookDecisionResponse = serde_json::from_str(&s).unwrap();
+        match back.verdict.decision {
+            Decision::Deny { rule_id, .. } => assert_eq!(rule_id, "no-rm-rf-root"),
+            _ => panic!("expected deny"),
+        }
+    }
+
+    #[test]
+    fn v1_observe_envelope_still_round_trips_byte_identical() {
+        let env = HookEnvelope {
+            protocol_version: 1,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::nil(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookInvocation {
+                agent: AiTool::ClaudeCode,
+                agent_session_id: Some("s".into()),
+                tool_use_id: Some("t".into()),
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: None,
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains("\"msg_type\":\"hook_invocation\""));
+        let back: HookEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, env);
+    }
 
     #[test]
     fn envelope_round_trips_with_bash_action() {

--- a/crates/sigil-core/src/policy/deny_rule.rs
+++ b/crates/sigil-core/src/policy/deny_rule.rs
@@ -1,0 +1,138 @@
+//! Stage 2 (#100): operator deny rules over runtime hook actions. The subject
+//! is a `HookAction` (a tool call), distinct from rule packs (config files).
+use crate::policy::Matcher;
+use serde::{Deserialize, Serialize};
+
+/// What to do when no verdict is obtainable (daemon down, timeout, malformed).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FailMode {
+    #[default]
+    Open,
+    Closed,
+}
+
+/// One deny rule. Fires when its `match_` holds for the action.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct DenyRule {
+    pub id: String,
+    #[serde(rename = "match")]
+    pub match_: HookActionMatch,
+}
+
+/// Matches one HookAction shape. Every present field-matcher must hold (AND).
+/// The `kind` tag mirrors `hook_proto::HookAction`'s wire kinds.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HookActionMatch {
+    Bash {
+        command: Matcher,
+    },
+    FileEdit {
+        path: Matcher,
+    },
+    McpCall {
+        server: Matcher,
+        tool: Matcher,
+    },
+    /// `detail` matches against the normalized detail PREVIEW form, not the
+    /// opaque `detail_hash`.
+    Other {
+        label: Matcher,
+        detail: Matcher,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_rule_yaml_round_trips_with_match_rename() {
+        let yaml = r#"
+id: no-rm-rf-root
+match:
+  kind: bash
+  command: { kind: regex, pattern: "rm -rf /" }
+"#;
+        let r: DenyRule = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(r.id, "no-rm-rf-root");
+        match &r.match_ {
+            HookActionMatch::Bash {
+                command: Matcher::Regex { pattern },
+            } => assert_eq!(pattern, "rm -rf /"),
+            _ => panic!("expected bash/regex"),
+        }
+        // serialize direction: the `match_` field must re-emit as `match:`.
+        let out = serde_yaml::to_string(&r).unwrap();
+        assert!(out.contains("match:"));
+    }
+
+    #[test]
+    fn fail_mode_defaults_to_open() {
+        assert_eq!(FailMode::default(), FailMode::Open);
+        let m: FailMode = serde_yaml::from_str("closed").unwrap();
+        assert_eq!(m, FailMode::Closed);
+    }
+
+    #[test]
+    fn mcp_match_round_trips_both_fields() {
+        let yaml = r#"
+id: no-prod-deploy
+match:
+  kind: mcp_call
+  server: { kind: equals, value: "deploy" }
+  tool:   { kind: equals, value: "promote_production" }
+"#;
+        let r: DenyRule = serde_yaml::from_str(yaml).unwrap();
+        match r.match_ {
+            HookActionMatch::McpCall {
+                server: Matcher::Equals { value: s },
+                tool: Matcher::Equals { value: t },
+            } => {
+                assert_eq!(s, "deploy");
+                assert_eq!(t, "promote_production");
+            }
+            _ => panic!("expected mcp_call/equals"),
+        }
+    }
+
+    #[test]
+    fn file_edit_match_deserializes() {
+        let yaml = r#"
+id: no-edit-etc
+match:
+  kind: file_edit
+  path: { kind: regex, pattern: "/etc/" }
+"#;
+        let r: DenyRule = serde_yaml::from_str(yaml).unwrap();
+        match r.match_ {
+            HookActionMatch::FileEdit {
+                path: Matcher::Regex { pattern },
+            } => assert_eq!(pattern, "/etc/"),
+            _ => panic!("expected file_edit/regex"),
+        }
+    }
+
+    #[test]
+    fn other_match_deserializes_both_fields() {
+        let yaml = r#"
+id: no-weird-tool
+match:
+  kind: other
+  label:  { kind: equals, value: "browser" }
+  detail: { kind: equals, value: "navigate" }
+"#;
+        let r: DenyRule = serde_yaml::from_str(yaml).unwrap();
+        match r.match_ {
+            HookActionMatch::Other {
+                label: Matcher::Equals { value: l },
+                detail: Matcher::Equals { value: d },
+            } => {
+                assert_eq!(l, "browser");
+                assert_eq!(d, "navigate");
+            }
+            _ => panic!("expected other/equals"),
+        }
+    }
+}

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -19,6 +19,9 @@ pub use pubkeys::{Keystore, KeystoreEntry, KeystoreError};
 pub use signed_envelope::{SignedEnvelope, SignedPolicyResponse};
 pub use verify::{verify_envelope, VerifiedPolicy, VerifyError};
 
+pub mod deny_rule;
+pub use deny_rule::{DenyRule, FailMode, HookActionMatch};
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tier {
@@ -182,6 +185,13 @@ pub struct PolicyDocument {
     /// runtime. Absent field = no overrides.
     #[serde(default)]
     pub rubric_overrides: HashMap<String, f32>,
+    /// Stage 2 (#100) — operator deny rules evaluated by the hook-decide path.
+    /// Empty/absent = no enforcement (observe-only). Wire-additive, back-compat.
+    #[serde(default)]
+    pub hook_deny_rules: Vec<deny_rule::DenyRule>,
+    /// Stage 2 (#100) — behavior when a verdict cannot be obtained. Default open.
+    #[serde(default)]
+    pub on_failure: deny_rule::FailMode,
 }
 
 fn default_host_id_strategy() -> HostIdStrategy {
@@ -403,6 +413,8 @@ pub fn defaults() -> Result<PolicyDocument, PolicyError> {
             antigravity_workspaces: vec![],
             rule_packs,
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         }),
     }
 }
@@ -538,6 +550,8 @@ targets:
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         }
     }
 
@@ -605,6 +619,8 @@ targets:
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
         let ids: Vec<&str> = eff.targets.iter().map(|t| t.id.as_str()).collect();
@@ -630,6 +646,8 @@ targets:
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
         assert_eq!(eff.targets[0].tier, Tier::Standard);
@@ -654,6 +672,8 @@ targets:
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         let err = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::UnknownOverrideId(_)));
@@ -674,6 +694,8 @@ targets:
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         let err = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::DuplicateId(_)));
@@ -698,6 +720,8 @@ targets:
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         let err = merge(defaults, None, None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::EmptyTargets));
@@ -1010,6 +1034,8 @@ host_id_strategy: hostname
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         user.rubric_overrides
             .insert("destructive_in_hook_script".into(), 5.5);
@@ -1081,10 +1107,20 @@ host_id_strategy: hostname
             antigravity_workspaces: vec!["~/src/c".to_string()],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: deny_rule::FailMode::Open,
         };
         let eff = merge(defaults().unwrap(), Some(user), None, current_platform()).unwrap();
         assert_eq!(eff.gemini_workspaces, vec!["~/src/a".to_string()]);
         assert_eq!(eff.cursor_workspaces, vec!["~/src/b".to_string()]);
         assert_eq!(eff.antigravity_workspaces, vec!["~/src/c".to_string()]);
+    }
+
+    #[test]
+    fn policy_without_hook_deny_rules_defaults_empty_open() {
+        // use the same minimal valid policy shape the other tests in this module use
+        let doc = parse(yaml_minimal()).unwrap();
+        assert!(doc.hook_deny_rules.is_empty());
+        assert_eq!(doc.on_failure, FailMode::Open);
     }
 }

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -190,6 +190,8 @@ pub struct PolicyDocument {
     #[serde(default)]
     pub hook_deny_rules: Vec<deny_rule::DenyRule>,
     /// Stage 2 (#100) — behavior when a verdict cannot be obtained. Default open.
+    // Consumed by the hook locally via its --on-failure registration flag (not by
+    // the agent); intentionally not threaded into EffectivePolicy.
     #[serde(default)]
     pub on_failure: deny_rule::FailMode,
 }
@@ -263,6 +265,9 @@ pub struct EffectivePolicy {
     /// Phase 3b.5 — operator-tunable rubric weights (merged from user
     /// PolicyDocument; defaults map is empty).
     pub rubric_overrides: HashMap<String, f32>,
+    /// Stage 2 (#100) — operator deny rules forwarded from user PolicyDocument.
+    /// Empty = no enforcement (observe-only).
+    pub hook_deny_rules: Vec<deny_rule::DenyRule>,
 }
 
 /// Merge a defaults document and a user-override document into an effective policy.
@@ -369,6 +374,11 @@ pub fn merge(
         .map(|u| u.rubric_overrides.clone())
         .unwrap_or_default();
 
+    let hook_deny_rules = user
+        .as_ref()
+        .map(|u| u.hook_deny_rules.clone())
+        .unwrap_or_default();
+
     Ok(EffectivePolicy {
         host_id_strategy: strategy,
         targets: by_id,
@@ -380,6 +390,7 @@ pub fn merge(
         antigravity_workspaces,
         rule_packs,
         rubric_overrides,
+        hook_deny_rules,
     })
 }
 

--- a/crates/sigil-core/tests/properties.rs
+++ b/crates/sigil-core/tests/properties.rs
@@ -3,7 +3,9 @@
 use proptest::prelude::*;
 use sigil_core::debounce::Debouncer;
 use sigil_core::event::{Event, FileChangeKind};
-use sigil_core::policy::{merge, HostIdStrategy, Platform, PolicyDocument, Tier, WatchTarget};
+use sigil_core::policy::{
+    merge, FailMode, HostIdStrategy, Platform, PolicyDocument, Tier, WatchTarget,
+};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -43,6 +45,8 @@ proptest! {
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: FailMode::Open,
         };
         let r1 = merge(defaults.clone(), None, None, Platform::Any).unwrap();
         let r2 = merge(defaults, None, None, Platform::Any).unwrap();
@@ -71,6 +75,8 @@ proptest! {
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: FailMode::Open,
         };
         let user = PolicyDocument {
             version: 1,
@@ -85,6 +91,8 @@ proptest! {
             antigravity_workspaces: vec![],
             rule_packs: vec![],
             rubric_overrides: HashMap::new(),
+            hook_deny_rules: vec![],
+            on_failure: FailMode::Open,
         };
         let res = merge(defaults, Some(user), None, Platform::Any);
         prop_assert!(res.is_err());

--- a/crates/sigil-hook/src/decide.rs
+++ b/crates/sigil-hook/src/decide.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 // called by the claude-code enforce path (Task 9)
 #[cfg(unix)]
-#[allow(dead_code)]
 pub fn request_verdict(
     socket: &Path,
     req: &HookDecisionRequest,
@@ -33,7 +32,6 @@ pub fn request_verdict(
 
 // called by the claude-code enforce path (Task 9)
 #[cfg(not(unix))]
-#[allow(dead_code)]
 pub fn request_verdict(
     _socket: &Path,
     _req: &HookDecisionRequest,

--- a/crates/sigil-hook/src/decide.rs
+++ b/crates/sigil-hook/src/decide.rs
@@ -1,0 +1,79 @@
+//! Stage 2 (#100): hook-side synchronous decision transport. Blocking std
+//! sockets (the hook is a short-lived process; no tokio). Any failure → None
+//! so the caller falls back to its local on_failure mode.
+use sigil_core::hook_proto::{HookDecisionRequest, HookDecisionResponse, HookVerdict};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::time::Duration;
+
+// called by the claude-code enforce path (Task 9)
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn request_verdict(
+    socket: &Path,
+    req: &HookDecisionRequest,
+    deadline: Duration,
+) -> Option<HookVerdict> {
+    use std::os::unix::net::UnixStream;
+    let stream = UnixStream::connect(socket).ok()?;
+    stream.set_read_timeout(Some(deadline)).ok()?;
+    stream.set_write_timeout(Some(deadline)).ok()?;
+    // set_*_timeout is a socket-level option (SO_RCVTIMEO/SO_SNDTIMEO); try_clone inherits it on the dup'd fd.
+    let mut w = stream.try_clone().ok()?;
+    let mut line = serde_json::to_string(req).ok()?;
+    line.push('\n');
+    w.write_all(line.as_bytes()).ok()?;
+    w.flush().ok()?;
+    let mut resp = String::new();
+    // Single-line response; read_line completes in one syscall on a domain socket, so deadline-per-read is acceptable for slice 1.
+    BufReader::new(stream).read_line(&mut resp).ok()?;
+    let parsed: HookDecisionResponse = serde_json::from_str(resp.trim()).ok()?;
+    Some(parsed.verdict)
+}
+
+// called by the claude-code enforce path (Task 9)
+#[cfg(not(unix))]
+#[allow(dead_code)]
+pub fn request_verdict(
+    _socket: &Path,
+    _req: &HookDecisionRequest,
+    _deadline: Duration,
+) -> Option<HookVerdict> {
+    None // Windows enforce is out of scope (slice 1): always fall back to on_failure.
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    #[test]
+    fn missing_socket_returns_none() {
+        let req = sample_req();
+        let v = request_verdict(
+            Path::new("/nonexistent/sigil/hook-decide.sock"),
+            &req,
+            Duration::from_millis(100),
+        );
+        assert!(v.is_none());
+    }
+    fn sample_req() -> HookDecisionRequest {
+        use sigil_core::hook_proto::*;
+        HookDecisionRequest {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            request_id: uuid::Uuid::nil(),
+            sent_at_unix_ms: 0,
+            invocation: HookInvocation {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: Some("x".into()),
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+            deadline_ms: 100,
+        }
+    }
+}

--- a/crates/sigil-hook/src/decide.rs
+++ b/crates/sigil-hook/src/decide.rs
@@ -1,8 +1,7 @@
 //! Stage 2 (#100): hook-side synchronous decision transport. Blocking std
 //! sockets (the hook is a short-lived process; no tokio). Any failure → None
 //! so the caller falls back to its local on_failure mode.
-use sigil_core::hook_proto::{HookDecisionRequest, HookDecisionResponse, HookVerdict};
-use std::io::{BufRead, BufReader, Write};
+use sigil_core::hook_proto::{HookDecisionRequest, HookVerdict};
 use std::path::Path;
 use std::time::Duration;
 
@@ -13,6 +12,9 @@ pub fn request_verdict(
     req: &HookDecisionRequest,
     deadline: Duration,
 ) -> Option<HookVerdict> {
+    // unix-only imports kept local so the non-unix stub doesn't trip unused-import.
+    use sigil_core::hook_proto::HookDecisionResponse;
+    use std::io::{BufRead, BufReader, Write};
     use std::os::unix::net::UnixStream;
     let stream = UnixStream::connect(socket).ok()?;
     stream.set_read_timeout(Some(deadline)).ok()?;

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -43,6 +43,9 @@ fn command_string(exe: &str, agent: &str, capture: &str) -> String {
 }
 
 fn command_string_enforce(exe: &str, agent: &str, capture: &str, on_failure: &str) -> String {
+    // Registrations dedupe by binary path: installing enforce over an existing observe
+    // registration (same exe) REPLACES it — operators upgrading observe→enforce get the
+    // observe entry overwritten, not a second entry.
     format!("{exe} {agent} --enforce --on-failure {on_failure} --capture {capture}")
 }
 
@@ -223,6 +226,8 @@ pub fn render_block_enforce(exe: &str, agent: &str, capture: &str, on_failure: &
 /// Merge an enforce-mode registration into the settings JSON.
 /// For claude-code (NestedPreToolUse): merges with the enforce command string.
 /// For Cursor and unknown agents: returns false (not supported in slice 1).
+///
+/// slice 1: enforce is claude-code only; the CLI guards non-claude-code before reaching here.
 pub fn merge_into_enforce(
     root: &mut Value,
     exe: &str,

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -42,6 +42,10 @@ fn command_string(exe: &str, agent: &str, capture: &str) -> String {
     format!("{exe} {agent} --capture {capture}")
 }
 
+fn command_string_enforce(exe: &str, agent: &str, capture: &str, on_failure: &str) -> String {
+    format!("{exe} {agent} --enforce --on-failure {on_failure} --capture {capture}")
+}
+
 /// First whitespace token of a command string (= the binary path).
 fn first_token(cmd: &str) -> &str {
     cmd.split_whitespace().next().unwrap_or("")
@@ -160,9 +164,9 @@ fn merge_cursor(root: &mut Value, exe: &str, cmd: &str) -> bool {
 // Public API (dispatched by agent format)
 // ---------------------------------------------------------------------------
 
-/// Human-pasteable block showing the settings fragment + undo hint.
-pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
-    let cmd = command_string(exe, agent, capture);
+/// Shared body for `render_block` / `render_block_enforce`: builds the
+/// human-pasteable settings fragment + undo hint for a prebuilt command string.
+fn render_block_inner(cmd: &str, agent: &str) -> String {
     let Some(fmt) = agent_format(agent) else {
         return format!("// unsupported agent '{agent}'\n");
     };
@@ -170,7 +174,7 @@ pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|| "<settings>".into());
     let fragment = match fmt {
-        HookFormat::NestedPreToolUse => json!({ "hooks": { "PreToolUse": [claude_entry(&cmd)] } }),
+        HookFormat::NestedPreToolUse => json!({ "hooks": { "PreToolUse": [claude_entry(cmd)] } }),
         HookFormat::Cursor => json!({
             "version": 1,
             "hooks": {
@@ -192,6 +196,12 @@ pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
     )
 }
 
+/// Human-pasteable block showing the settings fragment + undo hint.
+pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
+    let cmd = command_string(exe, agent, capture);
+    render_block_inner(&cmd, agent)
+}
+
 /// Idempotently ensure the sigil-hook entry is present. Returns `true` if the
 /// document was modified.
 pub fn merge_into(root: &mut Value, exe: &str, agent: &str, capture: &str) -> bool {
@@ -199,6 +209,31 @@ pub fn merge_into(root: &mut Value, exe: &str, agent: &str, capture: &str) -> bo
     match agent_format(agent) {
         Some(HookFormat::NestedPreToolUse) => merge_claude(pretooluse_array_mut(root), exe, &cmd),
         Some(HookFormat::Cursor) => merge_cursor(root, exe, &cmd),
+        None => false,
+    }
+}
+
+/// Like `render_block`, but the registered command runs the Stage 2 enforce
+/// (deny-decision) path with the given on_failure mode.
+pub fn render_block_enforce(exe: &str, agent: &str, capture: &str, on_failure: &str) -> String {
+    let cmd = command_string_enforce(exe, agent, capture, on_failure);
+    render_block_inner(&cmd, agent)
+}
+
+/// Merge an enforce-mode registration into the settings JSON.
+/// For claude-code (NestedPreToolUse): merges with the enforce command string.
+/// For Cursor and unknown agents: returns false (not supported in slice 1).
+pub fn merge_into_enforce(
+    root: &mut Value,
+    exe: &str,
+    agent: &str,
+    capture: &str,
+    on_failure: &str,
+) -> bool {
+    let cmd = command_string_enforce(exe, agent, capture, on_failure);
+    match agent_format(agent) {
+        Some(HookFormat::NestedPreToolUse) => merge_claude(pretooluse_array_mut(root), exe, &cmd),
+        Some(HookFormat::Cursor) => false,
         None => false,
     }
 }
@@ -335,6 +370,15 @@ pub fn write_baseline(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn render_block_enforce_carries_flags() {
+        let s = render_block_enforce("/abs/sigil-hook", "claude-code", "redacted", "open");
+        assert!(s.contains(
+            "/abs/sigil-hook claude-code --enforce --on-failure open --capture redacted"
+        ));
+        assert!(s.contains("PreToolUse"));
+    }
 
     // --- Claude Code (nested) ---
     #[test]

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -110,6 +110,32 @@ fn hook_socket_path() -> PathBuf {
         .unwrap_or_default()
 }
 
+/// Resolve the decide socket for the enforce path. Mirrors `hook_socket_path`
+/// but targets `hook-decide.sock` (the Stage 2 synchronous channel).
+/// `SIGIL_HOOK_DECIDE_SOCKET` overrides everything.
+#[cfg(unix)]
+fn hook_decide_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("SIGIL_HOOK_DECIDE_SOCKET") {
+        return PathBuf::from(p);
+    }
+    let system = PathBuf::from("/var/run/sigil/hook-decide.sock");
+    if system.exists() {
+        return system;
+    }
+    let uid = unsafe { libc::geteuid() };
+    let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+    let tmp = std::env::var("TMPDIR").ok();
+    sigil_core::control_proto::resolve_control_socket(uid == 0, xdg, tmp, uid)
+        .with_file_name("hook-decide.sock")
+}
+
+#[cfg(not(unix))]
+fn hook_decide_socket_path() -> PathBuf {
+    std::env::var("SIGIL_HOOK_DECIDE_SOCKET")
+        .map(PathBuf::from)
+        .unwrap_or_default()
+}
+
 #[derive(Parser)]
 #[command(
     name = "sigil-hook",
@@ -127,6 +153,12 @@ enum Cmd {
     ClaudeCode {
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
         capture: CaptureArg,
+        /// Stage 2: run the synchronous deny-decision path instead of observe.
+        #[arg(long)]
+        enforce: bool,
+        /// Behavior when no verdict is obtainable. Default open (fail-open).
+        #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
+        on_failure: OnFailureArg,
     },
 
     /// Codex CLI PreToolUse entrypoint: read stdin, emit, exit 0.
@@ -191,10 +223,100 @@ impl From<CaptureArg> for CaptureLevel {
     }
 }
 
+/// Behavior when no verdict is obtainable from the decide daemon.
+#[derive(Copy, Clone, ValueEnum)]
+enum OnFailureArg {
+    Open,
+    Closed,
+}
+
+/// Maximum elapsed time waiting for a verdict before falling back to on_failure.
+const DECISION_DEADLINE: Duration = Duration::from_millis(250);
+
+/// claude-code enforce entrypoint. Panic-safe; never hangs past the watchdog.
+/// On Deny → print the permissionDecision JSON; on Allow → nothing.
+/// No verdict (daemon down / timeout / malformed) → apply on_failure.
+fn run_enforce(capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
+    std::panic::set_hook(Box::new(|_| std::process::exit(0)));
+    emit::arm_watchdog(Duration::from_millis(800)); // > decision deadline, < agent UX budget
+    let adapter = match adapters::for_agent("claude-code") {
+        Some(a) => a,
+        None => std::process::exit(0),
+    };
+
+    let mut buf = Vec::new();
+    let _ = std::io::stdin()
+        .take(MAX_STDIN as u64 + 1)
+        .read_to_end(&mut buf);
+    let oversized = buf.len() > MAX_STDIN;
+    let payload: serde_json::Value =
+        serde_json::from_slice(&buf).unwrap_or(serde_json::Value::Null);
+    let mut inv = match adapter.normalize(&payload, capture) {
+        Ok(i) => i,
+        Err(status) => minimal_unparsed(adapter.agent(), capture, status),
+    };
+    if oversized {
+        inv.capture_status = CaptureStatus::Oversized;
+    }
+
+    let req = HookDecisionRequest {
+        protocol_version: HOOK_PROTOCOL_VERSION,
+        request_id: uuid::Uuid::now_v7(),
+        sent_at_unix_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+        invocation: inv,
+        deadline_ms: DECISION_DEADLINE.as_millis() as u32,
+    };
+
+    match decide::request_verdict(&hook_decide_socket_path(), &req, DECISION_DEADLINE) {
+        Some(v) => match v.decision {
+            Decision::Deny { rule_id, reason } => {
+                print_deny(&rule_id, &reason);
+                std::process::exit(0);
+            }
+            Decision::Allow => std::process::exit(0),
+        },
+        None => match on_failure {
+            OnFailureArg::Open => std::process::exit(0),
+            OnFailureArg::Closed => {
+                print_deny("fail_closed", "decision unavailable; on_failure=closed");
+                std::process::exit(0);
+            }
+        },
+    }
+}
+
+/// Pure builder for the Claude Code PreToolUse deny JSON (testable).
+fn deny_json(rule_id: &str, reason: &str) -> serde_json::Value {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": format!("Blocked by Sigil rule {rule_id}: {reason}")
+        }
+    })
+}
+
+fn print_deny(rule_id: &str, reason: &str) {
+    println!("{}", deny_json(rule_id, reason));
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.cmd {
-        Cmd::ClaudeCode { capture } => run_hook("claude-code", capture.into()),
+        Cmd::ClaudeCode {
+            capture,
+            enforce,
+            on_failure,
+        } => {
+            if enforce {
+                run_enforce(capture.into(), on_failure)
+            } else {
+                run_hook("claude-code", capture.into())
+            }
+        }
         Cmd::Codex { capture } => run_hook("codex", capture.into()),
         Cmd::Cursor { capture } => run_hook("cursor", capture.into()),
         Cmd::Antigravity { capture } => run_hook("antigravity", capture.into()),
@@ -440,4 +562,24 @@ fn cmd_uninstall_antigravity(write: bool) {
         }
     }
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_json_has_pretooluse_deny_shape() {
+        let v = deny_json("no-rm", "destructive");
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+        assert!(v["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap()
+            .contains("no-rm"));
+        assert_eq!(
+            v["hookSpecificOutput"]["permissionDecisionReason"],
+            "Blocked by Sigil rule no-rm: destructive"
+        );
+    }
 }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -193,6 +193,12 @@ enum Cmd {
         /// Capture level for the registered hook command.
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
         capture: CaptureArg,
+        /// Register the Stage 2 enforce (deny-decision) hook instead of observe.
+        #[arg(long)]
+        enforce: bool,
+        /// Fail mode baked into the enforce command. Default open.
+        #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
+        on_failure: OnFailureArg,
     },
 
     /// Remove the sigil-hook registration from an agent's settings.
@@ -324,7 +330,9 @@ fn main() {
             agent,
             write,
             capture,
-        } => cmd_install(&agent, write, capture),
+            enforce,
+            on_failure,
+        } => cmd_install(&agent, write, capture, enforce, on_failure),
         Cmd::Uninstall { agent, write } => cmd_uninstall(&agent, write),
     }
 }
@@ -337,11 +345,21 @@ fn exe_path() -> String {
         .unwrap_or_else(|| "sigil-hook".to_string())
 }
 
-fn cmd_install(agent: &str, write: bool, capture: CaptureArg) {
+fn cmd_install(
+    agent: &str,
+    write: bool,
+    capture: CaptureArg,
+    enforce: bool,
+    on_failure: OnFailureArg,
+) {
     let capture_str = match capture {
         CaptureArg::Redacted => "redacted",
         CaptureArg::Raw => "raw",
         CaptureArg::HashOnly => "hash-only",
+    };
+    let on_failure_str = match on_failure {
+        OnFailureArg::Open => "open",
+        OnFailureArg::Closed => "closed",
     };
     let exe = exe_path();
 
@@ -352,8 +370,26 @@ fn cmd_install(agent: &str, write: bool, capture: CaptureArg) {
     }
 
     if !write {
-        print!("{}", install::render_block(&exe, agent, capture_str));
+        if enforce {
+            print!(
+                "{}",
+                install::render_block_enforce(&exe, agent, capture_str, on_failure_str)
+            );
+        } else {
+            print!("{}", install::render_block(&exe, agent, capture_str));
+        }
         return;
+    }
+
+    // Enforce-mode --write is only wired for NestedPreToolUse agents in slice 1
+    // (claude-code, codex). For Cursor or unknown agents, merge_into_enforce is
+    // a no-op — guard explicitly so we never print a misleading "already
+    // installed (no change)" or write an unchanged settings file as if it took.
+    if enforce && !matches!(agent, "claude-code" | "codex") {
+        eprintln!(
+            "error: enforce-mode install is only supported for claude-code/codex in slice 1 (agent '{agent}' not registered)"
+        );
+        std::process::exit(1);
     }
 
     // Resolve the settings path for this agent.
@@ -379,7 +415,11 @@ fn cmd_install(agent: &str, write: bool, capture: CaptureArg) {
         serde_json::json!({})
     };
 
-    let changed = install::merge_into(&mut root, &exe, agent, capture_str);
+    let changed = if enforce {
+        install::merge_into_enforce(&mut root, &exe, agent, capture_str, on_failure_str)
+    } else {
+        install::merge_into(&mut root, &exe, agent, capture_str)
+    };
 
     // Write back atomically: write to a temp file beside the target, then rename.
     let pretty = serde_json::to_string_pretty(&root).unwrap_or_default();

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -277,12 +277,15 @@ fn run_enforce(capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
     };
 
     match decide::request_verdict(&hook_decide_socket_path(), &req, DECISION_DEADLINE) {
-        Some(v) => match v.decision {
-            Decision::Deny { rule_id, reason } => {
+        Some(v) => match (v.decision, v.enforcement_mode) {
+            // Only block when the daemon explicitly says Deny AND is in Enforce mode.
+            // A Deny down-shifted to Observe (spec §4) must not block the tool call.
+            (Decision::Deny { rule_id, reason }, EnforcementMode::Enforce) => {
                 print_deny(&rule_id, &reason);
                 std::process::exit(0);
             }
-            Decision::Allow => std::process::exit(0),
+            // Allow, or a Deny down-shifted to Observe → do not block.
+            _ => std::process::exit(0),
         },
         None => match on_failure {
             OnFailureArg::Open => std::process::exit(0),
@@ -381,13 +384,14 @@ fn cmd_install(
         return;
     }
 
-    // Enforce-mode --write is only wired for NestedPreToolUse agents in slice 1
-    // (claude-code, codex). For Cursor or unknown agents, merge_into_enforce is
-    // a no-op — guard explicitly so we never print a misleading "already
-    // installed (no change)" or write an unchanged settings file as if it took.
-    if enforce && !matches!(agent, "claude-code" | "codex") {
+    // Enforce-mode --write is only supported for claude-code in slice 1.
+    // The Codex subcommand has no --enforce flag (clap would exit 2 at runtime),
+    // and codex enforce is out of scope for slice 1. For any other agent, guard
+    // explicitly so we never write a misleading settings file or print a
+    // confusing "already installed (no change)" message.
+    if enforce && agent != "claude-code" {
         eprintln!(
-            "error: enforce-mode install is only supported for claude-code/codex in slice 1 (agent '{agent}' not registered)"
+            "error: enforce-mode install is only supported for claude-code in slice 1 (agent '{agent}' not registered)"
         );
         std::process::exit(1);
     }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -1,4 +1,5 @@
 mod adapters;
+mod decide;
 mod emit;
 mod install;
 mod install_antigravity;

--- a/crates/sigil-hook/tests/enforce_e2e.rs
+++ b/crates/sigil-hook/tests/enforce_e2e.rs
@@ -1,0 +1,120 @@
+//! E2E (#100): the hook binary's claude-code --enforce path against a stub
+//! decide server. Verifies deny JSON, allow silence, and fail-open.
+#![cfg(unix)]
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// One-shot stub: accept one connection, read the request line, reply with a
+/// fixed verdict. `deny` chooses the verdict.
+fn spawn_stub(socket: std::path::PathBuf, deny: bool) {
+    std::thread::spawn(move || {
+        let listener = UnixListener::bind(&socket).unwrap();
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut line = String::new();
+            BufReader::new(s.try_clone().unwrap())
+                .read_line(&mut line)
+                .unwrap();
+            // Build the response with the EXACT verified wire shape.
+            // HookDecisionResponse { protocol_version, request_id, verdict: HookVerdict { decision, enforcement_mode } }
+            // Decision is serde(tag = "kind", rename_all = "snake_case"):
+            //   Deny { rule_id, reason } → {"kind":"deny","rule_id":"...","reason":"..."}
+            //   Allow → {"kind":"allow"}
+            let decision = if deny {
+                r#"{"kind":"deny","rule_id":"no-rm","reason":"destructive"}"#
+            } else {
+                r#"{"kind":"allow"}"#
+            };
+            let resp = format!(
+                r#"{{"protocol_version":2,"request_id":"00000000-0000-0000-0000-000000000000","verdict":{{"decision":{decision},"enforcement_mode":"enforce"}}}}"#
+            );
+            writeln!(s, "{resp}").unwrap();
+        }
+    });
+}
+
+fn run_hook_enforce(socket: &std::path::Path, stdin_json: &str) -> (String, i32) {
+    let exe = env!("CARGO_BIN_EXE_sigil-hook");
+    let mut child = Command::new(exe)
+        .args(["claude-code", "--enforce", "--on-failure", "open"])
+        .env("SIGIL_HOOK_DECIDE_SOCKET", socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin_json.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Poll until the stub's listening socket appears (guards the bind race between
+/// the spawned stub thread and the hook process connecting).
+fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..50 {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Build a claude-code Bash stdin payload.
+/// Verified against adapters/claude_code.rs normalize():
+///   - top-level key "tool_name" → tool dispatch
+///   - top-level key "tool_input" → nested object
+///   - "tool_input"."command" → Bash command string
+// NOTE: cmd must not contain `"` or `\` — interpolated raw into JSON (fine for the simple test commands here).
+fn bash_stdin(cmd: &str) -> String {
+    format!(r#"{{"tool_name":"Bash","tool_input":{{"command":"{cmd}"}}}}"#)
+}
+
+#[test]
+fn deny_emits_permission_decision_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), true);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_hook_enforce(&socket, &bash_stdin("rm -rf /"));
+    assert_eq!(code, 0, "hook must always exit 0");
+    assert!(
+        stdout.contains("\"permissionDecision\":\"deny\""),
+        "got: {stdout}"
+    );
+    assert!(stdout.contains("no-rm"));
+}
+
+#[test]
+fn allow_is_silent() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), false);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_hook_enforce(&socket, &bash_stdin("ls -la"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "allow must print nothing, got: {stdout}"
+    );
+}
+
+#[test]
+fn missing_socket_fails_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("absent.sock"); // never bound
+    let (stdout, code) = run_hook_enforce(&socket, &bash_stdin("rm -rf /"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "fail-open (on_failure=open) → allow, no output"
+    );
+}

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -138,7 +138,10 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
         | Evidence::EventUnprocessableLocal { .. }
         | Evidence::ServerProtocolViolation { .. }
         | Evidence::RulePackBundleApplied { .. } => { /* identity + severity only */ }
-        Evidence::HookInvocation(_) | Evidence::Unknown => { /* not indexed in Stage 1 */ }
+        Evidence::HookInvocation(_) | Evidence::HookDecision(_) | Evidence::Unknown => {
+            // Hook observe/decision events are not indexed into the fleet rollup
+            // (slice 1); the severity-bucket increment above already counts them.
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Stage 2 of `sigil-hook` (#100, **slice 1**): the Claude Code `PreToolUse` hook can now **deny** a runtime tool call when an agent-local deny rule matches, over a synchronous decision socket. Stage 1 (observe, #64) is unchanged.

**This is in-domain, advisory enforcement** — it blocks ordinary tool calls *when the agent honors the registered hook*, **fails open by default**, and is positioned as *agent-intent policy + tamper-evidence*, **never** tamper-resistant runtime command security (the agent owns the config that registers its own hook). Always exits 0, latency-bounded.

## What's in slice 1

- **Wire contract** (`hook_proto` v2, additive) — `HookDecisionRequest`/`Response`, `HookVerdict`, `Decision` (`Allow`/`Deny{rule_id, reason}`), `EnforcementMode`. v1 observe types byte-unchanged (back-compat tested).
- **Deny-rule policy** — `DenyRule`/`HookActionMatch` matching a runtime `HookAction` (not config files), reusing the `Matcher` vocab; carried in agent policy (`hook_deny_rules` + global `on_failure`).
- **Separate `hook-decide.sock`** request/response listener in the agent — records the observe event + evaluates deny rules + records a `HookDecision` event **reliably (awaited send) before** returning the verdict. Observe `hook.sock` stays one-way/lossy.
- **`HookDecision` event** — emitted agent-side on deny / error-fail-open only (not on allow).
- **Claude Code enforce path** — `sigil-hook claude-code --enforce [--on-failure open|closed]`: normalize → request verdict → translate `Deny` to `permissionDecision: deny` JSON; no verdict → local `on_failure` (open=allow, closed=deny). Panic-safe, 800ms watchdog.
- **Enforce install registration** + an end-to-end test (real binary vs stub decide server: deny → JSON, allow → silent, missing socket → fail-open).

## Design decisions (locked spec)

- **Fail-open by default**; opt-in fail-closed via the hook's local `--on-failure` flag (the agent never consumes `on_failure` — when reached it always returns a definite verdict).
- **Honest, evidence-first** deny reason names the `rule_id`; re-prompt evasion is the documented structural limit of an advisory tool-boundary layer (not prevented).
- **Capture-aware**: a deny rule needing command/path text can't match when the preview is absent (hash-only) → allow.

## Out of scope (named follow-on under #100)

codex/cursor/antigravity enforce adapters · signed fleet distribution of deny rules · **tamper-evidence** (hook config drift/missing/bypass detection) · per-rule `on_failure` · active anti-evasion · Windows enforce.

## Review & quality

12 TDD tasks, each with spec-compliance + code-quality review; a final holistic review returned **Ready-to-merge**. Local gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (0 failures). The new `Evidence::HookDecision` variant is handled in all downstream exhaustive matches (sink_task, show, fleet_index_update).

Public repo — mechanism-only, no monetization language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)