### PR TITLE
feat(hook): Cursor enforce — observe → observe + enforce (#100)

### DIFF
--- a/crates/sigil-hook/src/adapters/cursor.rs
+++ b/crates/sigil-hook/src/adapters/cursor.rs
@@ -97,6 +97,12 @@ impl HookAdapter for Cursor {
     fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
         permission_deny(rule_id, reason)
     }
+
+    /// Cursor blocks empty-stdout allows under `failClosed`, so emit an explicit
+    /// allow. (See `allow_output` on the trait.)
+    fn allow_output(&self) -> Option<String> {
+        Some(serde_json::json!({ "permission": "allow" }).to_string())
+    }
 }
 
 #[cfg(test)]
@@ -170,5 +176,12 @@ mod tests {
         );
         // NOT the default Claude PreToolUse shape
         assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn allow_output_is_permission_allow() {
+        let s = Cursor.allow_output().expect("cursor emits explicit allow");
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["permission"], "allow");
     }
 }

--- a/crates/sigil-hook/src/adapters/cursor.rs
+++ b/crates/sigil-hook/src/adapters/cursor.rs
@@ -1,4 +1,4 @@
-use super::HookAdapter;
+use super::{permission_deny, DenyOutput, HookAdapter};
 use crate::redact::capture;
 use sigil_core::event::AiTool;
 use sigil_core::hook_proto::*;
@@ -91,6 +91,12 @@ impl HookAdapter for Cursor {
             cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
         })
     }
+
+    /// Cursor blocks via a stdout `{"permission":"deny", …}` on exit 0 — not the
+    /// default Claude PreToolUse JSON.
+    fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
+        permission_deny(rule_id, reason)
+    }
 }
 
 #[cfg(test)]
@@ -149,5 +155,20 @@ mod tests {
             Cursor.normalize(&p, CaptureLevel::Redacted).unwrap_err(),
             CaptureStatus::Malformed
         );
+    }
+
+    #[test]
+    fn deny_output_is_permission_deny() {
+        let out = Cursor.deny_output("no-rm", "destructive");
+        assert_eq!(out.exit_code, 0);
+        let s = out.stdout.expect("deny prints stdout");
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["permission"], "deny");
+        assert_eq!(
+            v["agent_message"],
+            "Blocked by Sigil rule no-rm: destructive"
+        );
+        // NOT the default Claude PreToolUse shape
+        assert!(v.get("hookSpecificOutput").is_none());
     }
 }

--- a/crates/sigil-hook/src/adapters/grok.rs
+++ b/crates/sigil-hook/src/adapters/grok.rs
@@ -7,7 +7,7 @@ use sigil_core::hook_proto::*;
 /// `hookEventName:"pre_tool_use"`). Only the verified shell tool
 /// (`toolName == "run_terminal_command"`; command read from `toolInput.command`)
 /// maps to `Bash`; every other tool is `Other` until its payload is
-/// hardware-verified. Deny is Cursor-style `{"decision":"deny"}`.
+/// hardware-verified. Deny is Grok-style `{"decision":"deny"}`.
 pub struct Grok;
 
 impl HookAdapter for Grok {

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -50,7 +50,6 @@ pub(crate) fn decision_deny(rule_id: &str, reason: &str) -> DenyOutput {
 /// on stdout, exit 0. Cursor's `beforeShellExecution`/`beforeMCPExecution` honor a
 /// stdout `permission` field on exit 0 (verified against its bundled hook skill).
 /// Distinct from Grok's `decision_deny` — different field name.
-#[allow(dead_code)] // wired up in the cursor enforce task (next)
 pub(crate) fn permission_deny(rule_id: &str, reason: &str) -> DenyOutput {
     let msg = format!("Blocked by Sigil rule {rule_id}: {reason}");
     let v = serde_json::json!({

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -79,6 +79,16 @@ pub trait HookAdapter {
     fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
         pretooluse_deny(rule_id, reason)
     }
+
+    /// Explicit allow output for a deliberate allow, if the agent needs one.
+    /// Default `None` = stay silent (claude-code/codex/grok: silence == allow).
+    /// Cursor overrides: under `failClosed:true` Cursor treats empty stdout as a
+    /// hook failure and BLOCKS, so a Cursor allow must be an explicit
+    /// `{"permission":"allow"}` (hardware-verified). Keeping this `None` for the
+    /// other agents means an empty-stdout exit there still means allow.
+    fn allow_output(&self) -> Option<String> {
+        None
+    }
 }
 
 pub fn for_agent(name: &str) -> Option<Box<dyn HookAdapter>> {
@@ -118,6 +128,12 @@ mod tests {
             a.deny_output("no-rm", "destructive").stdout,
             pretooluse_deny("no-rm", "destructive").stdout
         );
+    }
+
+    #[test]
+    fn adapter_default_allow_output_is_none() {
+        // claude-code uses the default trait impl => silent allow (None).
+        assert!(claude_code::ClaudeCode.allow_output().is_none());
     }
 
     #[test]

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -32,13 +32,31 @@ pub(crate) fn pretooluse_deny(rule_id: &str, reason: &str) -> DenyOutput {
     }
 }
 
-/// Cursor/Grok-shaped deny: `{"decision":"deny","reason":"…"}` on stdout, exit 0.
-/// Grok honors the deny decision regardless of exit code. Reusable by a future
-/// cursor enforce.
+/// Grok-shaped deny: `{"decision":"deny","reason":"…"}` on stdout, exit 0.
+/// Grok honors the deny decision regardless of exit code. (Cursor uses a
+/// different `permission`-keyed shape — see `permission_deny`.)
 pub(crate) fn decision_deny(rule_id: &str, reason: &str) -> DenyOutput {
     let v = serde_json::json!({
         "decision": "deny",
         "reason": format!("Blocked by Sigil rule {rule_id}: {reason}"),
+    });
+    DenyOutput {
+        stdout: Some(v.to_string()),
+        exit_code: 0,
+    }
+}
+
+/// Cursor-shaped deny: `{"permission":"deny","agent_message":"…","user_message":"…"}`
+/// on stdout, exit 0. Cursor's `beforeShellExecution`/`beforeMCPExecution` honor a
+/// stdout `permission` field on exit 0 (verified against its bundled hook skill).
+/// Distinct from Grok's `decision_deny` — different field name.
+#[allow(dead_code)] // wired up in the cursor enforce task (next)
+pub(crate) fn permission_deny(rule_id: &str, reason: &str) -> DenyOutput {
+    let msg = format!("Blocked by Sigil rule {rule_id}: {reason}");
+    let v = serde_json::json!({
+        "permission": "deny",
+        "agent_message": msg,
+        "user_message": msg,
     });
     DenyOutput {
         stdout: Some(v.to_string()),
@@ -111,5 +129,22 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&s).unwrap();
         assert_eq!(v["decision"], "deny");
         assert_eq!(v["reason"], "Blocked by Sigil rule no-rm: destructive");
+    }
+
+    #[test]
+    fn permission_deny_exact_json_and_exit0() {
+        let out = permission_deny("no-rm", "destructive");
+        assert_eq!(out.exit_code, 0);
+        let s = out.stdout.expect("deny prints stdout");
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["permission"], "deny");
+        assert_eq!(
+            v["agent_message"],
+            "Blocked by Sigil rule no-rm: destructive"
+        );
+        assert_eq!(
+            v["user_message"],
+            "Blocked by Sigil rule no-rm: destructive"
+        );
     }
 }

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -127,7 +127,27 @@ fn cursor_entry_is_ours(entry: &Value, exe: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn merge_cursor(root: &mut Value, exe: &str, cmd: &str) -> bool {
+/// The settings entry object for our hook on a Cursor event. Observe = bare
+/// command; enforce-closed additionally carries `failClosed:true`, coupling our
+/// `--on-failure closed` to Cursor's own fail-closed so a hook process that
+/// crashes / times out / returns invalid JSON blocks the tool call instead of
+/// failing open.
+fn cursor_observe_entry(cmd: &str) -> Value {
+    cursor_enforce_entry(cmd, "open")
+}
+
+fn cursor_enforce_entry(cmd: &str, on_failure: &str) -> Value {
+    if on_failure == "closed" {
+        json!({ "command": cmd, "failClosed": true })
+    } else {
+        json!({ "command": cmd })
+    }
+}
+
+/// Upsert our prebuilt entry on BOTH Cursor gate events, keyed by exe first-token.
+/// Replaces the whole entry object on change (so a stale `failClosed` from a prior
+/// closed install is dropped on a later open install). Returns true if changed.
+fn upsert_cursor_entry(root: &mut Value, exe: &str, entry: &Value) -> bool {
     if !root.is_object() {
         *root = json!({});
     }
@@ -149,18 +169,26 @@ fn merge_cursor(root: &mut Value, exe: &str, cmd: &str) -> bool {
         };
         match arr.iter().position(|e| cursor_entry_is_ours(e, exe)) {
             Some(i) => {
-                if arr[i].get("command").and_then(|c| c.as_str()) != Some(cmd) {
-                    arr[i] = json!({ "command": cmd });
+                if &arr[i] != entry {
+                    arr[i] = entry.clone();
                     changed = true;
                 }
             }
             None => {
-                arr.push(json!({ "command": cmd }));
+                arr.push(entry.clone());
                 changed = true;
             }
         }
     }
     changed
+}
+
+fn merge_cursor(root: &mut Value, exe: &str, cmd: &str) -> bool {
+    upsert_cursor_entry(root, exe, &cursor_observe_entry(cmd))
+}
+
+fn merge_cursor_enforce(root: &mut Value, exe: &str, cmd: &str, on_failure: &str) -> bool {
+    upsert_cursor_entry(root, exe, &cursor_enforce_entry(cmd, on_failure))
 }
 
 // ---------------------------------------------------------------------------
@@ -169,7 +197,9 @@ fn merge_cursor(root: &mut Value, exe: &str, cmd: &str) -> bool {
 
 /// Shared body for `render_block` / `render_block_enforce`: builds the
 /// human-pasteable settings fragment + undo hint for a prebuilt command string.
-fn render_block_inner(cmd: &str, agent: &str) -> String {
+/// `cursor_entry` is the pre-built Cursor entry object (observe or enforce with
+/// optional `failClosed`) — used only for the Cursor format arm.
+fn render_block_inner(cmd: &str, agent: &str, cursor_entry: &Value) -> String {
     let Some(fmt) = agent_format(agent) else {
         return format!("// unsupported agent '{agent}'\n");
     };
@@ -181,8 +211,8 @@ fn render_block_inner(cmd: &str, agent: &str) -> String {
         HookFormat::Cursor => json!({
             "version": 1,
             "hooks": {
-                "beforeShellExecution": [{ "command": cmd }],
-                "beforeMCPExecution": [{ "command": cmd }],
+                "beforeShellExecution": [cursor_entry],
+                "beforeMCPExecution": [cursor_entry],
             }
         }),
     };
@@ -202,7 +232,7 @@ fn render_block_inner(cmd: &str, agent: &str) -> String {
 /// Human-pasteable block showing the settings fragment + undo hint.
 pub fn render_block(exe: &str, agent: &str, capture: &str) -> String {
     let cmd = command_string(exe, agent, capture);
-    render_block_inner(&cmd, agent)
+    render_block_inner(&cmd, agent, &cursor_observe_entry(&cmd))
 }
 
 /// Idempotently ensure the sigil-hook entry is present. Returns `true` if the
@@ -220,14 +250,14 @@ pub fn merge_into(root: &mut Value, exe: &str, agent: &str, capture: &str) -> bo
 /// (deny-decision) path with the given on_failure mode.
 pub fn render_block_enforce(exe: &str, agent: &str, capture: &str, on_failure: &str) -> String {
     let cmd = command_string_enforce(exe, agent, capture, on_failure);
-    render_block_inner(&cmd, agent)
+    render_block_inner(&cmd, agent, &cursor_enforce_entry(&cmd, on_failure))
 }
 
 /// Merge an enforce-mode registration into the settings JSON.
-/// For claude-code (NestedPreToolUse): merges with the enforce command string.
-/// For Cursor and unknown agents: returns false (not supported in slice 1).
-///
-/// Enforce install is for the NestedPreToolUse agents (claude-code, codex); the CLI guards other agents before reaching here.
+/// For claude-code / codex (NestedPreToolUse): merges with the enforce command string.
+/// For Cursor: upserts both gate-event entries; adds `failClosed:true` when
+/// `on_failure == "closed"` to couple Cursor's own fail-closed behaviour to ours.
+/// Returns `true` if the document was modified, `false` if already up-to-date.
 pub fn merge_into_enforce(
     root: &mut Value,
     exe: &str,
@@ -238,7 +268,7 @@ pub fn merge_into_enforce(
     let cmd = command_string_enforce(exe, agent, capture, on_failure);
     match agent_format(agent) {
         Some(HookFormat::NestedPreToolUse) => merge_claude(pretooluse_array_mut(root), exe, &cmd),
-        Some(HookFormat::Cursor) => false,
+        Some(HookFormat::Cursor) => merge_cursor_enforce(root, exe, &cmd, on_failure),
         None => false,
     }
 }
@@ -533,6 +563,117 @@ mod tests {
     fn unsupported_agent_paths() {
         assert!(settings_path("nope").is_none());
         assert_eq!(count_sigil_entries(&json!({}), "/x", "nope"), 0);
+    }
+
+    // --- Cursor enforce ---
+
+    #[test]
+    fn cursor_enforce_registers_both_events_with_failclosed() {
+        let mut v = json!({});
+        assert!(merge_into_enforce(
+            &mut v,
+            "/abs/sigil-hook",
+            "cursor",
+            "redacted",
+            "closed"
+        ));
+        for ev in CURSOR_EVENTS {
+            let arr = v["hooks"][ev].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "{ev} has exactly one entry");
+            assert_eq!(arr[0]["failClosed"], json!(true));
+            let cmd = arr[0]["command"].as_str().unwrap();
+            assert!(cmd.contains("--enforce"), "got: {cmd}");
+            assert!(cmd.contains("--on-failure closed"), "got: {cmd}");
+        }
+        // idempotent
+        assert!(!merge_into_enforce(
+            &mut v,
+            "/abs/sigil-hook",
+            "cursor",
+            "redacted",
+            "closed"
+        ));
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook", "cursor"), 2);
+    }
+
+    #[test]
+    fn cursor_enforce_open_has_no_failclosed() {
+        let mut v = json!({});
+        merge_into_enforce(&mut v, "/abs/sigil-hook", "cursor", "redacted", "open");
+        let arr = v["hooks"]["beforeShellExecution"].as_array().unwrap();
+        assert!(arr[0].get("failClosed").is_none());
+    }
+
+    #[test]
+    fn cursor_closed_to_open_strips_failclosed() {
+        let mut v = json!({});
+        merge_into_enforce(&mut v, "/abs/sigil-hook", "cursor", "redacted", "closed");
+        assert!(merge_into_enforce(
+            &mut v,
+            "/abs/sigil-hook",
+            "cursor",
+            "redacted",
+            "open"
+        ));
+        let arr = v["hooks"]["beforeShellExecution"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(
+            arr[0].get("failClosed").is_none(),
+            "stale failClosed must be removed"
+        );
+        assert_eq!(
+            arr[0].as_object().unwrap().len(),
+            1,
+            "entry is exactly {{command}}"
+        );
+    }
+
+    #[test]
+    fn cursor_observe_to_enforce_replaces_in_place() {
+        let mut v = json!({});
+        merge_into(&mut v, "/abs/sigil-hook", "cursor", "redacted");
+        assert!(merge_into_enforce(
+            &mut v,
+            "/abs/sigil-hook",
+            "cursor",
+            "redacted",
+            "open"
+        ));
+        // replaced, not stacked: still one per event (2 total)
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook", "cursor"), 2);
+        let arr = v["hooks"]["beforeShellExecution"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(arr[0]["command"].as_str().unwrap().contains("--enforce"));
+    }
+
+    #[test]
+    fn cursor_enforce_to_observe_strips_enforce() {
+        let mut v = json!({});
+        merge_into_enforce(&mut v, "/abs/sigil-hook", "cursor", "redacted", "closed");
+        assert!(merge_into(&mut v, "/abs/sigil-hook", "cursor", "redacted"));
+        let arr = v["hooks"]["beforeShellExecution"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let entry = arr[0].as_object().unwrap();
+        assert_eq!(entry.len(), 1, "downgrade leaves exactly {{command}}");
+        assert!(!entry["command"].as_str().unwrap().contains("--enforce"));
+        assert!(
+            entry.get("failClosed").is_none(),
+            "stale failClosed stripped on downgrade"
+        );
+    }
+
+    #[test]
+    fn cursor_enforce_preview_closed_shows_failclosed() {
+        let s = render_block_enforce("/abs/sigil-hook", "cursor", "redacted", "closed");
+        assert!(
+            s.contains("\"failClosed\": true"),
+            "closed preview must show failClosed:\n{s}"
+        );
+        let open = render_block_enforce("/abs/sigil-hook", "cursor", "redacted", "open");
+        assert!(
+            !open.contains("failClosed"),
+            "open preview must NOT show failClosed:\n{open}"
+        );
     }
 
     // --- write_baseline records the actual installed command ---

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -175,10 +175,16 @@ enum Cmd {
         on_failure: OnFailureArg,
     },
 
-    /// Cursor before{Shell,MCP}Execution entrypoint: read stdin, emit, exit 0.
+    /// Cursor before{Shell,MCP}Execution entrypoint: observe (emit, exit 0), or --enforce (deny-decision path).
     Cursor {
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
         capture: CaptureArg,
+        /// Stage 2: run the synchronous deny-decision path instead of observe.
+        #[arg(long)]
+        enforce: bool,
+        /// Behavior when no verdict is obtainable. Default open (fail-open).
+        #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
+        on_failure: OnFailureArg,
     },
 
     /// Antigravity PreToolUse entrypoint: read stdin, emit, exit 0.
@@ -362,7 +368,17 @@ fn main() {
                 run_hook("codex", capture.into())
             }
         }
-        Cmd::Cursor { capture } => run_hook("cursor", capture.into()),
+        Cmd::Cursor {
+            capture,
+            enforce,
+            on_failure,
+        } => {
+            if enforce {
+                run_enforce("cursor", capture.into(), on_failure)
+            } else {
+                run_hook("cursor", capture.into())
+            }
+        }
         Cmd::Antigravity { capture } => run_hook("antigravity", capture.into()),
         Cmd::Grok {
             capture,
@@ -438,13 +454,14 @@ fn cmd_install(
     }
 
     // Enforce-mode --write is supported for the NestedPreToolUse agents
-    // (claude-code, codex) in this slice. For any other agent (cursor, unknown),
-    // guard explicitly so we never write a misleading settings file or print a
-    // confusing "already installed (no change)" message. (antigravity is routed
-    // to its own plugin path before this point.)
-    if enforce && !matches!(agent, "claude-code" | "codex" | "grok") {
+    // (claude-code, codex), for cursor (beforeShellExecution/beforeMCPExecution),
+    // and for grok (native ~/.grok/hooks). Guard any other agent so we never
+    // write a misleading settings file. (antigravity routes to its own plugin
+    // path above; grok routes to cmd_install_grok above — so by here the only
+    // enforce-capable agents reaching the generic path are claude-code/codex/cursor.)
+    if enforce && !matches!(agent, "claude-code" | "codex" | "grok" | "cursor") {
         eprintln!(
-            "error: enforce-mode install is only supported for claude-code/codex/grok in this slice (agent '{agent}' not registered)"
+            "error: enforce-mode install is only supported for claude-code/codex/grok/cursor in this slice (agent '{agent}' not registered)"
         );
         std::process::exit(1);
     }
@@ -499,18 +516,25 @@ fn cmd_install(
         std::process::exit(1);
     }
 
-    // Write baseline / update discovery index.
-    if let Err(e) = install::write_baseline(
-        agent,
-        &sp,
-        &exe,
-        agent,
-        capture_str,
-        "*",
-        enforce,
-        on_failure_str,
-    ) {
-        eprintln!("warning: could not write baseline: {e}");
+    // Write baseline / update discovery index. Only for agents whose `verify`
+    // path is implemented (claude-code/codex). Cursor's settings use
+    // beforeShellExecution/beforeMCPExecution, which slice-1 verify can't check,
+    // and the baseline is a single global file — a cursor baseline would both
+    // false-positive `verify` and clobber the claude one (spec D6). (grok and
+    // antigravity never reach here; they return to their own install fns above.)
+    if matches!(agent, "claude-code" | "codex") {
+        if let Err(e) = install::write_baseline(
+            agent,
+            &sp,
+            &exe,
+            agent,
+            capture_str,
+            "*",
+            enforce,
+            on_failure_str,
+        ) {
+            eprintln!("warning: could not write baseline: {e}");
+        }
     }
 
     if changed {

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -274,7 +274,10 @@ enum OnFailureArg {
 const DECISION_DEADLINE: Duration = Duration::from_millis(250);
 
 /// Per-agent enforce entrypoint. Panic-safe; never hangs past the watchdog.
-/// On Deny → emit the agent's deny output; on Allow → nothing.
+/// On Deny → emit the agent's deny output; on a deliberate Allow → emit the
+/// agent's allow output (empty for agents where silence==allow). A
+/// panic/watchdog exits silently (empty stdout), which Cursor's failClosed
+/// converts to a block in closed mode.
 /// No verdict (daemon down / timeout / malformed) → apply on_failure.
 fn run_enforce(agent: &str, capture: CaptureLevel, on_failure: OnFailureArg) -> ! {
     std::panic::set_hook(Box::new(|_| std::process::exit(0)));
@@ -318,10 +321,10 @@ fn run_enforce(agent: &str, capture: CaptureLevel, on_failure: OnFailureArg) -> 
                 emit_deny(&*adapter, &rule_id, &reason);
             }
             // Allow, or a Deny down-shifted to Observe → do not block.
-            _ => std::process::exit(0),
+            _ => emit_allow(&*adapter),
         },
         None => match on_failure {
-            OnFailureArg::Open => std::process::exit(0),
+            OnFailureArg::Open => emit_allow(&*adapter),
             OnFailureArg::Closed => {
                 emit_deny(
                     &*adapter,
@@ -331,6 +334,16 @@ fn run_enforce(agent: &str, capture: CaptureLevel, on_failure: OnFailureArg) -> 
             }
         },
     }
+}
+
+/// Emit the adapter's explicit allow output (if any) and exit 0. Used on every
+/// DELIBERATE-allow branch so the only empty-stdout exit is a panic/watchdog
+/// failure — which Cursor's failClosed converts to a block in closed mode.
+fn emit_allow(adapter: &dyn adapters::HookAdapter) -> ! {
+    if let Some(s) = adapter.allow_output() {
+        println!("{s}");
+    }
+    std::process::exit(0);
 }
 
 /// Print the adapter's deny output (if any) and exit with its code.

--- a/crates/sigil-hook/tests/enforce_cursor_e2e.rs
+++ b/crates/sigil-hook/tests/enforce_cursor_e2e.rs
@@ -85,7 +85,7 @@ fn cursor_deny_emits_permission_deny_json() {
 }
 
 #[test]
-fn cursor_allow_is_silent() {
+fn cursor_allow_emits_permission_allow() {
     let dir = tempfile::tempdir().unwrap();
     let socket = dir.path().join("hook-decide.sock");
     spawn_stub(socket.clone(), false);
@@ -93,8 +93,12 @@ fn cursor_allow_is_silent() {
     let (stdout, code) = run_cursor_enforce(&socket, "open", &shell_stdin("ls -la"));
     assert_eq!(code, 0);
     assert!(
-        stdout.trim().is_empty(),
-        "allow must print nothing, got: {stdout}"
+        stdout.contains("\"permission\":\"allow\""),
+        "allow must be explicit, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"permission\":\"deny\""),
+        "allow must not deny, got: {stdout}"
     );
 }
 
@@ -104,7 +108,10 @@ fn cursor_missing_socket_open_fails_open() {
     let socket = dir.path().join("absent.sock"); // never bound
     let (stdout, code) = run_cursor_enforce(&socket, "open", &shell_stdin("rm -rf /"));
     assert_eq!(code, 0);
-    assert!(stdout.trim().is_empty(), "fail-open → allow, no output");
+    assert!(
+        stdout.contains("\"permission\":\"allow\""),
+        "fail-open now emits explicit allow, got: {stdout}"
+    );
 }
 
 #[test]

--- a/crates/sigil-hook/tests/enforce_cursor_e2e.rs
+++ b/crates/sigil-hook/tests/enforce_cursor_e2e.rs
@@ -1,0 +1,120 @@
+//! E2E (#100): `sigil-hook cursor --enforce` against a stub decide server.
+#![cfg(unix)]
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// One-shot stub: accept one connection, read the request line, reply with a
+/// fixed verdict. `deny` chooses the verdict.
+fn spawn_stub(socket: std::path::PathBuf, deny: bool) {
+    std::thread::spawn(move || {
+        let listener = UnixListener::bind(&socket).unwrap();
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut line = String::new();
+            BufReader::new(s.try_clone().unwrap())
+                .read_line(&mut line)
+                .unwrap();
+            let decision = if deny {
+                r#"{"kind":"deny","rule_id":"no-rm","reason":"destructive"}"#
+            } else {
+                r#"{"kind":"allow"}"#
+            };
+            let resp = format!(
+                r#"{{"protocol_version":2,"request_id":"00000000-0000-0000-0000-000000000000","verdict":{{"decision":{decision},"enforcement_mode":"enforce"}}}}"#
+            );
+            writeln!(s, "{resp}").unwrap();
+        }
+    });
+}
+
+/// Run `sigil-hook cursor --enforce --on-failure <mode>` with the given stdin.
+fn run_cursor_enforce(
+    socket: &std::path::Path,
+    on_failure: &str,
+    stdin_json: &str,
+) -> (String, i32) {
+    let exe = env!("CARGO_BIN_EXE_sigil-hook");
+    let mut child = Command::new(exe)
+        .args(["cursor", "--enforce", "--on-failure", on_failure])
+        .env("SIGIL_HOOK_DECIDE_SOCKET", socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin_json.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..50 {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Cursor `beforeShellExecution` stdin: top-level `command`, snake_case keys.
+fn shell_stdin(cmd: &str) -> String {
+    format!(
+        r#"{{"hook_event_name":"beforeShellExecution","command":"{cmd}","conversation_id":"c","generation_id":"g","cwd":"/x"}}"#
+    )
+}
+
+#[test]
+fn cursor_deny_emits_permission_deny_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), true);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_cursor_enforce(&socket, "open", &shell_stdin("rm -rf /"));
+    assert_eq!(code, 0, "hook must always exit 0");
+    assert!(stdout.contains("\"permission\":\"deny\""), "got: {stdout}");
+    assert!(stdout.contains("no-rm"), "got: {stdout}");
+}
+
+#[test]
+fn cursor_allow_is_silent() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("hook-decide.sock");
+    spawn_stub(socket.clone(), false);
+    wait_for_socket(&socket);
+    let (stdout, code) = run_cursor_enforce(&socket, "open", &shell_stdin("ls -la"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "allow must print nothing, got: {stdout}"
+    );
+}
+
+#[test]
+fn cursor_missing_socket_open_fails_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("absent.sock"); // never bound
+    let (stdout, code) = run_cursor_enforce(&socket, "open", &shell_stdin("rm -rf /"));
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty(), "fail-open → allow, no output");
+}
+
+#[test]
+fn cursor_missing_socket_closed_emits_deny() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("absent.sock"); // never bound
+    let (stdout, code) = run_cursor_enforce(&socket, "closed", &shell_stdin("rm -rf /"));
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("\"permission\":\"deny\""),
+        "fail-closed → deny, got: {stdout}"
+    );
+}

--- a/crates/sigil-hook/tests/install_cursor_enforce.rs
+++ b/crates/sigil-hook/tests/install_cursor_enforce.rs
@@ -1,0 +1,54 @@
+//! CLI e2e (#100): `sigil-hook install --agent cursor --enforce --write` must
+//! actually write both Cursor gate events with the enforce command (+failClosed
+//! when closed), and must NOT write an install baseline for cursor (spec D6).
+#![cfg(unix)]
+use std::process::Command;
+
+#[test]
+fn cursor_enforce_install_writes_both_events_and_no_baseline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let state = home.join("state");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .args([
+            "install",
+            "--agent",
+            "cursor",
+            "--enforce",
+            "--on-failure",
+            "closed",
+            "--write",
+        ])
+        .env("HOME", home)
+        .env("XDG_STATE_HOME", &state)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let hooks = std::fs::read_to_string(home.join(".cursor/hooks.json"))
+        .expect("hooks.json must be written");
+    let v: serde_json::Value = serde_json::from_str(&hooks).unwrap();
+    for ev in ["beforeShellExecution", "beforeMCPExecution"] {
+        let e = &v["hooks"][ev][0];
+        assert!(
+            e["command"].as_str().unwrap().contains("--enforce"),
+            "{ev} entry must use the enforce command, got: {e}"
+        );
+        assert_eq!(
+            e["failClosed"],
+            serde_json::json!(true),
+            "{ev} closed → failClosed"
+        );
+    }
+
+    // D6: no baseline written for cursor.
+    assert!(
+        !state.join("sigil/hook-registration.json").exists(),
+        "cursor install must not write a verify baseline"
+    );
+}


### PR DESCRIPTION
Adds a Stage 2 **enforce** path to the existing Cursor observe adapter — `sigil-hook cursor --enforce` blocks denied tool calls at Cursor's `beforeShellExecution` / `beforeMCPExecution` gate events. Mirrors the shipped Grok/Codex enforce slices, but uses Cursor's own deny contract.

Part of the #100 enforce epic. Producer-side, mechanism-only.

## The contract (hardware-verified)
Cursor's bundled hook skill documents — and a live Cursor IDE run confirmed — that `beforeShellExecution`/`beforeMCPExecution` honor a stdout `permission` field on exit 0:
- **deny** = `{"permission":"deny","agent_message":"…","user_message":"…"}` → Cursor blocks. This is a **distinct shape** from Grok's `{"decision":"deny"}`, so a new `permission_deny` helper is added (the old "Cursor/Grok-shaped" comment on `decision_deny` was wrong and is corrected).
- **allow** = `{"permission":"allow"}` (see the failClosed finding below).

## What's here
- **`permission_deny`** helper + Cursor `deny_output` override (the deny shape).
- **`sigil-hook cursor --enforce [--on-failure open|closed]`** entrypoint, routed through the shared `run_enforce`/`DenyOutput` seam like Grok/Codex.
- **Real Cursor enforce install**: registers the deny command on both gate events. A shared `upsert_cursor_entry` core replaces the whole entry object on change, so mode transitions (observe↔enforce, open↔closed) never stack duplicates or leave stale fields.
- **failClosed coupling**: `--on-failure closed` ⇒ entry gets `failClosed:true` (couples our daemon-down handling to Cursor's own fail-closed). Default install is `--on-failure open` (safe); closed is opt-in.
- **No install baseline for Cursor**: the slice-1 `verify` path is claude-shaped (`hooks.PreToolUse`) and the baseline file is a single global — a Cursor baseline would false-positive `verify` and clobber the claude one. `write_baseline` is gated to claude-code/codex. (Cursor verify/tamper-evidence is a follow-on.)

## Hardware finding → explicit allow output
Live testing found that under `failClosed:true`, Cursor treats an **empty-stdout / exit-0** hook as a *failure* and blocks the tool call ("Hook returned no output"). Our allow path used to exit silently — which would have wrongly blocked **allowed** commands in closed mode.

Fix (a new `allow_output` trait seam, default `None`): the Cursor allow path now emits an explicit `{"permission":"allow"}`. Other agents are unchanged (silence == allow). This also makes closed mode **genuinely** fail-closed: the only remaining empty-stdout exit is a panic/watchdog failure, which `failClosed` now correctly blocks.

Hardware-verified in a live Cursor IDE:
- deny → command **blocked**;
- explicit allow under `failClosed:true` → command **runs**;
- empty-stdout under `failClosed:true` → blocked (the failure path we now reserve for crashes).

## Testing
- Unit: `permission_deny`/`allow_output` exact JSON; install merge (both events, failClosed iff closed, observe↔enforce replace-in-place, closed→open strips failClosed, enforce→observe downgrade, preview shows failClosed); default-None allow contract.
- Integration: CLI full-path install (writes both events + failClosed, **no** baseline) and a socket-level e2e quartet (deny / allow=explicit-allow / fail-open / fail-closed). Grok/Codex/Claude silent-allow tests unchanged and still green.
- `cargo fmt` + `clippy -D warnings` clean; full `sigil-hook` suite green.

## Out of scope (follow-on)
Cursor `verify`/tamper-evidence + cursor baseline; `preToolUse` enforce; `updated_input` rewrite; per-rule on_failure; `show_risk --tool` parser gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)