### PR TITLE
feat(hook): tamper-evidence — config-drift detection via 'sigil-hook verify' (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ workspace libraries.
   hook, **fails open by default**, and is *agent-intent policy + tamper-evidence*,
   **not** tamper-resistant runtime command security (the agent owns the config that
   registers its own hook). Always exits 0, latency-bounded.
+- **Tamper-evidence — `sigil-hook verify` (#100)** — the detection counterweight to
+  advisory enforcement: compares the recorded install **baseline** against the live
+  agent settings file and reports registration **drift** (entry removed, binary
+  repointed, capture/fail-closed flipped, matcher narrowed, or the baseline itself
+  missing). It prints a result + exit code and emits a `HookConfigDrift` event over
+  `hook.sock`. This is **detection, not prevention** — a fully-neutralized hook
+  silences the check too; that blind spot (agent-side silence detection) is tracked
+  separately. Tamper-*evidence* raises the cost and visibility of in-domain tampering;
+  it does not stop it.
 
 **Libraries**
 

--- a/crates/sigil-agent/src/hook_listener.rs
+++ b/crates/sigil-agent/src/hook_listener.rs
@@ -14,9 +14,12 @@
 
 use crate::state_task::CommittableEvent;
 use sigil_core::event::{
-    Evidence, HookInvocationEvidence, Severity, SourceKind, Subject, AGENT_VERSION, SCHEMA_VERSION,
+    Evidence, HookConfigDriftEvidence, HookInvocationEvidence, Severity, SourceKind, Subject,
+    AGENT_VERSION, SCHEMA_VERSION,
 };
-use sigil_core::hook_proto::{HookAction, HookEnvelope};
+use sigil_core::hook_proto::{
+    HookAction, HookConfigDriftReport, HookDriftEnvelope, HookEnvelope, HookMsgType,
+};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
@@ -103,20 +106,46 @@ pub async fn serve(
                 return;
             }
 
-            let env: HookEnvelope = match serde_json::from_str(line.trim()) {
-                Ok(e) => e,
-                Err(e) => {
-                    tracing::debug!(error = ?e, "hook: malformed envelope; dropping");
+            let line = line.trim();
+            let kind = serde_json::from_str::<MsgTypeHeader>(line)
+                .ok()
+                .map(|h| h.msg_type);
+            let committable = match kind {
+                Some(HookMsgType::DriftReport) => {
+                    match serde_json::from_str::<HookDriftEnvelope>(line) {
+                        Ok(env) => CommittableEvent {
+                            event: to_drift_event(env, peer_uid, &host_id),
+                            new_hash: None,
+                            path_for_db: PathBuf::new(),
+                            target_id: String::new(),
+                        },
+                        Err(e) => {
+                            tracing::debug!(error = ?e, "hook: malformed drift report; dropping");
+                            return;
+                        }
+                    }
+                }
+                Some(HookMsgType::HookInvocation) | None => {
+                    // observe (hook_invocation), and legacy senders with no msg_type field — existing path, unchanged.
+                    let env: HookEnvelope = match serde_json::from_str(line) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            tracing::debug!(error = ?e, "hook: malformed envelope; dropping");
+                            return;
+                        }
+                    };
+                    CommittableEvent {
+                        event: to_event(env, peer_uid, &host_id),
+                        new_hash: None,
+                        path_for_db: PathBuf::new(),
+                        target_id: String::new(),
+                    }
+                }
+                Some(other) => {
+                    // DecisionRequest/DecisionResponse belong on hook-decide.sock, not here; any other type is unhandled on the observe socket.
+                    tracing::debug!(?other, "hook: unhandled msg_type on hook.sock; dropping");
                     return;
                 }
-            };
-
-            let ev = to_event(env, peer_uid, &host_id);
-            let committable = CommittableEvent {
-                event: ev,
-                new_hash: None,
-                path_for_db: PathBuf::new(),
-                target_id: String::new(),
             };
 
             // try_send: if the channel is full (sink backpressure) we drop rather
@@ -125,6 +154,43 @@ pub async fn serve(
                 tracing::debug!("hook: event channel full; dropping hook event");
             }
         });
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct MsgTypeHeader {
+    msg_type: HookMsgType,
+}
+
+/// Convert a decoded `HookDriftEnvelope` + kernel-verified `peer_uid` into a
+/// `HookConfigDrift` Event for the sink pipeline.
+pub(crate) fn to_drift_event(
+    env: HookDriftEnvelope,
+    peer_uid: u32,
+    host_id: &str,
+) -> sigil_core::event::Event {
+    // envelope metadata (protocol_version/request_id/sent_at) is intentionally not threaded into the event, matching to_event.
+    let r: HookConfigDriftReport = env.payload;
+    sigil_core::event::Event {
+        schema_version: SCHEMA_VERSION,
+        event_id: uuid::Uuid::now_v7(),
+        ts: time::OffsetDateTime::now_utc(),
+        host_id: host_id.to_string(),
+        agent_version: AGENT_VERSION.to_string(),
+        severity: Severity::Warn,
+        source: SourceKind::AgentHook,
+        subject: Subject::Self_,
+        evidence: Evidence::HookConfigDrift(HookConfigDriftEvidence {
+            agent: r.agent,
+            peer_uid,
+            drift_kind: enum_str(&r.drift_kind),
+            settings_path: r.settings_path,
+            expected_command_hash: r.expected_command_hash,
+            observed_command_hash: r.observed_command_hash,
+            expected_matcher: r.expected_matcher,
+            observed_matcher: r.observed_matcher,
+        }),
+        target_id: None,
     }
 }
 
@@ -301,5 +367,37 @@ mod tests {
             }
             other => panic!("expected HookInvocation, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn drift_report_becomes_hook_config_drift_event() {
+        use sigil_core::hook_proto::{
+            DriftKind, HookConfigDriftReport, HookDriftEnvelope, HookMsgType, HOOK_PROTOCOL_VERSION,
+        };
+        let env = HookDriftEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::DriftReport,
+            request_id: uuid::Uuid::now_v7(),
+            sent_at_unix_ms: 0,
+            payload: HookConfigDriftReport {
+                agent: sigil_core::event::AiTool::ClaudeCode,
+                drift_kind: DriftKind::MatcherDrift,
+                settings_path: "/s".into(),
+                expected_command_hash: "ab".repeat(32),
+                observed_command_hash: Some("cd".repeat(32)),
+                expected_matcher: Some("*".into()),
+                observed_matcher: Some("Bash".into()),
+            },
+        };
+        let ev = to_drift_event(env, 501, "host-x");
+        match ev.evidence {
+            Evidence::HookConfigDrift(d) => {
+                assert_eq!(d.drift_kind, "matcher_drift");
+                assert_eq!(d.peer_uid, 501);
+                assert_eq!(d.observed_matcher.as_deref(), Some("Bash"));
+            }
+            other => panic!("expected HookConfigDrift, got {other:?}"),
+        }
+        assert!(matches!(ev.severity, Severity::Warn));
     }
 }

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -526,6 +526,10 @@ fn evidence_summary(e: &sigil_core::event::Evidence) -> (&'static str, String) {
             "hook_decision",
             format!("kind={} decision={}", d.action_kind, d.decision),
         ),
+        Evidence::HookConfigDrift(d) => (
+            "hook_config_drift",
+            format!("kind={} settings_path={}", d.drift_kind, d.settings_path),
+        ),
         Evidence::Unknown => ("unknown", String::new()),
     }
 }

--- a/crates/sigil-agent/src/sink_task.rs
+++ b/crates/sigil-agent/src/sink_task.rs
@@ -70,6 +70,7 @@ fn evidence_kind_str(e: &sigil_core::event::Evidence) -> &'static str {
         HostMetaSnapshot { .. } => "host_meta_snapshot",
         HookInvocation(_) => "hook_invocation",
         HookDecision(_) => "hook_decision",
+        HookConfigDrift(_) => "hook_config_drift",
         Unknown => "unknown",
     }
 }

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -249,6 +249,21 @@ pub struct HookDecisionEvidence {
     pub capture_level: String,
 }
 
+/// sigil-hook tamper-evidence (#100). A detected drift between the recorded
+/// hook registration baseline and the live agent settings file.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct HookConfigDriftEvidence {
+    pub agent: AiTool,
+    pub peer_uid: u32,
+    /// "baseline_absent" | "entry_missing" | "command_drift" | "matcher_drift".
+    pub drift_kind: String,
+    pub settings_path: String,
+    pub expected_command_hash: String,
+    pub observed_command_hash: Option<String>,
+    pub expected_matcher: Option<String>,
+    pub observed_matcher: Option<String>,
+}
+
 /// Phase 3b.4-pre — full host identity / OS / network snapshot, emitted by
 /// host_meta_snapshot_task. Surfaces hostname (so server-side fleet views
 /// can label hosts with something human-readable instead of UUIDs) plus
@@ -486,6 +501,8 @@ pub enum Evidence {
     HookInvocation(HookInvocationEvidence),
     /// sigil-hook Stage 2 (#100). A deny / degradation decision outcome.
     HookDecision(HookDecisionEvidence),
+    /// sigil-hook tamper-evidence (#100). Hook registration drift vs the install baseline.
+    HookConfigDrift(HookConfigDriftEvidence),
     /// Forward-compat: an evidence kind this build doesn't recognize. A newer
     /// producer's variant deserializes here instead of failing the whole event.
     #[serde(other)]
@@ -1188,6 +1205,25 @@ mod tests {
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains(r#""rule_pack_id":"my-pack""#));
         assert_eq!(ev, serde_json::from_str::<Evidence>(&s).unwrap());
+    }
+
+    #[test]
+    fn hook_config_drift_evidence_serializes_snake_case() {
+        let ev = Evidence::HookConfigDrift(HookConfigDriftEvidence {
+            agent: AiTool::ClaudeCode,
+            peer_uid: 501,
+            drift_kind: "matcher_drift".into(),
+            settings_path: "/home/dev/.claude/settings.json".into(),
+            expected_command_hash: "ab".repeat(32),
+            observed_command_hash: Some("ab".repeat(32)),
+            expected_matcher: Some("*".into()),
+            observed_matcher: Some("Bash".into()),
+        });
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"kind\":\"hook_config_drift\""));
+        assert!(s.contains("\"drift_kind\":\"matcher_drift\""));
+        let back: Evidence = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ev);
     }
 
     #[test]

--- a/crates/sigil-core/src/hook_proto.rs
+++ b/crates/sigil-core/src/hook_proto.rs
@@ -9,12 +9,13 @@ use uuid::Uuid;
 /// Hook IPC protocol version. Bump on any breaking wire change.
 pub const HOOK_PROTOCOL_VERSION: u16 = 2;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum HookMsgType {
     HookInvocation,
     DecisionRequest,
     DecisionResponse,
+    DriftReport,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -125,6 +126,37 @@ pub enum EnforcementMode {
     Enforce,
 }
 
+/// tamper-evidence (#100): a one-way config-drift report on `hook.sock`.
+/// Separate envelope so the v1 `HookEnvelope` shape stays byte-identical.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct HookDriftEnvelope {
+    pub protocol_version: u16,
+    pub msg_type: HookMsgType,
+    pub request_id: Uuid,
+    pub sent_at_unix_ms: u64,
+    pub payload: HookConfigDriftReport,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct HookConfigDriftReport {
+    pub agent: AiTool,
+    pub drift_kind: DriftKind,
+    pub settings_path: String,
+    pub expected_command_hash: String,
+    pub observed_command_hash: Option<String>,
+    pub expected_matcher: Option<String>,
+    pub observed_matcher: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DriftKind {
+    BaselineAbsent,
+    EntryMissing,
+    CommandDrift,
+    MatcherDrift,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +221,56 @@ mod tests {
                 agent: AiTool::ClaudeCode,
                 agent_session_id: Some("s".into()),
                 tool_use_id: Some("t".into()),
+                action: HookAction::Bash {
+                    command_hash: "ab".repeat(32),
+                    command_preview: None,
+                },
+                capture_level: CaptureLevel::Redacted,
+                capture_status: CaptureStatus::Ok,
+                cwd: None,
+            },
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains("\"msg_type\":\"hook_invocation\""));
+        let back: HookEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, env);
+    }
+
+    #[test]
+    fn drift_envelope_round_trips() {
+        let env = HookDriftEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::DriftReport,
+            request_id: uuid::Uuid::nil(),
+            sent_at_unix_ms: 1_700_000_000_000,
+            payload: HookConfigDriftReport {
+                agent: AiTool::ClaudeCode,
+                drift_kind: DriftKind::MatcherDrift,
+                settings_path: "/home/dev/.claude/settings.json".into(),
+                expected_command_hash: "ab".repeat(32),
+                observed_command_hash: Some("ab".repeat(32)),
+                expected_matcher: Some("*".into()),
+                observed_matcher: Some("Bash".into()),
+            },
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(s.contains("\"msg_type\":\"drift_report\""));
+        assert!(s.contains("\"drift_kind\":\"matcher_drift\""));
+        let back: HookDriftEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, env);
+    }
+
+    #[test]
+    fn v1_observe_envelope_unchanged_alongside_drift() {
+        let env = HookEnvelope {
+            protocol_version: HOOK_PROTOCOL_VERSION,
+            msg_type: HookMsgType::HookInvocation,
+            request_id: uuid::Uuid::nil(),
+            sent_at_unix_ms: 1,
+            payload: HookInvocation {
+                agent: AiTool::ClaudeCode,
+                agent_session_id: None,
+                tool_use_id: None,
                 action: HookAction::Bash {
                     command_hash: "ab".repeat(32),
                     command_preview: None,

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -323,6 +323,7 @@ pub fn settings_path(agent: &str) -> Option<PathBuf> {
 }
 
 /// Write `state_dir()/hook-registration.json` + append to the discovery index.
+#[allow(clippy::too_many_arguments)]
 pub fn write_baseline(
     agent: &str,
     settings_path: &std::path::Path,
@@ -330,11 +331,45 @@ pub fn write_baseline(
     agent_arg: &str,
     capture: &str,
     matcher: &str,
+    enforce: bool,
+    on_failure: &str,
 ) -> io::Result<()> {
-    let dir = state_dir();
-    std::fs::create_dir_all(&dir)?;
+    write_baseline_in(
+        &state_dir(),
+        agent,
+        settings_path,
+        exe,
+        agent_arg,
+        capture,
+        matcher,
+        enforce,
+        on_failure,
+    )
+}
 
-    let cmd = command_string(exe, agent_arg, capture);
+/// Directory-injectable core of [`write_baseline`]: writes
+/// `dir/hook-registration.json` + appends to `dir/hook-index.json`. Kept
+/// separate so tests can supply a temp dir without touching the process-global
+/// `XDG_STATE_HOME` env var (which would race other tests).
+#[allow(clippy::too_many_arguments)]
+fn write_baseline_in(
+    dir: &std::path::Path,
+    agent: &str,
+    settings_path: &std::path::Path,
+    exe: &str,
+    agent_arg: &str,
+    capture: &str,
+    matcher: &str,
+    enforce: bool,
+    on_failure: &str,
+) -> io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+
+    let cmd = if enforce {
+        command_string_enforce(exe, agent_arg, capture, on_failure)
+    } else {
+        command_string(exe, agent_arg, capture)
+    };
     let block_hash = blake3::hash(cmd.as_bytes()).to_hex().to_string();
     let written_at_unix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -491,5 +526,81 @@ mod tests {
     fn unsupported_agent_paths() {
         assert!(settings_path("nope").is_none());
         assert_eq!(count_sigil_entries(&json!({}), "/x", "nope"), 0);
+    }
+
+    // --- write_baseline records the actual installed command ---
+
+    /// Helper: call the directory-injectable `write_baseline_in` with `dir` and
+    /// return the parsed JSON from `dir/hook-registration.json`. Race-free: no
+    /// process-global env var (`XDG_STATE_HOME`) is touched, so these tests are
+    /// safe to run in parallel with any other state_dir()-dependent test.
+    fn baseline_json_in(
+        dir: &std::path::Path,
+        enforce: bool,
+        on_failure: &str,
+    ) -> serde_json::Value {
+        let settings = dir.join("settings.json");
+        write_baseline_in(
+            dir,
+            "claude-code",
+            &settings,
+            "/usr/bin/sigil-hook",
+            "claude-code",
+            "redacted",
+            "*",
+            enforce,
+            on_failure,
+        )
+        .unwrap();
+        let raw = std::fs::read(dir.join("hook-registration.json")).unwrap();
+        serde_json::from_slice(&raw).unwrap()
+    }
+
+    /// `command_string_enforce` produces the right flag sequence (pure, race-free).
+    #[test]
+    fn command_string_enforce_contains_enforce_flags() {
+        let cmd = command_string_enforce("/usr/bin/sigil-hook", "claude-code", "redacted", "open");
+        assert!(
+            cmd.contains("--enforce --on-failure open"),
+            "command_string_enforce must include enforce flags, got: {cmd}"
+        );
+        assert!(
+            cmd.contains("--capture redacted"),
+            "command_string_enforce must include --capture, got: {cmd}"
+        );
+    }
+
+    /// write_baseline(enforce=true) records the enforce command and a matching hash.
+    #[test]
+    fn write_baseline_records_enforce_command_when_enforce() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = baseline_json_in(tmp.path(), true, "open");
+        let cmd = v["command"].as_str().unwrap();
+        assert!(
+            cmd.contains("--enforce --on-failure open"),
+            "baseline must record the enforce command, got: {cmd}"
+        );
+        let expected_hash = blake3::hash(cmd.as_bytes()).to_hex().to_string();
+        assert_eq!(
+            v["block_hash"].as_str().unwrap(),
+            expected_hash,
+            "block_hash must be blake3 of the enforce command"
+        );
+    }
+
+    /// write_baseline(enforce=false) records the observe command (regression guard).
+    #[test]
+    fn write_baseline_records_observe_command_when_not_enforce() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = baseline_json_in(tmp.path(), false, "open");
+        let cmd = v["command"].as_str().unwrap();
+        assert!(
+            !cmd.contains("--enforce"),
+            "non-enforce baseline must NOT contain --enforce, got: {cmd}"
+        );
+        assert!(
+            cmd.contains("--capture redacted"),
+            "non-enforce baseline must contain --capture, got: {cmd}"
+        );
     }
 }

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -50,7 +50,7 @@ fn command_string_enforce(exe: &str, agent: &str, capture: &str, on_failure: &st
 }
 
 /// First whitespace token of a command string (= the binary path).
-fn first_token(cmd: &str) -> &str {
+pub(crate) fn first_token(cmd: &str) -> &str {
     cmd.split_whitespace().next().unwrap_or("")
 }
 
@@ -61,7 +61,7 @@ fn claude_entry(cmd: &str) -> Value {
 }
 
 /// The command of a Claude-style entry's first inner hook, if any.
-fn claude_entry_cmd(entry: &Value) -> Option<&str> {
+pub(crate) fn claude_entry_cmd(entry: &Value) -> Option<&str> {
     entry
         .get("hooks")
         .and_then(|h| h.as_array())
@@ -70,7 +70,7 @@ fn claude_entry_cmd(entry: &Value) -> Option<&str> {
         .and_then(|c| c.as_str())
 }
 
-fn claude_entry_is_ours(entry: &Value, exe: &str) -> bool {
+pub(crate) fn claude_entry_is_ours(entry: &Value, exe: &str) -> bool {
     entry
         .get("hooks")
         .and_then(|h| h.as_array())

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -4,6 +4,7 @@ mod emit;
 mod install;
 mod install_antigravity;
 mod redact;
+mod verify;
 
 use sigil_core::hook_proto::*;
 use std::io::Read;

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -211,6 +211,13 @@ enum Cmd {
         #[arg(long)]
         write: bool,
     },
+
+    /// tamper-evidence: compare the live hook registration against the install baseline.
+    Verify {
+        /// Agent whose registration to verify (slice 1: claude-code).
+        #[arg(long, default_value = INSTALL_AGENT_DEFAULT)]
+        agent: String,
+    },
 }
 
 #[derive(Copy, Clone, ValueEnum)]
@@ -338,6 +345,7 @@ fn main() {
             on_failure,
         } => cmd_install(&agent, write, capture, enforce, on_failure),
         Cmd::Uninstall { agent, write } => cmd_uninstall(&agent, write),
+        Cmd::Verify { agent } => std::process::exit(cmd_verify(&agent)),
     }
 }
 
@@ -609,6 +617,67 @@ fn cmd_uninstall_antigravity(write: bool) {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+fn drift_exit_code(kind: DriftKind) -> i32 {
+    use sigil_core::hook_proto::DriftKind::*;
+    match kind {
+        BaselineAbsent => 3,
+        EntryMissing | CommandDrift | MatcherDrift => 2,
+    }
+}
+
+fn cmd_verify(_agent: &str) -> i32 {
+    use sigil_core::event::AiTool;
+
+    let Some(report) = verify::check() else {
+        println!("[OK]    hook registration matches baseline");
+        return 0;
+    };
+
+    match report.kind {
+        DriftKind::BaselineAbsent => println!(
+            "[DRIFT] baseline not found at {} (baseline_absent)",
+            report.settings_path
+        ),
+        DriftKind::EntryMissing => println!(
+            "[DRIFT] no sigil hook entry in {} (entry_missing)",
+            report.settings_path
+        ),
+        DriftKind::CommandDrift => println!(
+            "[DRIFT] hook command changed in {} — binary repoint / flag flip (command_drift)",
+            report.settings_path
+        ),
+        DriftKind::MatcherDrift => println!(
+            "[DRIFT] matcher changed: {:?} -> {:?} (matcher_drift)",
+            report.expected_matcher.as_deref().unwrap_or("?"),
+            report.observed_matcher.as_deref().unwrap_or("?"),
+        ),
+    }
+
+    // Best-effort emit over hook.sock (agent-down -> still printed + exits).
+    let env = HookDriftEnvelope {
+        protocol_version: HOOK_PROTOCOL_VERSION,
+        msg_type: HookMsgType::DriftReport,
+        request_id: uuid::Uuid::now_v7(),
+        sent_at_unix_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+        payload: HookConfigDriftReport {
+            agent: AiTool::ClaudeCode, // slice 1
+            drift_kind: report.kind,
+            settings_path: report.settings_path.clone(),
+            expected_command_hash: report.expected_command_hash.clone(),
+            observed_command_hash: report.observed_command_hash.clone(),
+            expected_matcher: report.expected_matcher.clone(),
+            observed_matcher: report.observed_matcher.clone(),
+        },
+    };
+    if let Ok(line) = serde_json::to_string(&env) {
+        let _ = emit::send_envelope(&hook_socket_path(), &line, Duration::from_millis(150));
+    }
+    drift_exit_code(report.kind)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -626,5 +695,14 @@ mod tests {
             v["hookSpecificOutput"]["permissionDecisionReason"],
             "Blocked by Sigil rule no-rm: destructive"
         );
+    }
+
+    #[test]
+    fn drift_exit_codes() {
+        use sigil_core::hook_proto::DriftKind::*;
+        assert_eq!(drift_exit_code(BaselineAbsent), 3);
+        assert_eq!(drift_exit_code(EntryMissing), 2);
+        assert_eq!(drift_exit_code(CommandDrift), 2);
+        assert_eq!(drift_exit_code(MatcherDrift), 2);
     }
 }

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -456,7 +456,16 @@ fn cmd_install(
     }
 
     // Write baseline / update discovery index.
-    if let Err(e) = install::write_baseline(agent, &sp, &exe, agent, capture_str, "*") {
+    if let Err(e) = install::write_baseline(
+        agent,
+        &sp,
+        &exe,
+        agent,
+        capture_str,
+        "*",
+        enforce,
+        on_failure_str,
+    ) {
         eprintln!("warning: could not write baseline: {e}");
     }
 

--- a/crates/sigil-hook/src/verify.rs
+++ b/crates/sigil-hook/src/verify.rs
@@ -194,4 +194,76 @@ mod tests {
     fn baseline_absent_when_no_baseline() {
         assert!(load_baseline(Path::new("/nonexistent/hook-registration.json")).is_none());
     }
+
+    // --- enforce-install baseline tests (#100 regression) ---
+
+    /// An enforce-mode baseline is clean when the settings file contains the
+    /// exact enforce command string that was written at install time.
+    #[test]
+    fn clean_for_enforce_install_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = "/usr/bin/sigil-hook";
+        let enforce_cmd =
+            format!("{exe} claude-code --enforce --on-failure open --capture redacted");
+        let b = Baseline {
+            agent: "claude-code".into(),
+            settings_path: dir
+                .path()
+                .join("settings.json")
+                .to_string_lossy()
+                .into_owned(),
+            command: enforce_cmd.clone(),
+            matcher: "*".into(),
+            block_hash: blake3::hash(enforce_cmd.as_bytes()).to_hex().to_string(),
+        };
+        // Settings registered WITH the enforce command => clean (no drift).
+        let mut f = std::fs::File::create(&b.settings_path).unwrap();
+        write!(
+            f,
+            r#"{{"hooks":{{"PreToolUse":[{{"matcher":"*","hooks":[{{"type":"command","command":"{enforce_cmd}"}}]}}]}}}}"#
+        )
+        .unwrap();
+        assert_eq!(
+            check_one(&b),
+            None,
+            "enforce baseline must be clean against matching settings"
+        );
+    }
+
+    /// An enforce-mode baseline detects drift when the settings file contains
+    /// only the observe command (the bug this fix addresses: verify spuriously
+    /// reported command_drift right after 'install --enforce --write').
+    #[test]
+    fn command_drift_when_observe_command_in_enforce_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = "/usr/bin/sigil-hook";
+        let enforce_cmd =
+            format!("{exe} claude-code --enforce --on-failure open --capture redacted");
+        let observe_cmd = format!("{exe} claude-code --capture redacted");
+        let b = Baseline {
+            agent: "claude-code".into(),
+            settings_path: dir
+                .path()
+                .join("settings.json")
+                .to_string_lossy()
+                .into_owned(),
+            command: enforce_cmd.clone(),
+            matcher: "*".into(),
+            block_hash: blake3::hash(enforce_cmd.as_bytes()).to_hex().to_string(),
+        };
+        // Settings registered with the OBSERVE command while baseline expects ENFORCE
+        // => command_drift (this is the genuine tamper signal, not a false positive).
+        let mut f = std::fs::File::create(&b.settings_path).unwrap();
+        write!(
+            f,
+            r#"{{"hooks":{{"PreToolUse":[{{"matcher":"*","hooks":[{{"type":"command","command":"{observe_cmd}"}}]}}]}}}}"#
+        )
+        .unwrap();
+        let report = check_one(&b).expect("should detect drift");
+        assert_eq!(
+            report.kind,
+            DriftKind::CommandDrift,
+            "downgrade from enforce to observe command must be reported as command_drift"
+        );
+    }
 }

--- a/crates/sigil-hook/src/verify.rs
+++ b/crates/sigil-hook/src/verify.rs
@@ -1,0 +1,199 @@
+//! tamper-evidence (#100): compare the recorded install baseline against the
+//! live agent settings file. Pure (filesystem read only) — no IPC here.
+use crate::install;
+use serde::Deserialize;
+use sigil_core::hook_proto::DriftKind;
+use std::path::{Path, PathBuf};
+
+/// Subset of hook-registration.json we compare against (serde ignores the rest).
+#[derive(Deserialize, Debug, Clone)]
+pub struct Baseline {
+    #[allow(dead_code)] // used by the verify subcommand (Task 5)
+    pub agent: String,
+    pub settings_path: String,
+    pub command: String,
+    pub matcher: String,
+    pub block_hash: String,
+}
+
+/// A detected drift. `None` from `check()`/`check_one()` means clean.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DriftReport {
+    pub kind: DriftKind,
+    pub settings_path: String,
+    pub expected_command_hash: String,
+    pub observed_command_hash: Option<String>,
+    pub expected_matcher: Option<String>,
+    pub observed_matcher: Option<String>,
+}
+
+fn baseline_path() -> PathBuf {
+    install::state_dir().join("hook-registration.json")
+}
+
+/// Load the baseline, or None if absent/unreadable/malformed.
+// used by the verify subcommand (Task 5)
+#[allow(dead_code)]
+pub fn load_baseline(path: &Path) -> Option<Baseline> {
+    let raw = std::fs::read(path).ok()?;
+    serde_json::from_slice(&raw).ok()
+}
+
+/// Full check: None when clean, Some(report) on any drift (incl. baseline_absent).
+// used by the verify subcommand (Task 5)
+#[allow(dead_code)]
+pub fn check() -> Option<DriftReport> {
+    let bp = baseline_path();
+    let Some(b) = load_baseline(&bp) else {
+        return Some(DriftReport {
+            kind: DriftKind::BaselineAbsent,
+            settings_path: bp.to_string_lossy().into_owned(),
+            expected_command_hash: String::new(),
+            observed_command_hash: None,
+            expected_matcher: None,
+            observed_matcher: None,
+        });
+    };
+    check_one(&b)
+}
+
+/// Compare one baseline against its live settings file. None = clean.
+/// Order: entry_missing -> command_drift -> matcher_drift.
+pub fn check_one(b: &Baseline) -> Option<DriftReport> {
+    let exe = install::first_token(&b.command).to_string();
+    let root: serde_json::Value = std::fs::read(&b.settings_path)
+        .ok()
+        .and_then(|raw| serde_json::from_slice(&raw).ok())
+        // treat both an absent and a corrupt settings file as "entry not present" —
+        // the sigil entry simply can't be found, yielding EntryMissing.
+        .unwrap_or(serde_json::Value::Null);
+    let entry = root
+        .get("hooks")
+        .and_then(|h| h.get("PreToolUse"))
+        .and_then(|p| p.as_array())
+        .and_then(|arr| arr.iter().find(|e| install::claude_entry_is_ours(e, &exe)));
+
+    let Some(entry) = entry else {
+        return Some(DriftReport {
+            kind: DriftKind::EntryMissing,
+            settings_path: b.settings_path.clone(),
+            expected_command_hash: b.block_hash.clone(),
+            observed_command_hash: None,
+            expected_matcher: Some(b.matcher.clone()),
+            observed_matcher: None,
+        });
+    };
+
+    // block_hash was written as blake3(full command string); claude_entry_cmd
+    // returns that same inner command, so the hashes line up.
+    let live_cmd = install::claude_entry_cmd(entry).unwrap_or("");
+    let observed_hash = blake3::hash(live_cmd.as_bytes()).to_hex().to_string();
+    let observed_matcher = entry
+        .get("matcher")
+        .and_then(|m| m.as_str())
+        .map(String::from);
+
+    // note: a change to the binary PATH makes claude_entry_is_ours not match →
+    // EntryMissing, not CommandDrift; CommandDrift covers arg/flag-level changes
+    // to the same exe.
+    if observed_hash != b.block_hash {
+        return Some(DriftReport {
+            kind: DriftKind::CommandDrift,
+            settings_path: b.settings_path.clone(),
+            expected_command_hash: b.block_hash.clone(),
+            observed_command_hash: Some(observed_hash),
+            expected_matcher: Some(b.matcher.clone()),
+            observed_matcher,
+        });
+    }
+    if observed_matcher.as_deref() != Some(b.matcher.as_str()) {
+        return Some(DriftReport {
+            kind: DriftKind::MatcherDrift,
+            settings_path: b.settings_path.clone(),
+            expected_command_hash: b.block_hash.clone(),
+            observed_command_hash: Some(observed_hash),
+            expected_matcher: Some(b.matcher.clone()),
+            observed_matcher,
+        });
+    }
+    None // clean
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn baseline(dir: &Path, exe: &str, matcher: &str) -> Baseline {
+        let cmd = format!("{exe} claude-code --capture redacted");
+        Baseline {
+            agent: "claude-code".into(),
+            settings_path: dir.join("settings.json").to_string_lossy().into_owned(),
+            command: cmd.clone(),
+            matcher: matcher.into(),
+            block_hash: blake3::hash(cmd.as_bytes()).to_hex().to_string(),
+        }
+    }
+    fn write_settings(b: &Baseline, json: &str) {
+        let mut f = std::fs::File::create(&b.settings_path).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn clean_when_settings_match_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = baseline(dir.path(), "/usr/bin/sigil-hook", "*");
+        write_settings(
+            &b,
+            r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/usr/bin/sigil-hook claude-code --capture redacted"}]}]}}"#,
+        );
+        assert_eq!(check_one(&b), None);
+    }
+
+    #[test]
+    fn entry_missing_when_no_sigil_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = baseline(dir.path(), "/usr/bin/sigil-hook", "*");
+        write_settings(
+            &b,
+            r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/other/tool run"}]}]}}"#,
+        );
+        assert_eq!(check_one(&b).unwrap().kind, DriftKind::EntryMissing);
+    }
+
+    #[test]
+    fn command_drift_when_command_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = baseline(dir.path(), "/usr/bin/sigil-hook", "*");
+        write_settings(
+            &b,
+            r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/usr/bin/sigil-hook claude-code --capture raw"}]}]}}"#,
+        );
+        assert_eq!(check_one(&b).unwrap().kind, DriftKind::CommandDrift);
+    }
+
+    #[test]
+    fn matcher_drift_when_matcher_narrowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = baseline(dir.path(), "/usr/bin/sigil-hook", "*");
+        write_settings(
+            &b,
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/usr/bin/sigil-hook claude-code --capture redacted"}]}]}}"#,
+        );
+        let r = check_one(&b).unwrap();
+        assert_eq!(r.kind, DriftKind::MatcherDrift);
+        assert_eq!(r.observed_matcher.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn entry_missing_when_settings_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = baseline(dir.path(), "/usr/bin/sigil-hook", "*"); // settings.json never written
+        assert_eq!(check_one(&b).unwrap().kind, DriftKind::EntryMissing);
+    }
+
+    #[test]
+    fn baseline_absent_when_no_baseline() {
+        assert!(load_baseline(Path::new("/nonexistent/hook-registration.json")).is_none());
+    }
+}

--- a/crates/sigil-hook/src/verify.rs
+++ b/crates/sigil-hook/src/verify.rs
@@ -40,8 +40,6 @@ pub fn load_baseline(path: &Path) -> Option<Baseline> {
 }
 
 /// Full check: None when clean, Some(report) on any drift (incl. baseline_absent).
-// used by the verify subcommand (Task 5)
-#[allow(dead_code)]
 pub fn check() -> Option<DriftReport> {
     let bp = baseline_path();
     let Some(b) = load_baseline(&bp) else {

--- a/crates/sigil-hook/tests/verify_e2e.rs
+++ b/crates/sigil-hook/tests/verify_e2e.rs
@@ -1,0 +1,127 @@
+//! E2E (#100): `sigil-hook verify` against temp baseline + settings, plus a
+//! stub hook.sock to confirm the drift emit.
+#![cfg(unix)]
+use std::io::Read;
+use std::os::unix::net::UnixListener;
+use std::process::{Command, Stdio};
+
+fn blake3_hex(s: &str) -> String {
+    blake3::hash(s.as_bytes()).to_hex().to_string()
+}
+
+/// Write the baseline (under XDG_STATE_HOME=state) + a settings file.
+fn setup(state: &std::path::Path, settings: &std::path::Path, matcher: &str, settings_json: &str) {
+    let exe = "/usr/bin/sigil-hook";
+    let cmd = format!("{exe} claude-code --capture redacted");
+    let baseline = serde_json::json!({
+        "agent": "claude-code",
+        "settings_path": settings.to_string_lossy(),
+        "command": cmd,
+        "capture": "redacted",
+        "matcher": matcher,
+        "block_hash": blake3_hex(&cmd),
+        "written_at_unix": 0
+    });
+    let dir = state.join("sigil");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("hook-registration.json"),
+        serde_json::to_vec(&baseline).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(settings, settings_json).unwrap();
+}
+
+fn run_verify(state: &std::path::Path, stub_socket: Option<&std::path::Path>) -> i32 {
+    let exe = env!("CARGO_BIN_EXE_sigil-hook");
+    let mut c = Command::new(exe);
+    c.arg("verify")
+        .env("XDG_STATE_HOME", state)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(s) = stub_socket {
+        c.env("SIGIL_HOOK_SOCKET", s);
+    }
+    c.status().unwrap().code().unwrap_or(-1)
+}
+
+const CLEAN: &str = r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/usr/bin/sigil-hook claude-code --capture redacted"}]}]}}"#;
+const NARROWED: &str = r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/usr/bin/sigil-hook claude-code --capture redacted"}]}]}}"#;
+const FOREIGN: &str = r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/other/tool run"}]}]}}"#;
+const COMMAND_DRIFT: &str = r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/usr/bin/sigil-hook claude-code --capture raw"}]}]}}"#;
+
+#[test]
+fn clean_exits_0() {
+    let state = tempfile::tempdir().unwrap();
+    let sdir = tempfile::tempdir().unwrap();
+    let settings = sdir.path().join("settings.json");
+    setup(state.path(), &settings, "*", CLEAN);
+    assert_eq!(run_verify(state.path(), None), 0);
+}
+
+#[test]
+fn matcher_drift_exits_2() {
+    let state = tempfile::tempdir().unwrap();
+    let sdir = tempfile::tempdir().unwrap();
+    let settings = sdir.path().join("settings.json");
+    setup(state.path(), &settings, "*", NARROWED);
+    assert_eq!(run_verify(state.path(), None), 2);
+}
+
+#[test]
+fn entry_missing_exits_2() {
+    let state = tempfile::tempdir().unwrap();
+    let sdir = tempfile::tempdir().unwrap();
+    let settings = sdir.path().join("settings.json");
+    setup(state.path(), &settings, "*", FOREIGN);
+    assert_eq!(run_verify(state.path(), None), 2);
+}
+
+#[test]
+fn command_drift_exits_2() {
+    let state = tempfile::tempdir().unwrap();
+    let sdir = tempfile::tempdir().unwrap();
+    let settings = sdir.path().join("settings.json");
+    setup(state.path(), &settings, "*", COMMAND_DRIFT); // same exe, changed --capture => command_drift
+    assert_eq!(run_verify(state.path(), None), 2);
+}
+
+#[test]
+fn baseline_absent_exits_3() {
+    let state = tempfile::tempdir().unwrap(); // no hook-registration.json
+    assert_eq!(run_verify(state.path(), None), 3);
+}
+
+#[test]
+fn drift_emits_report_on_socket() {
+    let sockdir = tempfile::tempdir().unwrap();
+    let socket = sockdir.path().join("hook.sock");
+    let l = UnixListener::bind(&socket).unwrap();
+    let handle = std::thread::spawn(move || {
+        // l is blocking by default; accept() returns as soon as the hook connects.
+        match l.accept() {
+            Ok((mut s, _)) => {
+                let mut buf = String::new();
+                let _ = s.read_to_string(&mut buf);
+                buf
+            }
+            Err(_) => String::new(),
+        }
+    });
+
+    let state = tempfile::tempdir().unwrap();
+    let sdir = tempfile::tempdir().unwrap();
+    let settings = sdir.path().join("settings.json");
+    setup(state.path(), &settings, "*", NARROWED); // drift
+    let code = run_verify(state.path(), Some(&socket));
+    assert_eq!(code, 2);
+    let got = handle.join().unwrap();
+    assert!(
+        got.contains("\"msg_type\":\"drift_report\""),
+        "expected a drift_report emit, got: {got:?}"
+    );
+    assert!(
+        got.contains("\"drift_kind\":\"matcher_drift\""),
+        "drift_kind missing from emit: {got:?}"
+    );
+}

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -138,8 +138,11 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
         | Evidence::EventUnprocessableLocal { .. }
         | Evidence::ServerProtocolViolation { .. }
         | Evidence::RulePackBundleApplied { .. } => { /* identity + severity only */ }
-        Evidence::HookInvocation(_) | Evidence::HookDecision(_) | Evidence::Unknown => {
-            // Hook observe/decision events are not indexed into the fleet rollup
+        Evidence::HookInvocation(_)
+        | Evidence::HookDecision(_)
+        | Evidence::HookConfigDrift(_)
+        | Evidence::Unknown => {
+            // Hook observe/decision/drift events are not indexed into the fleet rollup
             // (slice 1); the severity-bucket increment above already counts them.
         }
     }


### PR DESCRIPTION
## Summary

The next slice of #100 (sigil-hook Stage 2): **tamper-evidence (config drift)**. A new `sigil-hook verify` subcommand detects drift between the recorded install **baseline** and the live agent settings file, prints a result + exit code, and emits a `HookConfigDrift` event over the existing one-way `hook.sock`.

This is the detection counterweight to advisory enforcement: Sigil can't *prevent* in-domain tampering (the agent owns the config that registers its own hook), but it can **detect and surface drift as evidence**.

## What it detects (baseline vs live settings)

| `drift_kind` | detection | maps to |
|---|---|---|
| `baseline_absent` | `hook-registration.json` missing | can't-verify signal |
| `entry_missing` | no sigil entry in the settings file (or file gone) | hook removed |
| `command_drift` | `blake3(live command) != baseline.block_hash` | binary repoint / capture change / **fail-closed flip** |
| `matcher_drift` | live matcher != baseline matcher | **broad bypass** (matcher narrowed) |

`sigil-hook verify` exits `0` clean / `2` drift / `3` baseline-absent, and emits `HookConfigDrift` (Warn) over `hook.sock` **only on drift** (clean = no event). The agent's `hook_listener` peeks `msg_type` and routes the drift report to the new evidence — the observe (`hook_invocation`) path is byte-unchanged.

## Honesty

**Detection, not prevention.** The check runs inside the (tamperable) hook's developer-domain, so it catches drift *while the sigil hook still runs*. A fully-neutralized hook (repointed to a non-sigil binary) silences the check too — that blind spot is **agent-side silence detection from an independent process**, split out to its own issue **#107** (different security model). Docs/output say "tamper-*evidence*", never "tamper-resistant".

## Notable

- `hook_proto` gains an additive `DriftReport` message (v1 observe `HookEnvelope` byte-unchanged); `Evidence::HookConfigDrift` is handled in all downstream exhaustive matches (sink_task, show, fleet_index_update).
- **Fixed during final review:** `write_baseline` now records the *actual* installed command (enforce or observe) — previously it always hashed the observe command, so `verify` reported a spurious `command_drift` right after `install --enforce` (and couldn't detect a fail-closed flip). Regression-tested.

## Out of scope (follow-on)

Agent-side silence/absence detection (**#107**) · foreign-hook scan · antigravity/cursor verify parsing · multi-agent baselines · a periodic/timer trigger.

## Review & quality

8 TDD tasks, each with spec-compliance + code-quality review; final holistic review returned **Ready-to-merge**. Local gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p sigil-hook` (68/0). The only full-workspace test failure is a pre-existing macOS FSEvents parallel-load flake in `sigil-agent basic_events` (**#108** — passes serially/in isolation; this branch doesn't touch the watcher path).

Public repo — mechanism-only, no monetization language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)