### PR TITLE
feat(hook): possible hook-activity silence detection (#107)

### DIFF
--- a/crates/sigil-agent/src/hook_decide_listener.rs
+++ b/crates/sigil-agent/src/hook_decide_listener.rs
@@ -27,6 +27,7 @@ pub async fn serve(
     tx: mpsc::Sender<CommittableEvent>,
     host_id: String,
     evaluator: Arc<DenyEvaluator>,
+    activity_map: crate::hook_silence::ActivityMap,
 ) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     if socket.exists() {
@@ -62,6 +63,7 @@ pub async fn serve(
         let tx = tx.clone();
         let host_id = host_id.clone();
         let evaluator = evaluator.clone();
+        let activity_map = activity_map.clone();
         tokio::spawn(async move {
             let _permit = permit;
             let mut line = String::new();
@@ -83,6 +85,14 @@ pub async fn serve(
             let mut stream = rd.into_inner().into_inner();
 
             // 1) Observe event (best-effort, like Stage 1's one-way path).
+            // D6: record BEFORE try_send so a dropped-on-backpressure
+            // observation never becomes false silence.
+            crate::hook_silence::record_hook_event(
+                &activity_map,
+                req.invocation.agent,
+                peer_uid,
+                time::OffsetDateTime::now_utc(),
+            );
             let action = req.invocation.action.clone();
             let inv = req.invocation.clone();
             let observe_env = HookEnvelope {
@@ -266,7 +276,14 @@ mod tests {
         );
         let sock2 = socket.clone();
         tokio::spawn(async move {
-            let _ = serve(sock2, tx, "host-x".into(), ev).await;
+            let _ = serve(
+                sock2,
+                tx,
+                "host-x".into(),
+                ev,
+                crate::hook_silence::new_map(),
+            )
+            .await;
         });
         for _ in 0..50 {
             if socket.exists() {

--- a/crates/sigil-agent/src/hook_listener.rs
+++ b/crates/sigil-agent/src/hook_listener.rs
@@ -47,6 +47,7 @@ pub async fn serve(
     socket: PathBuf,
     tx: mpsc::Sender<CommittableEvent>,
     host_id: String,
+    activity_map: crate::hook_silence::ActivityMap,
 ) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -93,6 +94,7 @@ pub async fn serve(
 
         let tx = tx.clone();
         let host_id = host_id.clone();
+        let activity_map = activity_map.clone();
 
         tokio::spawn(async move {
             // Permit is held for the lifetime of this task.
@@ -134,6 +136,14 @@ pub async fn serve(
                             return;
                         }
                     };
+                    // D6: record BEFORE try_send so a dropped-on-backpressure
+                    // observation never becomes false silence.
+                    crate::hook_silence::record_hook_event(
+                        &activity_map,
+                        env.payload.agent,
+                        peer_uid,
+                        time::OffsetDateTime::now_utc(),
+                    );
                     CommittableEvent {
                         event: to_event(env, peer_uid, &host_id),
                         new_hash: None,

--- a/crates/sigil-agent/src/hook_silence.rs
+++ b/crates/sigil-agent/src/hook_silence.rs
@@ -24,6 +24,20 @@ pub fn new_map() -> ActivityMap {
     Arc::new(Mutex::new(HashMap::new()))
 }
 
+/// Update at receive in the listeners — BEFORE the lossy `try_send` — so a
+/// dropped-on-backpressure observation never becomes false silence. A fresh
+/// hook event also closes any open silence episode.
+pub fn record_hook_event(map: &ActivityMap, agent: AiTool, uid: u32, now: OffsetDateTime) {
+    let mut g = map.lock();
+    let r = g.entry((agent, uid)).or_insert(ActivityRecord {
+        last_hook_event_at: now,
+        last_emitted_at: None,
+        episode_open: false,
+    });
+    r.last_hook_event_at = now;
+    r.episode_open = false;
+}
+
 /// Window W (silence threshold) and horizon H (expectation decay).
 #[derive(Debug, Clone, Copy)]
 pub struct SilenceCfg {
@@ -123,5 +137,25 @@ mod tests {
         let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
         let now = base + Duration::days(7); // since == H (inclusive) AND > W → silent
         assert!(decide(&rec_at(base), true, now, &cfg()).silent);
+    }
+
+    #[test]
+    fn record_hook_event_marks_seen_and_closes_episode() {
+        use sigil_core::event::AiTool;
+        let map = new_map();
+        let now = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        map.lock().insert(
+            (AiTool::Codex, 501),
+            ActivityRecord {
+                last_hook_event_at: now - Duration::days(1),
+                last_emitted_at: Some(now - Duration::days(1)),
+                episode_open: true,
+            },
+        );
+        record_hook_event(&map, AiTool::Codex, 501, now);
+        let g = map.lock();
+        let r = g.get(&(AiTool::Codex, 501)).unwrap();
+        assert_eq!(r.last_hook_event_at, now);
+        assert!(!r.episode_open);
     }
 }

--- a/crates/sigil-agent/src/hook_silence.rs
+++ b/crates/sigil-agent/src/hook_silence.rs
@@ -5,6 +5,7 @@
 use parking_lot::Mutex;
 use sigil_core::event::{AiTool, Confidence};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use time::{Duration, OffsetDateTime};
 
@@ -66,6 +67,154 @@ pub fn decide(
     Verdict {
         silent,
         confidence: Confidence::Low,
+    }
+}
+
+/// Runtime caps for the capped session-directory scan.
+#[derive(Debug, Clone, Copy)]
+pub struct ProbeCapRt {
+    pub max_entries: usize,
+    pub max_depth: usize,
+    pub budget: std::time::Duration,
+}
+
+/// Result of a single capped directory scan.
+#[derive(Debug, Clone)]
+pub struct ProbeResult {
+    pub active: bool,
+    pub last_activity_at: Option<OffsetDateTime>,
+    pub probe_kind: String,
+    /// blake3 hash of the matched path — never the raw path.
+    pub path_hash: Option<String>,
+    pub probe_error: Option<String>,
+    pub scan_truncated: bool,
+}
+
+/// Raw output of `newest_mtime_capped`.
+#[derive(Debug)]
+pub(crate) struct ScanOut {
+    pub newest: Option<(OffsetDateTime, PathBuf)>,
+    pub truncated: bool,
+}
+
+/// Capped, bounded-depth scan for the newest *file* mtime under `root`. Bounds:
+/// `max_depth` (subdirs pushed only while depth < max_depth), `max_entries`
+/// (counts files visited; dirs are not counted), and `budget` (checked once per
+/// directory dequeue — a secondary backstop, `max_entries` is the hard bound).
+/// Follows symlinks (`metadata`), but the depth+entry caps bound any cycle. A
+/// deliberately weak, spoofable activity oracle; see the spec threat model.
+pub(crate) fn newest_mtime_capped(root: &Path, cap: &ProbeCapRt) -> ScanOut {
+    let start = std::time::Instant::now();
+    let mut seen = 0usize;
+    let mut truncated = false;
+    let mut newest: Option<(OffsetDateTime, PathBuf)> = None;
+    let mut stack: Vec<(PathBuf, usize)> = vec![(root.to_path_buf(), 0)];
+    while let Some((dir, depth)) = stack.pop() {
+        if start.elapsed() > cap.budget {
+            truncated = true;
+            break;
+        }
+        let rd = match std::fs::read_dir(&dir) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        for ent in rd.flatten() {
+            if seen >= cap.max_entries {
+                truncated = true;
+                break;
+            }
+            seen += 1;
+            let md = match ent.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if md.is_dir() {
+                if depth < cap.max_depth {
+                    stack.push((ent.path(), depth + 1));
+                }
+                continue;
+            }
+            if let Ok(mt) = md.modified() {
+                let ot: OffsetDateTime = mt.into();
+                if newest.as_ref().map_or(true, |(n, _)| ot > *n) {
+                    newest = Some((ot, ent.path()));
+                }
+            }
+        }
+        if seen >= cap.max_entries {
+            truncated = true;
+            break;
+        }
+    }
+    ScanOut { newest, truncated }
+}
+
+/// Per-agent versioned allowlist of session/transcript roots, resolved under `home`.
+/// An unknown agent → empty → never flagged.
+pub fn session_dirs(agent: AiTool, home: &Path) -> Vec<PathBuf> {
+    match agent {
+        AiTool::Codex => vec![home.join(".codex/sessions")],
+        AiTool::ClaudeCode => vec![home.join(".claude/projects")],
+        _ => vec![],
+    }
+}
+
+/// Canonical probe-kind label for a given agent.
+pub fn probe_kind_for(agent: AiTool) -> &'static str {
+    match agent {
+        AiTool::Codex => "codex_sessions",
+        AiTool::ClaudeCode => "claude_transcripts",
+        _ => "none",
+    }
+}
+
+fn hash_path(p: &Path) -> String {
+    format!(
+        "blake3:{}",
+        blake3::hash(p.to_string_lossy().as_bytes()).to_hex()
+    )
+}
+
+/// Probe candidate dirs; `probe_error` is set when NONE of the candidate dirs exists.
+/// `last_activity_at` is the newest mtime found; the caller applies the activity window.
+pub fn probe_dirs(kind: &str, dirs: &[PathBuf], cap: &ProbeCapRt) -> ProbeResult {
+    let mut newest: Option<(OffsetDateTime, PathBuf)> = None;
+    let mut truncated = false;
+    let mut any_dir = false;
+    for d in dirs {
+        if !d.exists() {
+            continue;
+        }
+        any_dir = true;
+        let s = newest_mtime_capped(d, cap);
+        truncated |= s.truncated;
+        if let Some((ot, p)) = s.newest {
+            if newest.as_ref().map_or(true, |(n, _)| ot > *n) {
+                newest = Some((ot, p));
+            }
+        }
+    }
+    if !any_dir {
+        return ProbeResult {
+            active: false,
+            last_activity_at: None,
+            probe_kind: kind.into(),
+            path_hash: None,
+            probe_error: Some("session dir not found".into()),
+            scan_truncated: false,
+        };
+    }
+    let (la, ph) = match &newest {
+        Some((ot, p)) => (Some(*ot), Some(hash_path(p))),
+        None => (None, None),
+    };
+    ProbeResult {
+        active: la.is_some(),
+        last_activity_at: la,
+        probe_kind: kind.into(),
+        path_hash: ph,
+        probe_error: None,
+        scan_truncated: truncated,
     }
 }
 
@@ -157,5 +306,94 @@ mod tests {
         let r = g.get(&(AiTool::Codex, 501)).unwrap();
         assert_eq!(r.last_hook_event_at, now);
         assert!(!r.episode_open);
+    }
+
+    #[test]
+    fn newest_mtime_capped_truncates_and_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..10 {
+            std::fs::write(dir.path().join(format!("f{i}.jsonl")), "x").unwrap();
+        }
+        let cap = ProbeCapRt {
+            max_entries: 3,
+            max_depth: 1,
+            budget: std::time::Duration::from_millis(50),
+        };
+        let out = newest_mtime_capped(dir.path(), &cap);
+        assert!(out.newest.is_some());
+        assert!(out.truncated); // 10 files, cap 3
+    }
+
+    #[test]
+    fn newest_mtime_capped_respects_max_depth() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("deep.jsonl"), "x").unwrap(); // only file is at depth 1
+        let cap0 = ProbeCapRt {
+            max_entries: 256,
+            max_depth: 0,
+            budget: std::time::Duration::from_millis(50),
+        };
+        assert!(newest_mtime_capped(dir.path(), &cap0).newest.is_none()); // depth 0 → subdir not entered
+        let cap1 = ProbeCapRt {
+            max_entries: 256,
+            max_depth: 1,
+            budget: std::time::Duration::from_millis(50),
+        };
+        assert!(newest_mtime_capped(dir.path(), &cap1).newest.is_some()); // depth 1 → deep.jsonl found
+    }
+
+    #[test]
+    fn session_dirs_unknown_agent_is_empty() {
+        assert!(session_dirs(AiTool::ContinueDev, std::path::Path::new("/home/u")).is_empty());
+    }
+
+    #[test]
+    fn session_dirs_known_agents_resolve_under_home() {
+        let home = std::path::Path::new("/home/u");
+        assert_eq!(
+            session_dirs(AiTool::Codex, home),
+            vec![home.join(".codex/sessions")]
+        );
+        assert_eq!(
+            session_dirs(AiTool::ClaudeCode, home),
+            vec![home.join(".claude/projects")]
+        );
+    }
+
+    #[test]
+    fn probe_dirs_hashes_path_never_raw_and_sets_active() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("s.jsonl"), "x").unwrap();
+        let cap = ProbeCapRt {
+            max_entries: 256,
+            max_depth: 3,
+            budget: std::time::Duration::from_millis(50),
+        };
+        let pr = probe_dirs("codex_sessions", &[dir.path().to_path_buf()], &cap);
+        assert!(pr.active);
+        assert!(pr.last_activity_at.is_some());
+        assert!(pr.path_hash.as_ref().unwrap().starts_with("blake3:"));
+        let raw = dir.path().display().to_string();
+        assert!(!format!("{pr:?}").contains(&raw)); // raw path never retained in the struct
+        assert!(pr.probe_error.is_none());
+    }
+
+    #[test]
+    fn probe_dirs_missing_dir_reports_error() {
+        let cap = ProbeCapRt {
+            max_entries: 8,
+            max_depth: 1,
+            budget: std::time::Duration::from_millis(50),
+        };
+        let pr = probe_dirs(
+            "codex_sessions",
+            &[std::path::PathBuf::from("/no/such/dir/xyz")],
+            &cap,
+        );
+        assert!(!pr.active);
+        assert!(pr.probe_error.is_some());
+        assert!(pr.path_hash.is_none());
     }
 }

--- a/crates/sigil-agent/src/hook_silence.rs
+++ b/crates/sigil-agent/src/hook_silence.rs
@@ -1,0 +1,127 @@
+//! #107 — hook-activity silence detection: in-memory per-agent activity record
+//! and the pure silence-decision rule. The detector lives in the daemon (not the
+//! tamperable hook); see the silence_task module for the periodic driver.
+
+use parking_lot::Mutex;
+use sigil_core::event::{AiTool, Confidence};
+use std::collections::HashMap;
+use std::sync::Arc;
+use time::{Duration, OffsetDateTime};
+
+/// Per-(agent,uid) activity, updated by the listeners on each observed hook event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActivityRecord {
+    pub last_hook_event_at: OffsetDateTime,
+    pub last_emitted_at: Option<OffsetDateTime>,
+    pub episode_open: bool,
+}
+
+/// Shared, in-memory only: empty on daemon start, so no agent is "expected"
+/// until its hook fires again → no false alarm across a restart.
+pub type ActivityMap = Arc<Mutex<HashMap<(AiTool, u32), ActivityRecord>>>;
+
+pub fn new_map() -> ActivityMap {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+/// Window W (silence threshold) and horizon H (expectation decay).
+#[derive(Debug, Clone, Copy)]
+pub struct SilenceCfg {
+    pub window: Duration,
+    pub horizon: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Verdict {
+    pub silent: bool,
+    pub confidence: Confidence,
+}
+
+/// Pure, wall-clock silence rule. `session_active` is the (weak, spoofable)
+/// filesystem probe result, supplied by the caller.
+pub fn decide(
+    r: &ActivityRecord,
+    session_active: bool,
+    now: OffsetDateTime,
+    cfg: &SilenceCfg,
+) -> Verdict {
+    let since = now - r.last_hook_event_at;
+    // `since >= ZERO` clamps a future last_hook_event_at (clock skew) to "not silent".
+    let expected = since >= Duration::ZERO && since <= cfg.horizon;
+    let silent = expected && session_active && since > cfg.window;
+    Verdict {
+        silent,
+        confidence: Confidence::Low,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::{Duration, OffsetDateTime};
+
+    fn cfg() -> SilenceCfg {
+        SilenceCfg {
+            window: Duration::hours(12),
+            horizon: Duration::days(7),
+        }
+    }
+    fn rec_at(base: OffsetDateTime) -> ActivityRecord {
+        ActivityRecord {
+            last_hook_event_at: base,
+            last_emitted_at: None,
+            episode_open: false,
+        }
+    }
+
+    #[test]
+    fn active_and_silent_within_horizon_is_silent_low() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base + Duration::hours(13); // > W (12h), < H (7d)
+        let v = decide(&rec_at(base), true, now, &cfg());
+        assert!(v.silent);
+        assert_eq!(v.confidence, sigil_core::event::Confidence::Low);
+    }
+
+    #[test]
+    fn idle_session_is_not_silent() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base + Duration::hours(13);
+        assert!(!decide(&rec_at(base), false, now, &cfg()).silent); // session not active
+    }
+
+    #[test]
+    fn tool_free_turn_within_window_is_not_silent() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base + Duration::hours(3); // < W
+        assert!(!decide(&rec_at(base), true, now, &cfg()).silent);
+    }
+
+    #[test]
+    fn decayed_past_horizon_is_not_expected() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base + Duration::days(8); // > H → not expected
+        assert!(!decide(&rec_at(base), true, now, &cfg()).silent);
+    }
+
+    #[test]
+    fn future_last_hook_clock_skew_is_not_silent() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base - Duration::hours(1); // now < last_hook (skew)
+        assert!(!decide(&rec_at(base), true, now, &cfg()).silent);
+    }
+
+    #[test]
+    fn exactly_at_window_is_not_silent() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base + Duration::hours(12); // since == W; strict `>` → not silent
+        assert!(!decide(&rec_at(base), true, now, &cfg()).silent);
+    }
+
+    #[test]
+    fn exactly_at_horizon_is_still_expected() {
+        let base = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let now = base + Duration::days(7); // since == H (inclusive) AND > W → silent
+        assert!(decide(&rec_at(base), true, now, &cfg()).silent);
+    }
+}

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -31,6 +31,7 @@ pub mod policy_reload_task;
 pub mod runtime;
 pub mod sender_offset;
 pub mod show;
+pub mod silence_task;
 pub mod sink_task;
 pub mod state_task;
 pub mod supervisor;

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod gc_config;
 pub mod hasher;
 pub mod heartbeat;
 pub mod hook_deny;
+pub mod hook_silence;
 // The hook listener uses Unix-domain sockets (tokio UnixListener); Windows agent
 // IPC is a named pipe (see control.rs) and a named-pipe hook listener is a
 // follow-up, so the module is unix-only for Stage 1.

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -768,11 +768,18 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         let hook_sock = cfg.control_socket.with_file_name("hook.sock");
         let tx_hook = tx_sink.clone();
         let host_id_hook = host_id.clone();
+        // TODO(#107 T8): share one map across both listeners
+        let hook_activity_map = crate::hook_silence::new_map();
         sup.track(
             "hook_listener",
             tokio::spawn(async move {
-                if let Err(e) =
-                    crate::hook_listener::serve(hook_sock.clone(), tx_hook, host_id_hook).await
+                if let Err(e) = crate::hook_listener::serve(
+                    hook_sock.clone(),
+                    tx_hook,
+                    host_id_hook,
+                    hook_activity_map,
+                )
+                .await
                 {
                     tracing::error!(
                         error = ?e,
@@ -803,6 +810,8 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                 Arc::new(crate::hook_deny::DenyEvaluator::new(&[]).unwrap())
             }
         };
+        // TODO(#107 T8): share one map across both listeners
+        let decide_activity_map = crate::hook_silence::new_map();
         sup.track(
             "hook_decide_listener",
             tokio::spawn(async move {
@@ -811,6 +820,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                     tx_decide,
                     host_id_decide,
                     evaluator,
+                    decide_activity_map,
                 )
                 .await
                 {

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -759,6 +759,10 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         );
     }
 
+    // #107 — one shared activity map for both hook listeners so the silence
+    // task sees events from both sides (hook.sock + hook-decide.sock).
+    let activity_map = crate::hook_silence::new_map();
+
     // Hook IPC listener (sigil-hook Stage 1 #64): sits in the same socket
     // directory as the control socket, at `hook.sock`. One-way: emitters write
     // HookEnvelope JSON lines; no response is ever sent. Peer-cred stamping,
@@ -768,8 +772,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         let hook_sock = cfg.control_socket.with_file_name("hook.sock");
         let tx_hook = tx_sink.clone();
         let host_id_hook = host_id.clone();
-        // TODO(#107 T8): share one map across both listeners
-        let hook_activity_map = crate::hook_silence::new_map();
+        let hook_activity_map = activity_map.clone();
         sup.track(
             "hook_listener",
             tokio::spawn(async move {
@@ -810,8 +813,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                 Arc::new(crate::hook_deny::DenyEvaluator::new(&[]).unwrap())
             }
         };
-        // TODO(#107 T8): share one map across both listeners
-        let decide_activity_map = crate::hook_silence::new_map();
+        let decide_activity_map = activity_map.clone();
         sup.track(
             "hook_decide_listener",
             tokio::spawn(async move {
@@ -831,6 +833,32 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                     );
                 }
             }),
+        );
+    }
+
+    // #107 — silence-detection task. Uses the shared activity_map populated by
+    // both hook listeners above. Early-returns immediately when enabled_agents
+    // is empty (the default), so there is zero overhead when the feature is OFF.
+    {
+        let hs = effective.hook_silence.clone();
+        sup.track(
+            "silence",
+            tokio::spawn(crate::silence_task::run(crate::silence_task::RunCfg {
+                host_id: host_id.clone(),
+                map: activity_map.clone(),
+                enabled: hs.enabled_agents.clone(),
+                window: time::Duration::seconds(hs.window_secs as i64),
+                horizon: time::Duration::seconds(hs.horizon_secs as i64),
+                tick: std::time::Duration::from_secs(hs.tick_secs),
+                cap: crate::hook_silence::ProbeCapRt {
+                    max_entries: hs.probe_cap.max_entries,
+                    max_depth: hs.probe_cap.max_depth,
+                    budget: std::time::Duration::from_millis(hs.probe_cap.budget_ms),
+                },
+                home: home_dir.clone(),
+                event_tx: tx_sink.clone(),
+                shutdown: cancel.clone(),
+            })),
         );
     }
 

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -530,6 +530,13 @@ fn evidence_summary(e: &sigil_core::event::Evidence) -> (&'static str, String) {
             "hook_config_drift",
             format!("kind={} settings_path={}", d.drift_kind, d.settings_path),
         ),
+        Evidence::PossibleHookActivitySilent(d) => (
+            "possible_hook_activity_silent",
+            format!(
+                "{:?} hook silent for {}s (confidence {:?})",
+                d.agent, d.window_secs, d.confidence
+            ),
+        ),
         Evidence::Unknown => ("unknown", String::new()),
     }
 }

--- a/crates/sigil-agent/src/silence_task.rs
+++ b/crates/sigil-agent/src/silence_task.rs
@@ -1,0 +1,278 @@
+//! #107 — periodic driver for hook-activity silence detection. Opt-in per agent;
+//! probes each expected agent's session dir, runs the pure `decide()` rule, and
+//! emits one low-confidence `PossibleHookActivitySilent` per silence episode.
+
+use crate::hook_silence::{decide, ActivityMap, ProbeCapRt, ProbeResult, SilenceCfg};
+use crate::state_task::CommittableEvent;
+use sigil_core::event::{
+    AiTool, Confidence, Event, Evidence, PossibleHookActivitySilentEvidence, Severity, SourceKind,
+    Subject, AGENT_VERSION, SCHEMA_VERSION,
+};
+use std::path::PathBuf;
+use std::time::Duration as StdDuration;
+use time::{Duration, OffsetDateTime};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+pub struct SilenceTaskCtx {
+    pub host_id: String,
+    pub map: ActivityMap,
+    pub enabled: Vec<AiTool>,
+    pub window: Duration,
+    pub horizon: Duration,
+    pub event_tx: mpsc::Sender<CommittableEvent>,
+    pub now_fn: Box<dyn Fn() -> OffsetDateTime + Send + Sync>,
+    pub probe_fn: Box<dyn Fn(AiTool, u32) -> ProbeResult + Send + Sync>,
+}
+
+pub async fn evaluate(ctx: &SilenceTaskCtx) {
+    let now = (ctx.now_fn)();
+    let cfg = SilenceCfg {
+        window: ctx.window,
+        horizon: ctx.horizon,
+    };
+    // Snapshot keys for opted-in agents; do not hold the lock across probe/emit.
+    let keys: Vec<(AiTool, u32)> = {
+        let g = ctx.map.lock();
+        g.keys()
+            .filter(|(a, _)| ctx.enabled.contains(a))
+            .cloned()
+            .collect()
+    };
+    for key in keys {
+        let (agent, uid) = key;
+        let Some(record) = ctx.map.lock().get(&key).cloned() else {
+            continue;
+        };
+        let probe = (ctx.probe_fn)(agent, uid);
+        // window applied here (single place): session active = recent enough mtime.
+        let session_active = probe.active
+            && probe.last_activity_at.is_some_and(|la| {
+                let d = now - la;
+                d >= Duration::ZERO && d <= ctx.window
+            });
+        if decide(&record, session_active, now, &cfg).silent && !record.episode_open {
+            let ev = Event {
+                schema_version: SCHEMA_VERSION,
+                event_id: Uuid::now_v7(),
+                ts: now,
+                host_id: ctx.host_id.clone(),
+                agent_version: AGENT_VERSION.to_string(),
+                severity: Severity::Warn,
+                source: SourceKind::Agent,
+                subject: Subject::Self_,
+                evidence: Evidence::PossibleHookActivitySilent(
+                    PossibleHookActivitySilentEvidence {
+                        agent,
+                        uid: Some(uid),
+                        last_hook_seen_at: record.last_hook_event_at,
+                        last_session_activity_at: probe.last_activity_at,
+                        window_secs: ctx.window.whole_seconds().max(0) as u64,
+                        probe_kind: probe.probe_kind.clone(),
+                        path_hash: probe.path_hash.clone(),
+                        probe_error: probe.probe_error.clone(),
+                        scan_truncated: probe.scan_truncated,
+                        confidence: Confidence::Low,
+                    },
+                ),
+                target_id: None,
+            };
+            let _ = ctx
+                .event_tx
+                .send(CommittableEvent {
+                    event: ev,
+                    new_hash: None,
+                    path_for_db: PathBuf::new(),
+                    target_id: String::new(),
+                })
+                .await;
+            // Re-lock to set the latch. A concurrent record_hook_event() (from a
+            // listener) between the clone above and here could have closed the
+            // episode; re-opening it costs at most one extra tick of silence
+            // before the next evaluate sees the fresh hook and re-arms. Benign.
+            if let Some(r) = ctx.map.lock().get_mut(&key) {
+                r.episode_open = true;
+                r.last_emitted_at = Some(now);
+            }
+        }
+    }
+}
+
+/// Production wiring inputs.
+pub struct RunCfg {
+    pub host_id: String,
+    pub map: ActivityMap,
+    pub enabled: Vec<AiTool>,
+    pub window: Duration,
+    pub horizon: Duration,
+    pub tick: StdDuration,
+    pub cap: ProbeCapRt,
+    pub home: PathBuf,
+    pub event_tx: mpsc::Sender<CommittableEvent>,
+    pub shutdown: CancellationToken,
+}
+
+pub async fn run(rc: RunCfg) {
+    if rc.enabled.is_empty() {
+        return; // feature OFF → no-op
+    }
+    let cap = rc.cap;
+    let home = rc.home.clone();
+    let ctx = SilenceTaskCtx {
+        host_id: rc.host_id,
+        map: rc.map,
+        enabled: rc.enabled,
+        window: rc.window,
+        horizon: rc.horizon,
+        event_tx: rc.event_tx,
+        now_fn: Box::new(OffsetDateTime::now_utc),
+        probe_fn: Box::new(move |agent, _uid| {
+            let dirs = crate::hook_silence::session_dirs(agent, &home);
+            crate::hook_silence::probe_dirs(crate::hook_silence::probe_kind_for(agent), &dirs, &cap)
+        }),
+    };
+    let mut interval = tokio::time::interval(rc.tick);
+    interval.tick().await; // skip immediate
+    loop {
+        tokio::select! {
+            biased;
+            _ = rc.shutdown.cancelled() => break,
+            _ = interval.tick() => evaluate(&ctx).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hook_silence::{new_map, ActivityRecord, ProbeResult};
+    use sigil_core::event::{AiTool, Evidence};
+    use time::{Duration, OffsetDateTime};
+
+    fn probe(active: bool, last: Option<OffsetDateTime>) -> ProbeResult {
+        ProbeResult {
+            active,
+            last_activity_at: last,
+            probe_kind: "codex_sessions".into(),
+            path_hash: Some("blake3:x".into()),
+            probe_error: None,
+            scan_truncated: false,
+        }
+    }
+
+    fn ctx_with(
+        active: bool,
+    ) -> (
+        SilenceTaskCtx,
+        tokio::sync::mpsc::Receiver<crate::state_task::CommittableEvent>,
+    ) {
+        let now = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let map = new_map();
+        map.lock().insert(
+            (AiTool::Codex, 501),
+            ActivityRecord {
+                last_hook_event_at: now - Duration::hours(13),
+                last_emitted_at: None,
+                episode_open: false,
+            },
+        );
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let ctx = SilenceTaskCtx {
+            host_id: "h".into(),
+            map,
+            enabled: vec![AiTool::Codex],
+            window: Duration::hours(12),
+            horizon: Duration::days(7),
+            event_tx: tx,
+            now_fn: Box::new(move || now),
+            probe_fn: Box::new(move |_a, _u| probe(active, Some(now - Duration::minutes(5)))),
+        };
+        (ctx, rx)
+    }
+
+    #[tokio::test]
+    async fn active_silent_emits_once_per_episode() {
+        let (ctx, mut rx) = ctx_with(true);
+        evaluate(&ctx).await;
+        evaluate(&ctx).await; // same episode, second tick
+        let ev = rx.recv().await.unwrap();
+        assert!(matches!(
+            ev.event.evidence,
+            Evidence::PossibleHookActivitySilent(_)
+        ));
+        assert!(rx.try_recv().is_err()); // exactly one
+    }
+
+    #[tokio::test]
+    async fn disabled_agent_never_emits() {
+        let (mut ctx, mut rx) = ctx_with(true);
+        ctx.enabled = vec![]; // opt-in empty
+        evaluate(&ctx).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn inactive_session_does_not_emit() {
+        let (ctx, mut rx) = ctx_with(false); // probe inactive
+        evaluate(&ctx).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn resumed_hook_rearms_episode() {
+        let (ctx, mut rx) = ctx_with(true);
+        evaluate(&ctx).await;
+        let _ = rx.recv().await.unwrap();
+        // resumed hook traffic closes the episode + refreshes last seen…
+        crate::hook_silence::record_hook_event(&ctx.map, AiTool::Codex, 501, (ctx.now_fn)());
+        // …then age it back beyond W so it's silent again
+        ctx.map
+            .lock()
+            .get_mut(&(AiTool::Codex, 501))
+            .unwrap()
+            .last_hook_event_at = (ctx.now_fn)() - Duration::hours(13);
+        evaluate(&ctx).await;
+        assert!(matches!(
+            rx.recv().await.unwrap().event.evidence,
+            Evidence::PossibleHookActivitySilent(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_map_no_alarm() {
+        // restart behavior
+        let (mut ctx, mut rx) = ctx_with(true);
+        ctx.map = new_map();
+        evaluate(&ctx).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn decayed_agent_in_map_does_not_emit() {
+        let now = OffsetDateTime::UNIX_EPOCH + Duration::days(100);
+        let map = new_map();
+        // last hook 8 days ago > horizon (7d) → not expected, even though session is active
+        map.lock().insert(
+            (AiTool::Codex, 501),
+            ActivityRecord {
+                last_hook_event_at: now - Duration::days(8),
+                last_emitted_at: None,
+                episode_open: false,
+            },
+        );
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let ctx = SilenceTaskCtx {
+            host_id: "h".into(),
+            map,
+            enabled: vec![AiTool::Codex],
+            window: Duration::hours(12),
+            horizon: Duration::days(7),
+            event_tx: tx,
+            now_fn: Box::new(move || now),
+            probe_fn: Box::new(move |_a, _u| probe(true, Some(now - Duration::minutes(5)))),
+        };
+        evaluate(&ctx).await;
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/crates/sigil-agent/src/silence_task.rs
+++ b/crates/sigil-agent/src/silence_task.rs
@@ -240,6 +240,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_policy_makes_run_return_immediately() {
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let rc = RunCfg {
+            host_id: "h".into(),
+            map: crate::hook_silence::new_map(),
+            enabled: vec![],
+            window: time::Duration::hours(12),
+            horizon: time::Duration::days(7),
+            tick: std::time::Duration::from_millis(5),
+            cap: crate::hook_silence::ProbeCapRt {
+                max_entries: 16,
+                max_depth: 1,
+                budget: std::time::Duration::from_millis(5),
+            },
+            home: std::env::temp_dir(),
+            event_tx: tx,
+            shutdown: tokio_util::sync::CancellationToken::new(),
+        };
+        tokio::time::timeout(std::time::Duration::from_millis(200), run(rc))
+            .await
+            .expect("run() must return immediately when enabled is empty");
+    }
+
+    #[tokio::test]
     async fn empty_map_no_alarm() {
         // restart behavior
         let (mut ctx, mut rx) = ctx_with(true);

--- a/crates/sigil-agent/src/sink_task.rs
+++ b/crates/sigil-agent/src/sink_task.rs
@@ -71,6 +71,30 @@ fn evidence_kind_str(e: &sigil_core::event::Evidence) -> &'static str {
         HookInvocation(_) => "hook_invocation",
         HookDecision(_) => "hook_decision",
         HookConfigDrift(_) => "hook_config_drift",
+        PossibleHookActivitySilent(_) => "possible_hook_activity_silent",
         Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn possible_hook_activity_silent_has_sink_label() {
+        use sigil_core::event::{AiTool, Confidence, Evidence, PossibleHookActivitySilentEvidence};
+        let ev = Evidence::PossibleHookActivitySilent(PossibleHookActivitySilentEvidence {
+            agent: AiTool::Codex,
+            uid: None,
+            last_hook_seen_at: time::OffsetDateTime::UNIX_EPOCH,
+            last_session_activity_at: None,
+            window_secs: 0,
+            probe_kind: "codex_sessions".into(),
+            path_hash: None,
+            probe_error: None,
+            scan_truncated: false,
+            confidence: Confidence::Low,
+        });
+        assert_eq!(evidence_kind_str(&ev), "possible_hook_activity_silent");
     }
 }

--- a/crates/sigil-agent/tests/hook_listener_e2e.rs
+++ b/crates/sigil-agent/tests/hook_listener_e2e.rs
@@ -29,9 +29,14 @@ mod unix_only {
         // 3. Start the hook listener in a background task.
         let sock_path_clone = sock_path.clone();
         let _listener_task = tokio::spawn(async move {
-            hook_listener::serve(sock_path_clone, tx, "host-1".to_string())
-                .await
-                .expect("hook listener should not exit early");
+            hook_listener::serve(
+                sock_path_clone,
+                tx,
+                "host-1".to_string(),
+                sigil_agent::hook_silence::new_map(),
+            )
+            .await
+            .expect("hook listener should not exit early");
         });
 
         // 4. Wait for the socket file to appear (max 2 s).
@@ -151,9 +156,14 @@ mod unix_only {
 
         let sock_path_clone = sock_path.clone();
         let _listener_task = tokio::spawn(async move {
-            hook_listener::serve(sock_path_clone, tx, "host-overload".to_string())
-                .await
-                .expect("hook listener should not exit early");
+            hook_listener::serve(
+                sock_path_clone,
+                tx,
+                "host-overload".to_string(),
+                sigil_agent::hook_silence::new_map(),
+            )
+            .await
+            .expect("hook listener should not exit early");
         });
 
         // Wait for the socket to appear.

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -14,6 +14,15 @@ pub enum Severity {
     Warn,
 }
 
+/// Confidence in an inferred (non-definitive) signal. v1 emits only `Low`.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Low,
+    Medium,
+    High,
+}
+
 /// Origin of an event.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -264,6 +273,27 @@ pub struct HookConfigDriftEvidence {
     pub observed_matcher: Option<String>,
 }
 
+/// sigil-hook silence-detection (#107). A low-confidence tamper hint: an agent
+/// recently observed using its hook went hook-silent while its session files
+/// were still being written. Detection, not proof; a knowledgeable same-uid
+/// attacker is out of model.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct PossibleHookActivitySilentEvidence {
+    pub agent: AiTool,
+    pub uid: Option<u32>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_hook_seen_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub last_session_activity_at: Option<OffsetDateTime>,
+    pub window_secs: u64,
+    pub probe_kind: String,
+    // blake3 of the matched session path — NEVER the raw path.
+    pub path_hash: Option<String>,
+    pub probe_error: Option<String>,
+    pub scan_truncated: bool,
+    pub confidence: Confidence,
+}
+
 /// Phase 3b.4-pre — full host identity / OS / network snapshot, emitted by
 /// host_meta_snapshot_task. Surfaces hostname (so server-side fleet views
 /// can label hosts with something human-readable instead of UUIDs) plus
@@ -503,6 +533,8 @@ pub enum Evidence {
     HookDecision(HookDecisionEvidence),
     /// sigil-hook tamper-evidence (#100). Hook registration drift vs the install baseline.
     HookConfigDrift(HookConfigDriftEvidence),
+    /// #107 — low-confidence hook-silence hint.
+    PossibleHookActivitySilent(PossibleHookActivitySilentEvidence),
     /// Forward-compat: an evidence kind this build doesn't recognize. A newer
     /// producer's variant deserializes here instead of failing the whole event.
     #[serde(other)]
@@ -1222,6 +1254,30 @@ mod tests {
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains("\"kind\":\"hook_config_drift\""));
         assert!(s.contains("\"drift_kind\":\"matcher_drift\""));
+        let back: Evidence = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn possible_hook_activity_silent_roundtrips() {
+        use time::OffsetDateTime;
+        let ev = Evidence::PossibleHookActivitySilent(PossibleHookActivitySilentEvidence {
+            agent: AiTool::Codex,
+            uid: Some(501),
+            last_hook_seen_at: OffsetDateTime::UNIX_EPOCH,
+            last_session_activity_at: Some(OffsetDateTime::UNIX_EPOCH),
+            window_secs: 43_200,
+            probe_kind: "codex_sessions".into(),
+            path_hash: Some("blake3:abc".into()),
+            probe_error: None,
+            scan_truncated: false,
+            confidence: Confidence::Low,
+        });
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("possible_hook_activity_silent"));
+        assert!(s.contains("\"confidence\":\"low\""));
+        assert!(s.contains("1970-01-01T00:00:00Z")); // rfc3339 wire format guard
+        assert!(!s.contains("\"path\"")); // raw path never serialized
         let back: Evidence = serde_json::from_str(&s).unwrap();
         assert_eq!(back, ev);
     }

--- a/crates/sigil-core/src/policy/mod.rs
+++ b/crates/sigil-core/src/policy/mod.rs
@@ -194,10 +194,91 @@ pub struct PolicyDocument {
     // the agent); intentionally not threaded into EffectivePolicy.
     #[serde(default)]
     pub on_failure: deny_rule::FailMode,
+    /// #107 — opt-in hook-silence detection config. Empty `enabled_agents` = feature OFF.
+    #[serde(default)]
+    pub hook_silence: HookSilenceCfg,
 }
 
 fn default_host_id_strategy() -> HostIdStrategy {
     HostIdStrategy::MachineId
+}
+
+fn dflt_window() -> u64 {
+    43_200
+}
+fn dflt_horizon() -> u64 {
+    604_800
+}
+fn dflt_tick() -> u64 {
+    1_800
+}
+fn dflt_max_entries() -> usize {
+    256
+}
+fn dflt_max_depth() -> usize {
+    3
+}
+fn dflt_budget_ms() -> u64 {
+    50
+}
+
+/// Caps bounding the cost (and privacy exposure) of one session-dir probe scan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProbeCap {
+    /// Max directory entries visited per probe scan.
+    #[serde(default = "dflt_max_entries")]
+    pub max_entries: usize,
+    /// Max directory-traversal depth per probe scan.
+    #[serde(default = "dflt_max_depth")]
+    pub max_depth: usize,
+    /// Wall-time budget per probe scan, in milliseconds.
+    #[serde(default = "dflt_budget_ms")]
+    pub budget_ms: u64,
+}
+impl Default for ProbeCap {
+    fn default() -> Self {
+        Self {
+            max_entries: dflt_max_entries(),
+            max_depth: dflt_max_depth(),
+            budget_ms: dflt_budget_ms(),
+        }
+    }
+}
+
+/// #107 — opt-in hook-silence detection. Empty `enabled_agents` = feature OFF.
+/// When enabled for an agent, the daemon flags it when it has recent session
+/// activity but its hook has gone silent (a low-confidence tamper hint).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookSilenceCfg {
+    /// Per-agent opt-in allowlist. Empty = the whole feature is off.
+    #[serde(default)]
+    pub enabled_agents: Vec<crate::event::AiTool>,
+    /// Silence window W (seconds): an opted-in agent with session activity but
+    /// zero hook events for longer than this is flagged (default 43200 = 12h).
+    #[serde(default = "dflt_window")]
+    pub window_secs: u64,
+    /// Expectation horizon H (seconds): an agent is only eligible to be flagged
+    /// if its last hook event was within this long; older = treated as
+    /// abandoned and never flagged (default 604800 = 7d).
+    #[serde(default = "dflt_horizon")]
+    pub horizon_secs: u64,
+    /// How often the detector sweeps, in seconds (default 1800 = 30min).
+    #[serde(default = "dflt_tick")]
+    pub tick_secs: u64,
+    /// Caps on the per-agent session-directory scan.
+    #[serde(default)]
+    pub probe_cap: ProbeCap,
+}
+impl Default for HookSilenceCfg {
+    fn default() -> Self {
+        Self {
+            enabled_agents: vec![],
+            window_secs: dflt_window(),
+            horizon_secs: dflt_horizon(),
+            tick_secs: dflt_tick(),
+            probe_cap: ProbeCap::default(),
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -268,6 +349,8 @@ pub struct EffectivePolicy {
     /// Stage 2 (#100) — operator deny rules forwarded from user PolicyDocument.
     /// Empty = no enforcement (observe-only).
     pub hook_deny_rules: Vec<deny_rule::DenyRule>,
+    /// #107 — opt-in hook-silence detection config forwarded from user PolicyDocument.
+    pub hook_silence: HookSilenceCfg,
 }
 
 /// Merge a defaults document and a user-override document into an effective policy.
@@ -379,6 +462,11 @@ pub fn merge(
         .map(|u| u.hook_deny_rules.clone())
         .unwrap_or_default();
 
+    let hook_silence = user
+        .as_ref()
+        .map(|u| u.hook_silence.clone())
+        .unwrap_or_default();
+
     Ok(EffectivePolicy {
         host_id_strategy: strategy,
         targets: by_id,
@@ -391,6 +479,7 @@ pub fn merge(
         rule_packs,
         rubric_overrides,
         hook_deny_rules,
+        hook_silence,
     })
 }
 
@@ -426,6 +515,7 @@ pub fn defaults() -> Result<PolicyDocument, PolicyError> {
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         }),
     }
 }
@@ -563,6 +653,7 @@ targets:
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         }
     }
 
@@ -632,6 +723,7 @@ targets:
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
         let ids: Vec<&str> = eff.targets.iter().map(|t| t.id.as_str()).collect();
@@ -659,6 +751,7 @@ targets:
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
         assert_eq!(eff.targets[0].tier, Tier::Standard);
@@ -685,6 +778,7 @@ targets:
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let err = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::UnknownOverrideId(_)));
@@ -707,6 +801,7 @@ targets:
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let err = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::DuplicateId(_)));
@@ -733,6 +828,7 @@ targets:
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let err = merge(defaults, None, None, Platform::Macos).unwrap_err();
         assert!(matches!(err, PolicyError::EmptyTargets));
@@ -1047,6 +1143,7 @@ host_id_strategy: hostname
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         user.rubric_overrides
             .insert("destructive_in_hook_script".into(), 5.5);
@@ -1120,6 +1217,7 @@ host_id_strategy: hostname
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: deny_rule::FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let eff = merge(defaults().unwrap(), Some(user), None, current_platform()).unwrap();
         assert_eq!(eff.gemini_workspaces, vec!["~/src/a".to_string()]);
@@ -1133,5 +1231,34 @@ host_id_strategy: hostname
         let doc = parse(yaml_minimal()).unwrap();
         assert!(doc.hook_deny_rules.is_empty());
         assert_eq!(doc.on_failure, FailMode::Open);
+    }
+
+    #[test]
+    fn hook_silence_defaults_disabled() {
+        let doc: PolicyDocument = parse(
+            "version: 1\ntargets:\n  - id: t\n    description: x\n    tier: standard\n    platform: any\n    paths: [\"~/x\"]\n",
+        ).unwrap();
+        assert!(doc.hook_silence.enabled_agents.is_empty());
+        assert_eq!(doc.hook_silence.window_secs, 43_200);
+        assert_eq!(doc.hook_silence.horizon_secs, 604_800);
+        assert_eq!(doc.hook_silence.tick_secs, 1_800);
+        assert_eq!(doc.hook_silence.probe_cap.max_entries, 256);
+        assert_eq!(doc.hook_silence.probe_cap.max_depth, 3);
+        assert_eq!(doc.hook_silence.probe_cap.budget_ms, 50);
+    }
+
+    #[test]
+    fn merge_forwards_hook_silence_from_user() {
+        let user: PolicyDocument = parse(
+            "version: 1\ntargets: []\nhook_silence:\n  enabled_agents: [codex]\n  window_secs: 60\n",
+        ).unwrap();
+        let eff = merge(defaults_doc(), Some(user), None, Platform::Macos).unwrap();
+        assert_eq!(
+            eff.hook_silence.enabled_agents,
+            vec![crate::event::AiTool::Codex]
+        );
+        assert_eq!(eff.hook_silence.window_secs, 60);
+        // a field absent from the user's partial block still takes the documented default
+        assert_eq!(eff.hook_silence.horizon_secs, 604_800);
     }
 }

--- a/crates/sigil-core/tests/properties.rs
+++ b/crates/sigil-core/tests/properties.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use sigil_core::debounce::Debouncer;
 use sigil_core::event::{Event, FileChangeKind};
 use sigil_core::policy::{
-    merge, FailMode, HostIdStrategy, Platform, PolicyDocument, Tier, WatchTarget,
+    merge, FailMode, HookSilenceCfg, HostIdStrategy, Platform, PolicyDocument, Tier, WatchTarget,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -47,6 +47,7 @@ proptest! {
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let r1 = merge(defaults.clone(), None, None, Platform::Any).unwrap();
         let r2 = merge(defaults, None, None, Platform::Any).unwrap();
@@ -77,6 +78,7 @@ proptest! {
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let user = PolicyDocument {
             version: 1,
@@ -93,6 +95,7 @@ proptest! {
             rubric_overrides: HashMap::new(),
             hook_deny_rules: vec![],
             on_failure: FailMode::Open,
+            hook_silence: HookSilenceCfg::default(),
         };
         let res = merge(defaults, Some(user), None, Platform::Any);
         prop_assert!(res.is_err());

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -141,6 +141,7 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
         Evidence::HookInvocation(_)
         | Evidence::HookDecision(_)
         | Evidence::HookConfigDrift(_)
+        | Evidence::PossibleHookActivitySilent(_)
         | Evidence::Unknown => {
             // Hook observe/decision/drift events are not indexed into the fleet rollup
             // (slice 1); the severity-bucket increment above already counts them.


### PR DESCRIPTION
Implements **#107** — the counterweight to config-drift detection (#109). The independent `sigil-agent` daemon emits a **low-confidence** `PossibleHookActivitySilent` tamper-hint when an agent it *recently observed using its hook* goes hook-silent **while its session files are still being written**. The detector is the daemon, not the (tamperable) hook — the only vantage robust to in-domain self-tampering.

Locked spec (rev2, full codex adversarial-review adoption): `docs/superpowers/specs/2026-06-06-hook-silence-detection-design.html`.

## Threat model (honest, drives the design)
Anything that can neutralize the hook runs **as the same user** and can keep `last_hook_event_at` fresh (forge a `hook.sock` event) or spoof the session-dir mtime. So this is a **low-confidence hint against non-adaptive failure** (accidental removal, careless/sloppy bypass, full neutralization) — **not** a defense against a knowledgeable same-uid attacker. Encoded as: event name `Possible…`, `confidence = Low` always, `Severity::Warn`, and **default-OFF / per-agent opt-in**.

## What's here (8 TDD commits)
- `Evidence::PossibleHookActivitySilent` + `Confidence` enum (additive; `#[serde(other)]` forward-compat preserved; raw path **never** on the wire — only a blake3 `path_hash`).
- `hook_silence` policy block (`HookSilenceCfg`): opt-in `enabled_agents` (empty = OFF), `window_secs` (12h), `horizon_secs` (7d), `tick_secs` (30m), `probe_cap`.
- In-memory per-`(agent,uid)` activity record + pure `decide()` (expected-within-horizon, silent-while-active, clock-skew clamp; `SilenceDecider`-style isolated rule, learned-cadence deferred).
- `record_hook_event()` updated **at receive in both listeners, before the lossy `try_send`** (D6 — dropped-on-backpressure observations don't become false silence).
- Capped, hashed-path session-activity probe (weak/spoofable oracle by design; versioned per-agent allowlist; strict caps).
- `silence_task`: opt-in periodic driver, one event per silence episode, re-arms on resumed hook traffic; supervised via `sup.track`.
- Runtime wires ONE shared activity map into both listeners + the task.

## Scope / non-goals (per spec "Out")
No learned cadence, no per-session correlation, no defense vs adaptive same-uid attacker, no enforcement, no cross-host rollup, in-memory only (restart clears → no alarm until re-observed). Producer-side, OSS, mechanism-only.

## Tests / gate
`cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo test --workspace` green **except** the pre-existing `basic_events::it_emits_modified_event` macOS FSEvents flake (#108) — which **fails identically on `main`** on this host (env/timing, not a regression; Linux CI unaffected). New tests: event round-trip + no-path-leak; policy defaults/merge; `decide()` (incl. boundary + clock-skew); `record_hook_event`; capped probe (entries/depth/missing/hash); `silence_task` (emit-once/disabled/inactive/re-arm/restart/decayed); runtime no-op-when-disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)