### PR TITLE
feat(hook): generalize enforce per-agent + codex enforce (#100)

### DIFF
--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -9,8 +9,6 @@ pub mod cursor;
 /// deny response, if any) and the process exit code. claude-code/codex/
 /// antigravity: the JSON rides stdout with exit 0; the exit_code field lets a
 /// future agent whose deny path needs a non-zero exit express that.
-// Task 2 wires the production caller; allow until then.
-#[allow(dead_code)]
 pub struct DenyOutput {
     pub stdout: Option<String>,
     pub exit_code: i32,
@@ -19,8 +17,6 @@ pub struct DenyOutput {
 /// Shared PreToolUse deny: `{"hookSpecificOutput":{"hookEventName":"PreToolUse",
 /// "permissionDecision":"deny","permissionDecisionReason":"Blocked by Sigil rule
 /// <id>: <reason>"}}` on stdout, exit 0. Used by every Claude-shaped agent.
-// Task 2 wires the production caller; allow until then.
-#[allow(dead_code)]
 pub(crate) fn pretooluse_deny(rule_id: &str, reason: &str) -> DenyOutput {
     let v = serde_json::json!({
         "hookSpecificOutput": {
@@ -48,8 +44,6 @@ pub trait HookAdapter {
     /// Translate a Deny verdict into this agent's deny-UX wire output. Default =
     /// the shared PreToolUse permissionDecision JSON; override only when an
     /// agent's deny contract differs.
-    // Task 2 wires the production caller; allow until then.
-    #[allow(dead_code)]
     fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
         pretooluse_deny(rule_id, reason)
     }

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -5,6 +5,36 @@ pub mod claude_code;
 pub mod codex;
 pub mod cursor;
 
+/// What a deny verdict renders to for a given agent: the text to print (the
+/// deny response, if any) and the process exit code. claude-code/codex/
+/// antigravity: the JSON rides stdout with exit 0; the exit_code field lets a
+/// future agent whose deny path needs a non-zero exit express that.
+// Task 2 wires the production caller; allow until then.
+#[allow(dead_code)]
+pub struct DenyOutput {
+    pub stdout: Option<String>,
+    pub exit_code: i32,
+}
+
+/// Shared PreToolUse deny: `{"hookSpecificOutput":{"hookEventName":"PreToolUse",
+/// "permissionDecision":"deny","permissionDecisionReason":"Blocked by Sigil rule
+/// <id>: <reason>"}}` on stdout, exit 0. Used by every Claude-shaped agent.
+// Task 2 wires the production caller; allow until then.
+#[allow(dead_code)]
+pub(crate) fn pretooluse_deny(rule_id: &str, reason: &str) -> DenyOutput {
+    let v = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": format!("Blocked by Sigil rule {rule_id}: {reason}")
+        }
+    });
+    DenyOutput {
+        stdout: Some(v.to_string()),
+        exit_code: 0,
+    }
+}
+
 /// One impl per agent. Turns a vendor stdin payload into a normalized
 /// HookInvocation. (Shape mirrors ai_guard/parser, but is a distinct trait —
 /// that one assesses on-disk config, this one normalizes runtime stdin.)
@@ -15,6 +45,14 @@ pub trait HookAdapter {
         payload: &serde_json::Value,
         level: CaptureLevel,
     ) -> Result<HookInvocation, CaptureStatus>;
+    /// Translate a Deny verdict into this agent's deny-UX wire output. Default =
+    /// the shared PreToolUse permissionDecision JSON; override only when an
+    /// agent's deny contract differs.
+    // Task 2 wires the production caller; allow until then.
+    #[allow(dead_code)]
+    fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
+        pretooluse_deny(rule_id, reason)
+    }
 }
 
 pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
@@ -24,5 +62,34 @@ pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
         "cursor" => Some(Box::new(cursor::Cursor)),
         "antigravity" => Some(Box::new(antigravity::Antigravity)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pretooluse_deny_exact_json_and_exit0() {
+        let out = pretooluse_deny("no-rm", "destructive");
+        assert_eq!(out.exit_code, 0);
+        let s = out.stdout.expect("deny prints stdout");
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert_eq!(
+            v["hookSpecificOutput"]["permissionDecisionReason"],
+            "Blocked by Sigil rule no-rm: destructive"
+        );
+    }
+
+    #[test]
+    fn adapter_default_deny_output_is_pretooluse() {
+        // ClaudeCode uses the default trait impl => identical to pretooluse_deny.
+        let a = claude_code::ClaudeCode;
+        assert_eq!(
+            a.deny_output("no-rm", "destructive").stdout,
+            pretooluse_deny("no-rm", "destructive").stdout
+        );
     }
 }

--- a/crates/sigil-hook/src/decide.rs
+++ b/crates/sigil-hook/src/decide.rs
@@ -5,7 +5,7 @@ use sigil_core::hook_proto::{HookDecisionRequest, HookVerdict};
 use std::path::Path;
 use std::time::Duration;
 
-// called by the claude-code enforce path (Task 9)
+// called by the per-agent enforce path (run_enforce)
 #[cfg(unix)]
 pub fn request_verdict(
     socket: &Path,
@@ -32,7 +32,7 @@ pub fn request_verdict(
     Some(parsed.verdict)
 }
 
-// called by the claude-code enforce path (Task 9)
+// called by the per-agent enforce path (run_enforce)
 #[cfg(not(unix))]
 pub fn request_verdict(
     _socket: &Path,

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -227,7 +227,7 @@ pub fn render_block_enforce(exe: &str, agent: &str, capture: &str, on_failure: &
 /// For claude-code (NestedPreToolUse): merges with the enforce command string.
 /// For Cursor and unknown agents: returns false (not supported in slice 1).
 ///
-/// slice 1: enforce is claude-code only; the CLI guards non-claude-code before reaching here.
+/// Enforce install is for the NestedPreToolUse agents (claude-code, codex); the CLI guards other agents before reaching here.
 pub fn merge_into_enforce(
     root: &mut Value,
     exe: &str,

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -420,6 +420,13 @@ mod tests {
         assert!(s.contains("PreToolUse"));
     }
 
+    #[test]
+    fn render_block_enforce_codex_carries_flags() {
+        let s = render_block_enforce("/abs/sigil-hook", "codex", "redacted", "open");
+        assert!(s.contains("/abs/sigil-hook codex --enforce --on-failure open --capture redacted"));
+        assert!(s.contains("PreToolUse"));
+    }
+
     // --- Claude Code (nested) ---
     #[test]
     fn render_block_has_abs_path_and_capture() {

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -149,7 +149,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Claude Code PreToolUse entrypoint: read stdin, emit, exit 0.
+    /// Claude Code PreToolUse entrypoint: observe (emit, exit 0), or --enforce (deny-decision path).
     #[command(name = "claude-code")]
     ClaudeCode {
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
@@ -162,10 +162,16 @@ enum Cmd {
         on_failure: OnFailureArg,
     },
 
-    /// Codex CLI PreToolUse entrypoint: read stdin, emit, exit 0.
+    /// Codex CLI PreToolUse entrypoint: observe (emit, exit 0), or --enforce (deny-decision path).
     Codex {
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
         capture: CaptureArg,
+        /// Stage 2: run the synchronous deny-decision path instead of observe.
+        #[arg(long)]
+        enforce: bool,
+        /// Behavior when no verdict is obtainable. Default open (fail-open).
+        #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
+        on_failure: OnFailureArg,
     },
 
     /// Cursor before{Shell,MCP}Execution entrypoint: read stdin, emit, exit 0.
@@ -247,13 +253,13 @@ enum OnFailureArg {
 /// Maximum elapsed time waiting for a verdict before falling back to on_failure.
 const DECISION_DEADLINE: Duration = Duration::from_millis(250);
 
-/// claude-code enforce entrypoint. Panic-safe; never hangs past the watchdog.
-/// On Deny → print the permissionDecision JSON; on Allow → nothing.
+/// Per-agent enforce entrypoint. Panic-safe; never hangs past the watchdog.
+/// On Deny → emit the agent's deny output; on Allow → nothing.
 /// No verdict (daemon down / timeout / malformed) → apply on_failure.
-fn run_enforce(capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
+fn run_enforce(agent: &str, capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
     std::panic::set_hook(Box::new(|_| std::process::exit(0)));
     emit::arm_watchdog(Duration::from_millis(800)); // > decision deadline, < agent UX budget
-    let adapter = match adapters::for_agent("claude-code") {
+    let adapter = match adapters::for_agent(agent) {
         Some(a) => a,
         None => std::process::exit(0),
     };
@@ -289,8 +295,7 @@ fn run_enforce(capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
             // Only block when the daemon explicitly says Deny AND is in Enforce mode.
             // A Deny down-shifted to Observe (spec §4) must not block the tool call.
             (Decision::Deny { rule_id, reason }, EnforcementMode::Enforce) => {
-                print_deny(&rule_id, &reason);
-                std::process::exit(0);
+                emit_deny(&*adapter, &rule_id, &reason);
             }
             // Allow, or a Deny down-shifted to Observe → do not block.
             _ => std::process::exit(0),
@@ -298,26 +303,24 @@ fn run_enforce(capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
         None => match on_failure {
             OnFailureArg::Open => std::process::exit(0),
             OnFailureArg::Closed => {
-                print_deny("fail_closed", "decision unavailable; on_failure=closed");
-                std::process::exit(0);
+                emit_deny(
+                    &*adapter,
+                    "fail_closed",
+                    "decision unavailable; on_failure=closed",
+                );
             }
         },
     }
 }
 
-/// Pure builder for the Claude Code PreToolUse deny JSON (testable).
-fn deny_json(rule_id: &str, reason: &str) -> serde_json::Value {
-    serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": format!("Blocked by Sigil rule {rule_id}: {reason}")
-        }
-    })
-}
-
-fn print_deny(rule_id: &str, reason: &str) {
-    println!("{}", deny_json(rule_id, reason));
+/// Print the adapter's deny output (if any) and exit with its code.
+fn emit_deny(adapter: &dyn adapters::HookAdapter, rule_id: &str, reason: &str) -> ! {
+    let out = adapter.deny_output(rule_id, reason);
+    if let Some(s) = out.stdout {
+        // println! appends a trailing newline; the agent reads the deny response as a line.
+        println!("{s}");
+    }
+    std::process::exit(out.exit_code);
 }
 
 fn main() {
@@ -329,12 +332,22 @@ fn main() {
             on_failure,
         } => {
             if enforce {
-                run_enforce(capture.into(), on_failure)
+                run_enforce("claude-code", capture.into(), on_failure)
             } else {
                 run_hook("claude-code", capture.into())
             }
         }
-        Cmd::Codex { capture } => run_hook("codex", capture.into()),
+        Cmd::Codex {
+            capture,
+            enforce,
+            on_failure,
+        } => {
+            if enforce {
+                run_enforce("codex", capture.into(), on_failure)
+            } else {
+                run_hook("codex", capture.into())
+            }
+        }
         Cmd::Cursor { capture } => run_hook("cursor", capture.into()),
         Cmd::Antigravity { capture } => run_hook("antigravity", capture.into()),
         Cmd::Install {
@@ -690,21 +703,6 @@ fn cmd_verify(_agent: &str) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn deny_json_has_pretooluse_deny_shape() {
-        let v = deny_json("no-rm", "destructive");
-        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
-        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
-        assert!(v["hookSpecificOutput"]["permissionDecisionReason"]
-            .as_str()
-            .unwrap()
-            .contains("no-rm"));
-        assert_eq!(
-            v["hookSpecificOutput"]["permissionDecisionReason"],
-            "Blocked by Sigil rule no-rm: destructive"
-        );
-    }
 
     #[test]
     fn drift_exit_codes() {

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -406,14 +406,14 @@ fn cmd_install(
         return;
     }
 
-    // Enforce-mode --write is only supported for claude-code in slice 1.
-    // The Codex subcommand has no --enforce flag (clap would exit 2 at runtime),
-    // and codex enforce is out of scope for slice 1. For any other agent, guard
-    // explicitly so we never write a misleading settings file or print a
-    // confusing "already installed (no change)" message.
-    if enforce && agent != "claude-code" {
+    // Enforce-mode --write is supported for the NestedPreToolUse agents
+    // (claude-code, codex) in this slice. For any other agent (cursor, unknown),
+    // guard explicitly so we never write a misleading settings file or print a
+    // confusing "already installed (no change)" message. (antigravity is routed
+    // to its own plugin path before this point.)
+    if enforce && !matches!(agent, "claude-code" | "codex") {
         eprintln!(
-            "error: enforce-mode install is only supported for claude-code in slice 1 (agent '{agent}' not registered)"
+            "error: enforce-mode install is only supported for claude-code/codex in this slice (agent '{agent}' not registered)"
         );
         std::process::exit(1);
     }

--- a/crates/sigil-hook/tests/enforce_codex_e2e.rs
+++ b/crates/sigil-hook/tests/enforce_codex_e2e.rs
@@ -1,0 +1,120 @@
+//! E2E (#100): `sigil-hook codex --enforce` against a stub decide server.
+#![cfg(unix)]
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// One-shot stub: accept one connection, read the request line, reply with a
+/// fixed verdict. `deny` chooses the verdict.
+fn spawn_stub(socket: std::path::PathBuf, deny: bool) {
+    std::thread::spawn(move || {
+        let listener = UnixListener::bind(&socket).unwrap();
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut line = String::new();
+            BufReader::new(s.try_clone().unwrap())
+                .read_line(&mut line)
+                .unwrap();
+            // Build the response with the EXACT verified wire shape.
+            // HookDecisionResponse { protocol_version, request_id, verdict: HookVerdict { decision, enforcement_mode } }
+            // Decision is serde(tag = "kind", rename_all = "snake_case"):
+            //   Deny { rule_id, reason } → {"kind":"deny","rule_id":"...","reason":"..."}
+            //   Allow → {"kind":"allow"}
+            let decision = if deny {
+                r#"{"kind":"deny","rule_id":"no-rm","reason":"destructive"}"#
+            } else {
+                r#"{"kind":"allow"}"#
+            };
+            let resp = format!(
+                r#"{{"protocol_version":2,"request_id":"00000000-0000-0000-0000-000000000000","verdict":{{"decision":{decision},"enforcement_mode":"enforce"}}}}"#
+            );
+            writeln!(s, "{resp}").unwrap();
+        }
+    });
+}
+
+fn run_codex_enforce(socket: &std::path::Path, stdin_json: &str) -> (String, i32) {
+    let exe = env!("CARGO_BIN_EXE_sigil-hook");
+    let mut child = Command::new(exe)
+        .args(["codex", "--enforce", "--on-failure", "open"])
+        .env("SIGIL_HOOK_DECIDE_SOCKET", socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin_json.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Poll until the stub's listening socket appears (guards the bind race between
+/// the spawned stub thread and the hook process connecting).
+fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..50 {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Build a codex Bash stdin payload.
+/// Codex reuses the Claude Code hook shape: `tool_name` + `tool_input.command`.
+/// Verified against adapters/codex.rs normalize():
+///   - top-level key "tool_name" → tool dispatch
+///   - top-level key "tool_input" → nested object
+///   - "tool_input"."command" → Bash command string (HookAction::Bash branch)
+// NOTE: cmd must not contain `"` or `\` — interpolated raw into JSON (fine for the simple test commands here).
+fn bash_stdin(cmd: &str) -> String {
+    format!(r#"{{"tool_name":"Bash","tool_input":{{"command":"{cmd}"}}}}"#)
+}
+
+#[test]
+fn codex_deny_emits_permission_decision_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), true);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_codex_enforce(&socket, &bash_stdin("rm -rf /"));
+    assert_eq!(code, 0, "hook must always exit 0");
+    assert!(
+        stdout.contains("\"permissionDecision\":\"deny\""),
+        "got: {stdout}"
+    );
+    assert!(stdout.contains("no-rm"));
+}
+
+#[test]
+fn codex_allow_is_silent() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), false);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_codex_enforce(&socket, &bash_stdin("ls -la"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "allow must print nothing, got: {stdout}"
+    );
+}
+
+#[test]
+fn codex_missing_socket_fails_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("absent.sock"); // never bound
+    let (stdout, code) = run_codex_enforce(&socket, &bash_stdin("rm -rf /"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "fail-open (on_failure=open) → allow, no output"
+    );
+}


### PR DESCRIPTION
## Summary

Phase A of the enforce-adapters slice (#100): **generalize the claude-code-only enforce path per-agent** and add **codex** enforce. Builds on enforce slice 1 (#106) + tamper-evidence (#109).

The synchronous decision contract, the agent-side `hook_decide_listener`, and the deny-rule policy are already agent-agnostic and **unchanged** — this is hook-side only.

## What changed

- **`HookAdapter::deny_output(rule_id, reason) -> DenyOutput`** — a trait method (with a **default** = the shared `pretooluse_deny` JSON) so every adapter inherits the Claude-shaped `permissionDecision: deny` for free; override only where an agent's contract differs. The slice-1 hardcoded `deny_json`/`print_deny` is lifted into `adapters::pretooluse_deny` (single source).
- **`run_enforce(agent, capture, on_failure)`** — parameterized by agent; a single `emit_deny()` exit point routes both the deny and fail-closed paths through `adapter.deny_output()`. Non-deny paths (allow / fail-open / error / panic / watchdog) exit 0; a deny uses `DenyOutput.exit_code`.
- **codex enforce** — `sigil-hook codex --enforce [--on-failure open|closed]`; codex inherits the default `deny_output` (its deny format is web-confirmed identical to claude-code — Codex `PreToolUse` acts only on `deny`). The install guard widens to `claude-code | codex` (codex shares the `NestedPreToolUse` format). A driving E2E (`enforce_codex_e2e.rs`) exercises the real binary: deny → JSON, allow → silent, missing socket → fail-open.

**claude-code deny output is byte-identical** to slice 1 — the unchanged `enforce_e2e.rs` is the regression guard.

## Scope

codex only. **Antigravity is Phase B** — gated on an on-hardware deny-format verification (the observe-side approval key was `toolPermission`, so antigravity's deny output is not assumed; spec D5). Grok = new-agent onboarding (#110); cursor enforce = follow-on. No change to the decision contract / listener / deny-rule policy.

## Quality

5-task TDD with per-task spec + code-quality review; final holistic review **Ready-to-merge**. Gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p sigil-hook`. (The only full-workspace test failure is the pre-existing `basic_events` FSEvents parallel-load flake **#108** — passes in isolation; this diff is 100% sigil-hook and doesn't touch the watcher path.)

Public repo — mechanism-only, no monetization language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)