### PR TITLE
feat(hook): onboard Grok Build (xAI) — observe + enforce (#110)

### DIFF
--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -383,6 +383,7 @@ fn print_ai_guard_live(rep: &crate::control::DoctorAiGuardReport) {
                 sigil_core::event::AiTool::Gemini => "gemini",
                 sigil_core::event::AiTool::Cursor => "cursor",
                 sigil_core::event::AiTool::Antigravity => "antigravity",
+                sigil_core::event::AiTool::Grok => "grok",
                 sigil_core::event::AiTool::Other => "other",
             };
             let scope_str = match &r.scope {
@@ -428,6 +429,7 @@ fn format_parsers_summary(parsers: &[crate::control::ParserInfo]) -> String {
             sigil_core::event::AiTool::Gemini => "gemini",
             sigil_core::event::AiTool::Cursor => "cursor",
             sigil_core::event::AiTool::Antigravity => "antigravity",
+            sigil_core::event::AiTool::Grok => "grok",
             sigil_core::event::AiTool::Other => "other",
         };
         *counts.entry(key.to_string()).or_insert(0) += 1;

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -343,6 +343,7 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
             Cursor => new_cursor.iter().cloned().collect(),
             Antigravity => new_antigravity.iter().cloned().collect(),
             ClaudeDesktop => Vec::new(),
+            Grok => Vec::new(), // #110: no Grok project parser/workspace yet
             Other => Vec::new(),
         }
     };
@@ -562,6 +563,29 @@ mod tests {
     use super::*;
     use crate::runtime::expand_targets;
     use std::time::Duration;
+
+    /// Verify the repos_for_tool closure (as defined in reload()) returns an
+    /// empty Vec for AiTool::Grok — no project parser/workspace registered yet (#110).
+    #[test]
+    fn repos_for_tool_grok_is_empty() {
+        // Mirror the closure shape from reload(): all empty BTreeSets.
+        let empty: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
+        let repos_for_tool = |tool: sigil_core::event::AiTool| -> Vec<PathBuf> {
+            use sigil_core::event::AiTool::*;
+            match tool {
+                ContinueDev => empty.iter().cloned().collect(),
+                ClaudeCode => empty.iter().cloned().collect(),
+                Codex => empty.iter().cloned().collect(),
+                Gemini => empty.iter().cloned().collect(),
+                Cursor => empty.iter().cloned().collect(),
+                Antigravity => empty.iter().cloned().collect(),
+                ClaudeDesktop => Vec::new(),
+                Grok => Vec::new(), // #110: no Grok project parser/workspace yet
+                Other => Vec::new(),
+            }
+        };
+        assert!(repos_for_tool(sigil_core::event::AiTool::Grok).is_empty());
+    }
 
     fn policy_yaml(target_id: &str, watch_path: &str, tier: &str) -> String {
         format!(

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -259,6 +259,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
             Cursor => &cursor_repos,
             Antigravity => &antigravity_repos,
             ClaudeDesktop => &[],
+            Grok => &[], // #110: no Grok project parser/workspace yet
             Other => &[],
         }
     };
@@ -1383,6 +1384,7 @@ pub(crate) fn tool_display_for_extscript(tool: sigil_core::event::AiTool) -> &'s
         AiTool::Gemini => "gemini",
         AiTool::Cursor => "cursor",
         AiTool::Antigravity => "antigravity",
+        AiTool::Grok => "grok",
         AiTool::Other => "other",
     }
 }

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -577,9 +577,10 @@ fn show_risk(tool: Option<String>, pretty: bool) -> anyhow::Result<i32> {
         Some("codex") => Some(sigil_core::event::AiTool::Codex),
         Some("gemini") => Some(sigil_core::event::AiTool::Gemini),
         Some("cursor") => Some(sigil_core::event::AiTool::Cursor),
+        Some("grok") => Some(sigil_core::event::AiTool::Grok),
         Some("other") => Some(sigil_core::event::AiTool::Other),
         Some(other) => {
-            eprintln!("sigil show risk: unknown --tool '{other}' (expected: claude-code, codex, gemini, cursor)");
+            eprintln!("sigil show risk: unknown --tool '{other}' (expected: claude-code, codex, gemini, cursor, grok)");
             return Ok(2);
         }
     };
@@ -634,6 +635,7 @@ fn write_risk_pretty(w: &mut impl Write, p: &RiskPayload) -> io::Result<()> {
             sigil_core::event::AiTool::Gemini => "gemini",
             sigil_core::event::AiTool::Cursor => "cursor",
             sigil_core::event::AiTool::Antigravity => "antigravity",
+            sigil_core::event::AiTool::Grok => "grok",
             sigil_core::event::AiTool::Other => "other",
         };
         // Use the serde wire string (snake_case) rather than Debug. Robust

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -118,6 +118,8 @@ pub enum AiTool {
     /// Antigravity (Google) — successor to Gemini CLI (Gemini CLI sunset
     /// 2026-06-18). Config reuses the `~/.gemini/` tree. Wire string: "antigravity".
     Antigravity,
+    /// Grok Build (xAI) terminal coding agent. Wire string: "grok".
+    Grok,
     /// Phase 3b.7.5 — an operator-defined tool with no built-in parser. Wire
     /// string: "other". The human name rides `tool_label` (rule pack + event),
     /// never inside the enum, so AiTool stays Copy + a bare-string wire value.
@@ -877,6 +879,13 @@ mod tests {
             serde_json::from_str::<AiTool>(r#""other""#).unwrap(),
             AiTool::Other
         );
+    }
+
+    #[test]
+    fn aitool_grok_wire_string_roundtrips() {
+        assert_eq!(serde_json::to_string(&AiTool::Grok).unwrap(), "\"grok\"");
+        let back: AiTool = serde_json::from_str("\"grok\"").unwrap();
+        assert_eq!(back, AiTool::Grok);
     }
 
     #[test]

--- a/crates/sigil-hook/src/adapters/grok.rs
+++ b/crates/sigil-hook/src/adapters/grok.rs
@@ -1,0 +1,118 @@
+use super::{decision_deny, DenyOutput, HookAdapter};
+use crate::redact::capture;
+use sigil_core::event::AiTool;
+use sigil_core::hook_proto::*;
+
+/// Grok Build PreToolUse hook. camelCase JSON (`toolName`/`toolInput`,
+/// `hookEventName:"pre_tool_use"`). Only the verified shell tool
+/// (`toolName == "run_terminal_command"`; command read from `toolInput.command`)
+/// maps to `Bash`; every other tool is `Other` until its payload is
+/// hardware-verified. Deny is Cursor-style `{"decision":"deny"}`.
+pub struct Grok;
+
+impl HookAdapter for Grok {
+    fn agent(&self) -> AiTool {
+        AiTool::Grok
+    }
+
+    fn normalize(
+        &self,
+        p: &serde_json::Value,
+        level: CaptureLevel,
+    ) -> Result<HookInvocation, CaptureStatus> {
+        let tool = p
+            .get("toolName")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptureStatus::Malformed)?;
+        let input = p
+            .get("toolInput")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        let action = if tool == "run_terminal_command" {
+            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let c = capture(cmd, level);
+            HookAction::Bash {
+                command_hash: c.hash,
+                command_preview: c.preview,
+            }
+        } else {
+            let detail = serde_json::to_string(&input).unwrap_or_default();
+            let c = capture(&detail, level);
+            HookAction::Other {
+                label: tool.to_string(),
+                detail_hash: c.hash,
+                detail_preview: c.preview,
+            }
+        };
+
+        Ok(HookInvocation {
+            agent: AiTool::Grok,
+            agent_session_id: p
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            tool_use_id: p
+                .get("toolUseId")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            action,
+            capture_level: level,
+            capture_status: CaptureStatus::Ok,
+            cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
+        })
+    }
+
+    fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
+        decision_deny(rule_id, reason)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigil_core::hook_proto::{CaptureLevel, HookAction};
+
+    fn payload(tool: &str, input: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({ "hookEventName":"pre_tool_use", "toolName": tool,
+            "toolInput": input, "sessionId":"s", "cwd":"/x" })
+    }
+
+    #[test]
+    fn normalize_run_terminal_command_is_bash() {
+        let p = payload(
+            "run_terminal_command",
+            serde_json::json!({"command":"echo hi"}),
+        );
+        let inv = Grok.normalize(&p, CaptureLevel::Redacted).unwrap();
+        assert_eq!(inv.agent, AiTool::Grok);
+        assert!(matches!(inv.action, HookAction::Bash { .. }));
+    }
+
+    #[test]
+    fn normalize_read_file_is_other_not_fileedit() {
+        let p = payload("read_file", serde_json::json!({"path":"/etc/hosts"}));
+        let inv = Grok.normalize(&p, CaptureLevel::Redacted).unwrap();
+        match inv.action {
+            HookAction::Other { label, .. } => assert_eq!(label, "read_file"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_tool_name_is_malformed() {
+        let p = serde_json::json!({ "hookEventName":"pre_tool_use", "toolInput":{"command":"x"} });
+        assert_eq!(
+            Grok.normalize(&p, CaptureLevel::Redacted).unwrap_err(),
+            CaptureStatus::Malformed
+        );
+    }
+
+    #[test]
+    fn grok_deny_output_is_decision_deny() {
+        assert_eq!(
+            Grok.deny_output("no-rm", "x").stdout,
+            crate::adapters::decision_deny("no-rm", "x").stdout
+        );
+    }
+}

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -4,6 +4,7 @@ pub mod antigravity;
 pub mod claude_code;
 pub mod codex;
 pub mod cursor;
+pub mod grok;
 
 /// What a deny verdict renders to for a given agent: the text to print (the
 /// deny response, if any) and the process exit code. claude-code/codex/
@@ -34,7 +35,6 @@ pub(crate) fn pretooluse_deny(rule_id: &str, reason: &str) -> DenyOutput {
 /// Cursor/Grok-shaped deny: `{"decision":"deny","reason":"…"}` on stdout, exit 0.
 /// Grok honors the deny decision regardless of exit code. Reusable by a future
 /// cursor enforce.
-#[allow(dead_code)] // wired by a later task (Grok adapter override)
 pub(crate) fn decision_deny(rule_id: &str, reason: &str) -> DenyOutput {
     let v = serde_json::json!({
         "decision": "deny",
@@ -70,6 +70,7 @@ pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
         "codex" => Some(Box::new(codex::Codex)),
         "cursor" => Some(Box::new(cursor::Cursor)),
         "antigravity" => Some(Box::new(antigravity::Antigravity)),
+        "grok" => Some(Box::new(grok::Grok)),
         _ => None,
     }
 }

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -31,6 +31,21 @@ pub(crate) fn pretooluse_deny(rule_id: &str, reason: &str) -> DenyOutput {
     }
 }
 
+/// Cursor/Grok-shaped deny: `{"decision":"deny","reason":"…"}` on stdout, exit 0.
+/// Grok honors the deny decision regardless of exit code. Reusable by a future
+/// cursor enforce.
+#[allow(dead_code)] // wired by a later task (Grok adapter override)
+pub(crate) fn decision_deny(rule_id: &str, reason: &str) -> DenyOutput {
+    let v = serde_json::json!({
+        "decision": "deny",
+        "reason": format!("Blocked by Sigil rule {rule_id}: {reason}"),
+    });
+    DenyOutput {
+        stdout: Some(v.to_string()),
+        exit_code: 0,
+    }
+}
+
 /// One impl per agent. Turns a vendor stdin payload into a normalized
 /// HookInvocation. (Shape mirrors ai_guard/parser, but is a distinct trait —
 /// that one assesses on-disk config, this one normalizes runtime stdin.)
@@ -85,5 +100,15 @@ mod tests {
             a.deny_output("no-rm", "destructive").stdout,
             pretooluse_deny("no-rm", "destructive").stdout
         );
+    }
+
+    #[test]
+    fn decision_deny_exact_json_and_exit0() {
+        let out = decision_deny("no-rm", "destructive");
+        assert_eq!(out.exit_code, 0);
+        let s = out.stdout.expect("deny prints stdout");
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["decision"], "deny");
+        assert_eq!(v["reason"], "Blocked by Sigil rule no-rm: destructive");
     }
 }

--- a/crates/sigil-hook/src/install_grok.rs
+++ b/crates/sigil-hook/src/install_grok.rs
@@ -1,0 +1,101 @@
+// Grok install. Unlike the JSON-settings agents in install.rs, Grok loads hooks
+// from a dedicated JSON file at ~/.grok/hooks/sigil-hook.json — Grok's
+// always-trusted native hook dir. This is a dedicated-file agent (like
+// Antigravity), so it must NOT enter the shared-settings merge path.
+//
+// Canonical format (based on Grok's native hook dir):
+//   ~/.grok/hooks/sigil-hook.json
+//   { "hooks": { "PreToolUse": [ { "matcher": "", "hooks": [ { "type": "command", "command": "..." } ] } ] } }
+//
+// The matcher "" means match-all (equivalent to "*" in other agents).
+
+use serde_json::{json, Value};
+use std::io;
+use std::path::{Path, PathBuf};
+
+fn command_string(exe: &str, capture: &str, enforce: bool, on_failure: &str) -> String {
+    if enforce {
+        format!("{exe} grok --enforce --on-failure {on_failure} --capture {capture}")
+    } else {
+        format!("{exe} grok --capture {capture}")
+    }
+}
+
+/// The full hook JSON written to ~/.grok/hooks/sigil-hook.json.
+pub fn hook_json(exe: &str, capture: &str, enforce: bool, on_failure: &str) -> Value {
+    json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "",
+                "hooks": [{ "type": "command", "command": command_string(exe, capture, enforce, on_failure) }]
+            }]
+        }
+    })
+}
+
+/// ~/.grok/hooks/sigil-hook.json (Grok's always-trusted global hook dir).
+pub fn hook_file() -> Option<PathBuf> {
+    crate::install::home_dir().map(|h| h.join(".grok").join("hooks").join("sigil-hook.json"))
+}
+
+/// Write `v` (pretty-printed JSON) to `path`, creating parent dirs as needed.
+/// Idempotent: if the file already has identical content, no write occurs.
+pub fn write_file_at(path: &Path, v: &Value) -> io::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let content = serde_json::to_string_pretty(v).map_err(io::Error::other)?;
+    // Idempotent: skip the write if existing content is identical.
+    if let Ok(existing) = std::fs::read_to_string(path) {
+        if existing == content {
+            return Ok(());
+        }
+    }
+    std::fs::write(path, content.as_bytes())
+}
+
+/// Remove the sigil-hook.json file. If already absent, returns Ok (no error).
+pub fn remove_file_at(path: &Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_json_observe_renders_matcher_all_and_command() {
+        let s = serde_json::to_string(&hook_json("/usr/bin/sigil-hook", "redacted", false, "open"))
+            .unwrap();
+        assert!(s.contains("\"PreToolUse\""));
+        assert!(s.contains("\"matcher\":\"\""));
+        assert!(s.contains("sigil-hook grok"));
+        assert!(s.contains("--capture redacted"));
+        assert!(!s.contains("--enforce"));
+    }
+
+    #[test]
+    fn hook_json_enforce_includes_flags() {
+        let s = serde_json::to_string(&hook_json("/usr/bin/sigil-hook", "redacted", true, "open"))
+            .unwrap();
+        assert!(s.contains("--enforce"));
+        assert!(s.contains("--on-failure open"));
+    }
+
+    #[test]
+    fn write_is_idempotent_and_uninstall_removes_only_our_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("sigil-hook.json");
+        write_file_at(&f, &hook_json("x", "redacted", false, "open")).unwrap();
+        let a = std::fs::read(&f).unwrap();
+        write_file_at(&f, &hook_json("x", "redacted", false, "open")).unwrap();
+        assert_eq!(a, std::fs::read(&f).unwrap()); // idempotent
+        remove_file_at(&f).unwrap();
+        assert!(!f.exists());
+        remove_file_at(&f).unwrap(); // removing again = Ok (no error)
+    }
+}

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -3,6 +3,7 @@ mod decide;
 mod emit;
 mod install;
 mod install_antigravity;
+mod install_grok;
 mod redact;
 mod verify;
 
@@ -186,12 +187,25 @@ enum Cmd {
         capture: CaptureArg,
     },
 
+    /// Grok Build PreToolUse entrypoint: observe (emit, exit 0), or --enforce (deny-decision path).
+    Grok {
+        #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
+        capture: CaptureArg,
+        /// Stage 2: run the synchronous deny-decision path instead of observe.
+        #[arg(long)]
+        enforce: bool,
+        /// Behavior when no verdict is obtainable. Default open (fail-open).
+        #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
+        on_failure: OnFailureArg,
+    },
+
     /// Print (or write) the sigil-hook registration for an agent.
     ///
     /// claude-code | codex | cursor merge into a settings JSON file; antigravity
-    /// is registered as an `agy` plugin bundle (`agy plugin install`).
+    /// is registered as an `agy` plugin bundle (`agy plugin install`); grok
+    /// writes a dedicated ~/.grok/hooks/sigil-hook.json file.
     Install {
-        /// Agent to register with: claude-code | codex | cursor | antigravity.
+        /// Agent to register with: claude-code | codex | cursor | antigravity | grok.
         #[arg(long, default_value = INSTALL_AGENT_DEFAULT)]
         agent: String,
         /// Apply the change to the settings file (default: print only).
@@ -350,6 +364,17 @@ fn main() {
         }
         Cmd::Cursor { capture } => run_hook("cursor", capture.into()),
         Cmd::Antigravity { capture } => run_hook("antigravity", capture.into()),
+        Cmd::Grok {
+            capture,
+            enforce,
+            on_failure,
+        } => {
+            if enforce {
+                run_enforce("grok", capture.into(), on_failure)
+            } else {
+                run_hook("grok", capture.into())
+            }
+        }
         Cmd::Install {
             agent,
             write,
@@ -394,6 +419,12 @@ fn cmd_install(
         return cmd_install_antigravity(&exe, write, capture_str);
     }
 
+    // Grok is not a settings-merge agent: it writes a dedicated
+    // ~/.grok/hooks/sigil-hook.json file. Route before settings_path.
+    if agent == "grok" {
+        return cmd_install_grok(&exe, write, capture_str, enforce, on_failure_str);
+    }
+
     if !write {
         if enforce {
             print!(
@@ -411,9 +442,9 @@ fn cmd_install(
     // guard explicitly so we never write a misleading settings file or print a
     // confusing "already installed (no change)" message. (antigravity is routed
     // to its own plugin path before this point.)
-    if enforce && !matches!(agent, "claude-code" | "codex") {
+    if enforce && !matches!(agent, "claude-code" | "codex" | "grok") {
         eprintln!(
-            "error: enforce-mode install is only supported for claude-code/codex in this slice (agent '{agent}' not registered)"
+            "error: enforce-mode install is only supported for claude-code/codex/grok in this slice (agent '{agent}' not registered)"
         );
         std::process::exit(1);
     }
@@ -496,6 +527,10 @@ fn cmd_uninstall(agent: &str, write: bool) {
         return cmd_uninstall_antigravity(write);
     }
 
+    if agent == "grok" {
+        return cmd_uninstall_grok(write);
+    }
+
     let sp = match install::settings_path(agent) {
         Some(p) => p,
         None => {
@@ -557,6 +592,51 @@ fn cmd_uninstall(agent: &str, write: bool) {
         "sigil-hook: removed {count} entry/entries for {agent} from {}",
         sp.display()
     );
+}
+
+/// Grok install: write ~/.grok/hooks/sigil-hook.json (Grok's always-trusted
+/// native hook dir). Without `--write`, print the JSON + target path.
+fn cmd_install_grok(exe: &str, write: bool, capture: &str, enforce: bool, on_failure: &str) {
+    let v = install_grok::hook_json(exe, capture, enforce, on_failure);
+    let Some(path) = install_grok::hook_file() else {
+        eprintln!("cannot resolve home dir");
+        std::process::exit(1);
+    };
+    if !write {
+        println!(
+            "// Write this to {}:\n{}",
+            path.display(),
+            serde_json::to_string_pretty(&v).unwrap()
+        );
+        return;
+    }
+    match install_grok::write_file_at(&path, &v) {
+        Ok(()) => println!("installed grok hook → {}", path.display()),
+        Err(e) => {
+            eprintln!("write failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Grok uninstall: remove ~/.grok/hooks/sigil-hook.json.
+/// Without `--write`, print what would be removed.
+fn cmd_uninstall_grok(write: bool) {
+    let Some(path) = install_grok::hook_file() else {
+        eprintln!("cannot resolve home dir");
+        std::process::exit(1);
+    };
+    if !write {
+        println!("// Would remove {}", path.display());
+        return;
+    }
+    match install_grok::remove_file_at(&path) {
+        Ok(()) => println!("removed {}", path.display()),
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Antigravity install: materialize the plugin bundle, then register it with

--- a/crates/sigil-hook/tests/enforce_grok_e2e.rs
+++ b/crates/sigil-hook/tests/enforce_grok_e2e.rs
@@ -1,0 +1,120 @@
+//! E2E (#110): `sigil-hook grok --enforce` against a stub decide server.
+#![cfg(unix)]
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// One-shot stub: accept one connection, read the request line, reply with a
+/// fixed verdict. `deny` chooses the verdict.
+fn spawn_stub(socket: std::path::PathBuf, deny: bool) {
+    std::thread::spawn(move || {
+        let listener = UnixListener::bind(&socket).unwrap();
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut line = String::new();
+            BufReader::new(s.try_clone().unwrap())
+                .read_line(&mut line)
+                .unwrap();
+            // Build the response with the EXACT verified wire shape.
+            // HookDecisionResponse { protocol_version, request_id, verdict: HookVerdict { decision, enforcement_mode } }
+            // Decision is serde(tag = "kind", rename_all = "snake_case"):
+            //   Deny { rule_id, reason } → {"kind":"deny","rule_id":"...","reason":"..."}
+            //   Allow → {"kind":"allow"}
+            let decision = if deny {
+                r#"{"kind":"deny","rule_id":"no-rm","reason":"destructive"}"#
+            } else {
+                r#"{"kind":"allow"}"#
+            };
+            let resp = format!(
+                r#"{{"protocol_version":2,"request_id":"00000000-0000-0000-0000-000000000000","verdict":{{"decision":{decision},"enforcement_mode":"enforce"}}}}"#
+            );
+            writeln!(s, "{resp}").unwrap();
+        }
+    });
+}
+
+fn run_grok_enforce(socket: &std::path::Path, stdin_json: &str) -> (String, i32) {
+    let exe = env!("CARGO_BIN_EXE_sigil-hook");
+    let mut child = Command::new(exe)
+        .args(["grok", "--enforce", "--on-failure", "open"])
+        .env("SIGIL_HOOK_DECIDE_SOCKET", socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin_json.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Poll until the stub's listening socket appears (guards the bind race between
+/// the spawned stub thread and the hook process connecting).
+fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..50 {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Build a Grok PreToolUse stdin payload.
+/// Grok uses camelCase: `toolName` / `toolInput.command`, with
+/// `hookEventName:"pre_tool_use"`, `sessionId`, and `cwd`.
+/// Verified against adapters/grok.rs normalize():
+///   - top-level key "toolName" → tool dispatch
+///   - top-level key "toolInput" → nested object
+///   - "toolInput"."command" → Bash command string when toolName == "run_terminal_command"
+// NOTE: cmd must not contain `"` or `\` — interpolated raw into JSON (fine for the simple test commands here).
+fn bash_stdin(cmd: &str) -> String {
+    format!(
+        r#"{{"hookEventName":"pre_tool_use","toolName":"run_terminal_command","toolInput":{{"command":"{cmd}"}},"sessionId":"s","cwd":"/x"}}"#
+    )
+}
+
+#[test]
+fn grok_deny_emits_decision_deny_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), true);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_grok_enforce(&socket, &bash_stdin("rm -rf /"));
+    assert_eq!(code, 0, "hook must always exit 0");
+    assert!(stdout.contains("\"decision\":\"deny\""), "got: {stdout}");
+    assert!(stdout.contains("no-rm"), "got: {stdout}");
+}
+
+#[test]
+fn grok_allow_is_silent() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), false);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_grok_enforce(&socket, &bash_stdin("ls -la"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "allow must print nothing, got: {stdout}"
+    );
+}
+
+#[test]
+fn grok_missing_socket_fails_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("absent.sock"); // never bound
+    let (stdout, code) = run_grok_enforce(&socket, &bash_stdin("rm -rf /"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "fail-open (on_failure=open) → allow, no output"
+    );
+}


### PR DESCRIPTION
Onboards **Grok Build** (xAI's terminal coding agent, grok 0.2.32) as a first-class sigil-hook target — observe + (advisory) enforce at Grok's `PreToolUse` hook, like Claude Code / Codex.

## Hardware-verified contract
Live-tested on grok 0.2.32: an always-deny hook (`{"decision":"deny"}`) **blocked** the command (FIRED, echo didn't run); an observe-only hook (silent exit 0) **allowed** it (echo ran). Native hook dir `~/.grok/hooks/*.json` (always-trusted), camelCase stdin (`toolName:"run_terminal_command"`, `toolInput:{command}`), deny = stdout `{"decision":"deny","reason":"…"}` (honored regardless of exit). Authoritative local docs `~/.grok/docs/user-guide/10-hooks.md`. Locked spec rev2 (full codex adversarial-review adoption — 2 BLOCKER / 4 MAJOR / 2 MINOR).

## What's here (5 commits)
- **`AiTool::Grok`** (wire "grok") + every exhaustive-match arm (the compiler surfaced them; `repos_for_tool` uses an explicit `Grok => &[]`, not a wildcard — no GrokParser, `tool_label` stays None).
- **`adapters/grok.rs`** — normalizes Grok's camelCase payload; **only the verified `run_terminal_command` → `Bash`**, every other tool → `Other{label}` (NOT FileEdit — so an edit-deny rule can't block a read; codex-review BLOCKER fix). `deny_output` → the new Cursor-style `decision_deny`.
- **shared `decision_deny`** (`{"decision":"deny","reason":…}`, exit 0) — reusable by a future cursor enforce.
- **`sigil-hook grok`** entrypoint (observe + `--enforce`/`--on-failure`), mirroring Codex.
- **`install_grok`** — a dedicated `~/.grok/hooks/sigil-hook.json` (always-trusted; matcher `""`), routed **before** the shared-settings merge path (like Antigravity); idempotent write; scoped uninstall.
- **`enforce_grok_e2e.rs`** — drives the real binary over a stub `hook-decide.sock`: Deny → `{"decision":"deny"}`+exit0, Allow → silent exit0, socket-missing → fail-open.

## Scope / honesty
In-domain advisory (claude/codex framing); deny + allow both hardware-verified. **Out of scope (follow-on):** `~/.grok/config.toml` AI Guard parser, Grok `verify`/tamper-evidence, precise FileEdit/McpCall mapping (capture those payloads first), cursor enforce. **Distribution ≠ firing** is not relevant here (the hook is local); Grok's hook is verified to fire. Mechanism-only, OSS.

## Gate
`cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo test --workspace` green **except** the pre-existing `basic_events::it_emits_modified_event` FSEvents flake (#108, fails identically on main). Final holistic review: READY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)