### PR TITLE
feat(hook): format-aware verify + per-agent baseline (Cursor tamper-evidence) (#120)

### DIFF
--- a/crates/sigil-core/src/hook_proto.rs
+++ b/crates/sigil-core/src/hook_proto.rs
@@ -155,6 +155,7 @@ pub enum DriftKind {
     EntryMissing,
     CommandDrift,
     MatcherDrift,
+    FailModeDrift,
 }
 
 #[cfg(test)]
@@ -258,6 +259,12 @@ mod tests {
         assert!(s.contains("\"drift_kind\":\"matcher_drift\""));
         let back: HookDriftEnvelope = serde_json::from_str(&s).unwrap();
         assert_eq!(back, env);
+    }
+
+    #[test]
+    fn fail_mode_drift_serializes_snake_case() {
+        let s = serde_json::to_value(DriftKind::FailModeDrift).unwrap();
+        assert_eq!(s, serde_json::json!("fail_mode_drift"));
     }
 
     #[test]

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -355,6 +355,18 @@ pub fn state_dir() -> PathBuf {
     }
 }
 
+/// Per-agent baseline path, only for agents with a known hook format (so a raw
+/// `--agent` string can never be interpolated into a traversal path).
+pub(crate) fn baseline_path_in(dir: &std::path::Path, agent: &str) -> Option<PathBuf> {
+    agent_format(agent)?; // validate: known slug only
+    Some(dir.join(format!("hook-registration-{agent}.json")))
+}
+
+#[allow(dead_code)] // consumed by verify.rs in #120 Task 4
+pub(crate) fn baseline_path(agent: &str) -> Option<PathBuf> {
+    baseline_path_in(&state_dir(), agent)
+}
+
 /// Map agent name → absolute path to its hook config file.
 pub fn settings_path(agent: &str) -> Option<PathBuf> {
     let home = home_dir()?;
@@ -393,7 +405,7 @@ pub fn write_baseline(
 }
 
 /// Directory-injectable core of [`write_baseline`]: writes
-/// `dir/hook-registration.json` + appends to `dir/hook-index.json`. Kept
+/// `dir/hook-registration-<agent>.json` + appends to `dir/hook-index.json`. Kept
 /// separate so tests can supply a temp dir without touching the process-global
 /// `XDG_STATE_HOME` env var (which would race other tests).
 #[allow(clippy::too_many_arguments)]
@@ -423,6 +435,9 @@ fn write_baseline_in(
 
     let settings_path_str = settings_path.to_string_lossy().to_string();
 
+    let fail_closed: Option<bool> = (agent_format(agent) == Some(HookFormat::Cursor))
+        .then(|| enforce && on_failure == "closed");
+
     let baseline = json!({
         "agent": agent,
         "settings_path": settings_path_str,
@@ -430,10 +445,12 @@ fn write_baseline_in(
         "capture": capture,
         "matcher": matcher,
         "block_hash": block_hash,
+        "fail_closed": fail_closed,        // null for claude/codex; bool for cursor
         "written_at_unix": written_at_unix,
     });
 
-    let reg_path = dir.join("hook-registration.json");
+    let reg_path = baseline_path_in(dir, agent)
+        .ok_or_else(|| io::Error::other(format!("unknown agent for baseline: {agent}")))?;
     let pretty = serde_json::to_string_pretty(&baseline).map_err(io::Error::other)?;
     std::fs::write(&reg_path, pretty.as_bytes())?;
 
@@ -729,7 +746,7 @@ mod tests {
             on_failure,
         )
         .unwrap();
-        let raw = std::fs::read(dir.join("hook-registration.json")).unwrap();
+        let raw = std::fs::read(baseline_path_in(dir, "claude-code").unwrap()).unwrap();
         serde_json::from_slice(&raw).unwrap()
     }
 
@@ -779,5 +796,61 @@ mod tests {
             cmd.contains("--capture redacted"),
             "non-enforce baseline must contain --capture, got: {cmd}"
         );
+    }
+
+    #[test]
+    fn baseline_path_is_per_agent_and_validated() {
+        let dir = std::path::Path::new("/state");
+        assert_eq!(
+            baseline_path_in(dir, "cursor").unwrap(),
+            dir.join("hook-registration-cursor.json")
+        );
+        assert!(baseline_path_in(dir, "../evil").is_none()); // unknown slug → no path
+    }
+
+    #[test]
+    fn write_baseline_per_agent_no_clobber_and_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        // claude (observe) then cursor (enforce closed) → two distinct files
+        write_baseline_in(
+            dir.path(),
+            "claude-code",
+            std::path::Path::new("/h/.claude/settings.json"),
+            "/x/sigil-hook",
+            "claude-code",
+            "redacted",
+            "*",
+            false,
+            "open",
+        )
+        .unwrap();
+        write_baseline_in(
+            dir.path(),
+            "cursor",
+            std::path::Path::new("/h/.cursor/hooks.json"),
+            "/x/sigil-hook",
+            "cursor",
+            "redacted",
+            "*",
+            true,
+            "closed",
+        )
+        .unwrap();
+
+        let claude: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(dir.path().join("hook-registration-claude-code.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(claude["agent"], "claude-code");
+        assert!(claude["matcher"].is_string());
+        assert!(claude["fail_closed"].is_null()); // claude → no fail_closed
+
+        let cursor: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(dir.path().join("hook-registration-cursor.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(cursor["agent"], "cursor");
+        assert_eq!(cursor["fail_closed"], serde_json::json!(true)); // enforce + closed
+        assert!(cursor["matcher"].is_string()); // matcher kept for wire continuity
     }
 }

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -128,13 +128,11 @@ pub(crate) fn cursor_entry_is_ours(entry: &Value, exe: &str) -> bool {
 }
 
 /// The `command` string of a Cursor settings entry, if present.
-#[allow(dead_code)] // consumed by verify.rs in #120 Task 4
 pub(crate) fn cursor_entry_command(entry: &Value) -> Option<&str> {
     entry.get("command").and_then(|c| c.as_str())
 }
 
 /// Effective `failClosed` of a Cursor entry — absent means false (Cursor default).
-#[allow(dead_code)] // consumed by verify.rs in #120 Task 4
 pub(crate) fn cursor_entry_fail_closed(entry: &Value) -> bool {
     entry
         .get("failClosed")
@@ -362,7 +360,6 @@ pub(crate) fn baseline_path_in(dir: &std::path::Path, agent: &str) -> Option<Pat
     Some(dir.join(format!("hook-registration-{agent}.json")))
 }
 
-#[allow(dead_code)] // consumed by verify.rs in #120 Task 4
 pub(crate) fn baseline_path(agent: &str) -> Option<PathBuf> {
     baseline_path_in(&state_dir(), agent)
 }

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -20,15 +20,15 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[derive(Clone, Copy, PartialEq)]
-enum HookFormat {
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HookFormat {
     /// `root.hooks.PreToolUse[]` — Claude Code, Codex.
     NestedPreToolUse,
     /// `root.version` + `root.hooks.{beforeShellExecution,beforeMCPExecution}[]`.
     Cursor,
 }
 
-fn agent_format(agent: &str) -> Option<HookFormat> {
+pub(crate) fn agent_format(agent: &str) -> Option<HookFormat> {
     match agent {
         "claude-code" | "codex" => Some(HookFormat::NestedPreToolUse),
         "cursor" => Some(HookFormat::Cursor),
@@ -36,7 +36,7 @@ fn agent_format(agent: &str) -> Option<HookFormat> {
     }
 }
 
-const CURSOR_EVENTS: [&str; 2] = ["beforeShellExecution", "beforeMCPExecution"];
+pub(crate) const CURSOR_EVENTS: [&str; 2] = ["beforeShellExecution", "beforeMCPExecution"];
 
 fn command_string(exe: &str, agent: &str, capture: &str) -> String {
     format!("{exe} {agent} --capture {capture}")
@@ -119,11 +119,26 @@ fn merge_claude(arr: &mut Vec<Value>, exe: &str, cmd: &str) -> bool {
 
 // --- Cursor helpers ---
 
-fn cursor_entry_is_ours(entry: &Value, exe: &str) -> bool {
+pub(crate) fn cursor_entry_is_ours(entry: &Value, exe: &str) -> bool {
     entry
         .get("command")
         .and_then(|c| c.as_str())
         .map(|c| first_token(c) == exe)
+        .unwrap_or(false)
+}
+
+/// The `command` string of a Cursor settings entry, if present.
+#[allow(dead_code)] // consumed by verify.rs in #120 Task 4
+pub(crate) fn cursor_entry_command(entry: &Value) -> Option<&str> {
+    entry.get("command").and_then(|c| c.as_str())
+}
+
+/// Effective `failClosed` of a Cursor entry — absent means false (Cursor default).
+#[allow(dead_code)] // consumed by verify.rs in #120 Task 4
+pub(crate) fn cursor_entry_fail_closed(entry: &Value) -> bool {
+    entry
+        .get("failClosed")
+        .and_then(|v| v.as_bool())
         .unwrap_or(false)
 }
 
@@ -644,6 +659,20 @@ mod tests {
         let arr = v["hooks"]["beforeShellExecution"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["command"].as_str().unwrap().contains("--enforce"));
+    }
+
+    #[test]
+    fn cursor_entry_accessors() {
+        let e = json!({ "command": "/x/sigil-hook cursor --enforce", "failClosed": true });
+        assert_eq!(
+            cursor_entry_command(&e),
+            Some("/x/sigil-hook cursor --enforce")
+        );
+        assert!(cursor_entry_fail_closed(&e));
+        let no_fc = json!({ "command": "/x/sigil-hook cursor" });
+        assert!(!cursor_entry_fail_closed(&no_fc)); // absent = false (Cursor default)
+        assert_eq!(cursor_entry_command(&json!({})), None); // command absent → None
+        assert!(!cursor_entry_fail_closed(&json!({ "failClosed": "yes" }))); // non-bool → false
     }
 
     #[test]

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -529,13 +529,12 @@ fn cmd_install(
         std::process::exit(1);
     }
 
-    // Write baseline / update discovery index. Only for agents whose `verify`
-    // path is implemented (claude-code/codex). Cursor's settings use
-    // beforeShellExecution/beforeMCPExecution, which slice-1 verify can't check,
-    // and the baseline is a single global file — a cursor baseline would both
-    // false-positive `verify` and clobber the claude one (spec D6). (grok and
-    // antigravity never reach here; they return to their own install fns above.)
-    if matches!(agent, "claude-code" | "codex") {
+    // Write baseline / update discovery index. For agents whose `verify`
+    // path is implemented. Cursor gained format-aware verify in #120 (per-agent
+    // baseline file hook-registration-cursor.json), so the #119 D6 exclusion
+    // is removed. (grok and antigravity never reach here; they return to their
+    // own install fns above.)
+    if matches!(agent, "claude-code" | "codex" | "cursor") {
         if let Err(e) = install::write_baseline(
             agent,
             &sp,

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -764,10 +764,22 @@ fn drift_exit_code(kind: DriftKind) -> i32 {
     }
 }
 
-fn cmd_verify(_agent: &str) -> i32 {
+fn cmd_verify(agent: &str) -> i32 {
     use sigil_core::event::AiTool;
 
-    let Some(report) = verify::check() else {
+    // TODO(#120 follow-on): consolidate this agent→AiTool table with install::agent_format
+    // when more agents (grok/antigravity) gain verify support — keep the two in sync until then.
+    let aitool = match agent {
+        "claude-code" => AiTool::ClaudeCode,
+        "codex" => AiTool::Codex,
+        "cursor" => AiTool::Cursor,
+        other => {
+            eprintln!("sigil-hook verify: unsupported --agent '{other}' (expected: claude-code, codex, cursor)");
+            return 1; // usage error — distinct from drift (2) / baseline_absent (3) / clean (0)
+        }
+    };
+
+    let Some(report) = verify::check(agent) else {
         println!("[OK]    hook registration matches baseline");
         return 0;
     };
@@ -791,8 +803,8 @@ fn cmd_verify(_agent: &str) -> i32 {
             report.observed_matcher.as_deref().unwrap_or("?"),
         ),
         DriftKind::FailModeDrift => println!(
-            "[DRIFT] hook fail-mode (failClosed) changed in {} (fail_mode_drift)",
-            report.settings_path
+            "[DRIFT] fail-mode changed in {}: failClosed {:?} -> {:?} (fail_mode_drift)",
+            report.settings_path, report.expected_fail_closed, report.observed_fail_closed
         ),
     }
 
@@ -806,7 +818,7 @@ fn cmd_verify(_agent: &str) -> i32 {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0),
         payload: HookConfigDriftReport {
-            agent: AiTool::ClaudeCode, // slice 1
+            agent: aitool,
             drift_kind: report.kind,
             settings_path: report.settings_path.clone(),
             expected_command_hash: report.expected_command_hash.clone(),

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -760,7 +760,7 @@ fn drift_exit_code(kind: DriftKind) -> i32 {
     use sigil_core::hook_proto::DriftKind::*;
     match kind {
         BaselineAbsent => 3,
-        EntryMissing | CommandDrift | MatcherDrift => 2,
+        EntryMissing | CommandDrift | MatcherDrift | FailModeDrift => 2,
     }
 }
 
@@ -789,6 +789,10 @@ fn cmd_verify(_agent: &str) -> i32 {
             "[DRIFT] matcher changed: {:?} -> {:?} (matcher_drift)",
             report.expected_matcher.as_deref().unwrap_or("?"),
             report.observed_matcher.as_deref().unwrap_or("?"),
+        ),
+        DriftKind::FailModeDrift => println!(
+            "[DRIFT] hook fail-mode (failClosed) changed in {} (fail_mode_drift)",
+            report.settings_path
         ),
     }
 
@@ -828,5 +832,6 @@ mod tests {
         assert_eq!(drift_exit_code(EntryMissing), 2);
         assert_eq!(drift_exit_code(CommandDrift), 2);
         assert_eq!(drift_exit_code(MatcherDrift), 2);
+        assert_eq!(drift_exit_code(FailModeDrift), 2);
     }
 }

--- a/crates/sigil-hook/src/verify.rs
+++ b/crates/sigil-hook/src/verify.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 /// Subset of hook-registration-<agent>.json we compare against (serde ignores the rest).
 #[derive(Deserialize, Debug, Clone)]
 pub struct Baseline {
-    #[allow(dead_code)] // used by the verify subcommand (agent dispatch)
     pub agent: String,
     pub settings_path: String,
     pub command: String,

--- a/crates/sigil-hook/src/verify.rs
+++ b/crates/sigil-hook/src/verify.rs
@@ -3,17 +3,19 @@
 use crate::install;
 use serde::Deserialize;
 use sigil_core::hook_proto::DriftKind;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-/// Subset of hook-registration.json we compare against (serde ignores the rest).
+/// Subset of hook-registration-<agent>.json we compare against (serde ignores the rest).
 #[derive(Deserialize, Debug, Clone)]
 pub struct Baseline {
-    #[allow(dead_code)] // used by the verify subcommand (Task 5)
+    #[allow(dead_code)] // used by the verify subcommand (agent dispatch)
     pub agent: String,
     pub settings_path: String,
     pub command: String,
     pub matcher: String,
     pub block_hash: String,
+    #[serde(default)]
+    pub fail_closed: Option<bool>,
 }
 
 /// A detected drift. `None` from `check()`/`check_one()` means clean.
@@ -25,39 +27,53 @@ pub struct DriftReport {
     pub observed_command_hash: Option<String>,
     pub expected_matcher: Option<String>,
     pub observed_matcher: Option<String>,
-}
-
-fn baseline_path() -> PathBuf {
-    install::state_dir().join("hook-registration.json")
+    pub expected_fail_closed: Option<bool>,
+    pub observed_fail_closed: Option<bool>,
 }
 
 /// Load the baseline, or None if absent/unreadable/malformed.
-// used by the verify subcommand (Task 5)
-#[allow(dead_code)]
 pub fn load_baseline(path: &Path) -> Option<Baseline> {
     let raw = std::fs::read(path).ok()?;
     serde_json::from_slice(&raw).ok()
 }
 
+fn absent(path: &str) -> DriftReport {
+    DriftReport {
+        kind: DriftKind::BaselineAbsent,
+        settings_path: path.into(),
+        expected_command_hash: String::new(),
+        observed_command_hash: None,
+        expected_matcher: None,
+        observed_matcher: None,
+        expected_fail_closed: None,
+        observed_fail_closed: None,
+    }
+}
+
 /// Full check: None when clean, Some(report) on any drift (incl. baseline_absent).
-pub fn check() -> Option<DriftReport> {
-    let bp = baseline_path();
+pub fn check(agent: &str) -> Option<DriftReport> {
+    let Some(bp) = install::baseline_path(agent) else {
+        return Some(absent(&format!("<unknown agent {agent}>")));
+    };
     let Some(b) = load_baseline(&bp) else {
-        return Some(DriftReport {
-            kind: DriftKind::BaselineAbsent,
-            settings_path: bp.to_string_lossy().into_owned(),
-            expected_command_hash: String::new(),
-            observed_command_hash: None,
-            expected_matcher: None,
-            observed_matcher: None,
-        });
+        return Some(absent(&bp.to_string_lossy()));
     };
     check_one(&b)
 }
 
 /// Compare one baseline against its live settings file. None = clean.
-/// Order: entry_missing -> command_drift -> matcher_drift.
+/// Dispatches by agent format: Cursor gets a 3-pass algorithm (missing > command > fail-mode);
+/// Claude/codex use the NestedPreToolUse path (entry_missing -> command_drift -> matcher_drift).
 pub fn check_one(b: &Baseline) -> Option<DriftReport> {
+    match install::agent_format(&b.agent) {
+        Some(install::HookFormat::Cursor) => check_one_cursor(b),
+        _ => check_one_claude(b), // NestedPreToolUse (claude-code/codex) + unknown fall back
+    }
+}
+
+/// Claude/codex path (verbatim original check_one logic).
+/// Order: entry_missing -> command_drift -> matcher_drift.
+fn check_one_claude(b: &Baseline) -> Option<DriftReport> {
     let exe = install::first_token(&b.command).to_string();
     let root: serde_json::Value = std::fs::read(&b.settings_path)
         .ok()
@@ -79,6 +95,8 @@ pub fn check_one(b: &Baseline) -> Option<DriftReport> {
             observed_command_hash: None,
             expected_matcher: Some(b.matcher.clone()),
             observed_matcher: None,
+            expected_fail_closed: None,
+            observed_fail_closed: None,
         });
     };
 
@@ -102,6 +120,8 @@ pub fn check_one(b: &Baseline) -> Option<DriftReport> {
             observed_command_hash: Some(observed_hash),
             expected_matcher: Some(b.matcher.clone()),
             observed_matcher,
+            expected_fail_closed: None,
+            observed_fail_closed: None,
         });
     }
     if observed_matcher.as_deref() != Some(b.matcher.as_str()) {
@@ -112,15 +132,99 @@ pub fn check_one(b: &Baseline) -> Option<DriftReport> {
             observed_command_hash: Some(observed_hash),
             expected_matcher: Some(b.matcher.clone()),
             observed_matcher,
+            expected_fail_closed: None,
+            observed_fail_closed: None,
         });
     }
     None // clean
+}
+
+/// Cursor path: 3-pass drift check.
+/// Cursor writes our entry into BOTH `beforeShellExecution` and
+/// `beforeMCPExecution`; both must be present and consistent, or an attacker
+/// could strip coverage from one event. `failClosed` is a Cursor-native field
+/// (gates whether a crashing hook blocks vs passes through) — absent from the
+/// Claude/Codex format, which is why only this path checks it.
+/// PASS 1 — entry missing in any event (highest priority)
+/// PASS 2 — command hash differs in any event
+/// PASS 3 — failClosed differs from baseline in any event
+fn check_one_cursor(b: &Baseline) -> Option<DriftReport> {
+    use install::{
+        cursor_entry_command, cursor_entry_fail_closed, cursor_entry_is_ours, first_token,
+        CURSOR_EVENTS,
+    };
+    let exe = first_token(&b.command).to_string();
+    let root: serde_json::Value = std::fs::read(&b.settings_path)
+        .ok()
+        .and_then(|raw| serde_json::from_slice(&raw).ok())
+        .unwrap_or(serde_json::Value::Null);
+    let our = |ev: &str| -> Option<serde_json::Value> {
+        root.get("hooks")
+            .and_then(|h| h.get(ev))
+            .and_then(|a| a.as_array())
+            .and_then(|arr| arr.iter().find(|e| cursor_entry_is_ours(e, &exe)).cloned())
+    };
+    let entries: Vec<(&str, Option<serde_json::Value>)> =
+        CURSOR_EVENTS.iter().map(|ev| (*ev, our(ev))).collect();
+
+    // PASS 1 — any event missing our entry
+    if entries.iter().any(|(_, e)| e.is_none()) {
+        return Some(DriftReport {
+            kind: DriftKind::EntryMissing,
+            settings_path: b.settings_path.clone(),
+            expected_command_hash: b.block_hash.clone(),
+            observed_command_hash: None,
+            expected_matcher: None,
+            observed_matcher: None,
+            expected_fail_closed: None,
+            observed_fail_closed: None,
+        });
+    }
+    // PASS 2 — any event's command hash differs
+    for (_, e) in &entries {
+        let v = e.as_ref().unwrap(); // guaranteed Some past PASS 1
+                                     // cursor_entry_is_ours already matched on first_token(command), so command is present past PASS 1
+        let cmd = cursor_entry_command(v).unwrap_or("");
+        let observed = blake3::hash(cmd.as_bytes()).to_hex().to_string();
+        if observed != b.block_hash {
+            return Some(DriftReport {
+                kind: DriftKind::CommandDrift,
+                settings_path: b.settings_path.clone(),
+                expected_command_hash: b.block_hash.clone(),
+                observed_command_hash: Some(observed),
+                expected_matcher: None,
+                observed_matcher: None,
+                expected_fail_closed: None,
+                observed_fail_closed: None,
+            });
+        }
+    }
+    // PASS 3 — any event's failClosed differs from baseline
+    let expected_fc = b.fail_closed.unwrap_or(false);
+    for (_, e) in &entries {
+        let v = e.as_ref().unwrap(); // guaranteed Some past PASS 1
+        let observed_fc = cursor_entry_fail_closed(v);
+        if observed_fc != expected_fc {
+            return Some(DriftReport {
+                kind: DriftKind::FailModeDrift,
+                settings_path: b.settings_path.clone(),
+                expected_command_hash: b.block_hash.clone(),
+                observed_command_hash: None,
+                expected_matcher: None,
+                observed_matcher: None,
+                expected_fail_closed: Some(expected_fc),
+                observed_fail_closed: Some(observed_fc),
+            });
+        }
+    }
+    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::path::Path;
 
     fn baseline(dir: &Path, exe: &str, matcher: &str) -> Baseline {
         let cmd = format!("{exe} claude-code --capture redacted");
@@ -130,6 +234,7 @@ mod tests {
             command: cmd.clone(),
             matcher: matcher.into(),
             block_hash: blake3::hash(cmd.as_bytes()).to_hex().to_string(),
+            fail_closed: None,
         }
     }
     fn write_settings(b: &Baseline, json: &str) {
@@ -215,6 +320,7 @@ mod tests {
             command: enforce_cmd.clone(),
             matcher: "*".into(),
             block_hash: blake3::hash(enforce_cmd.as_bytes()).to_hex().to_string(),
+            fail_closed: None,
         };
         // Settings registered WITH the enforce command => clean (no drift).
         let mut f = std::fs::File::create(&b.settings_path).unwrap();
@@ -250,6 +356,7 @@ mod tests {
             command: enforce_cmd.clone(),
             matcher: "*".into(),
             block_hash: blake3::hash(enforce_cmd.as_bytes()).to_hex().to_string(),
+            fail_closed: None,
         };
         // Settings registered with the OBSERVE command while baseline expects ENFORCE
         // => command_drift (this is the genuine tamper signal, not a false positive).
@@ -265,5 +372,84 @@ mod tests {
             DriftKind::CommandDrift,
             "downgrade from enforce to observe command must be reported as command_drift"
         );
+    }
+
+    // --- Cursor verify tests ---
+
+    fn cursor_baseline(dir: &Path, fail_closed: bool) -> Baseline {
+        let exe = "/usr/bin/sigil-hook";
+        let cmd = format!(
+            "{exe} cursor --enforce --on-failure {} --capture redacted",
+            if fail_closed { "closed" } else { "open" }
+        );
+        Baseline {
+            agent: "cursor".into(),
+            settings_path: dir.join("hooks.json").to_string_lossy().into_owned(),
+            command: cmd.clone(),
+            matcher: "*".into(),
+            fail_closed: Some(fail_closed),
+            block_hash: blake3::hash(cmd.as_bytes()).to_hex().to_string(),
+        }
+    }
+
+    fn write_cursor_settings(b: &Baseline, sh: &str, mcp: &str) {
+        let json = format!(
+            r#"{{"version":1,"hooks":{{"beforeShellExecution":[{sh}],"beforeMCPExecution":[{mcp}]}}}}"#
+        );
+        std::fs::write(&b.settings_path, json).unwrap();
+    }
+
+    #[test]
+    fn cursor_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = cursor_baseline(dir.path(), true);
+        let entry = format!(r#"{{"command":"{}","failClosed":true}}"#, b.command);
+        write_cursor_settings(&b, &entry, &entry);
+        assert_eq!(check_one(&b), None);
+    }
+
+    #[test]
+    fn cursor_entry_missing_in_one_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = cursor_baseline(dir.path(), true);
+        let entry = format!(r#"{{"command":"{}","failClosed":true}}"#, b.command);
+        write_cursor_settings(&b, &entry, ""); // mcp event empty → missing
+        assert_eq!(check_one(&b).unwrap().kind, DriftKind::EntryMissing);
+    }
+
+    #[test]
+    fn cursor_command_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = cursor_baseline(dir.path(), true);
+        let tampered = format!(
+            r#"{{"command":"{} --capture raw","failClosed":true}}"#,
+            b.command
+        );
+        write_cursor_settings(&b, &tampered, &tampered);
+        assert_eq!(check_one(&b).unwrap().kind, DriftKind::CommandDrift);
+    }
+
+    #[test]
+    fn cursor_fail_mode_drift_when_failclosed_flipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = cursor_baseline(dir.path(), true); // baseline expects failClosed=true
+        let downgraded = format!(r#"{{"command":"{}","failClosed":false}}"#, b.command);
+        write_cursor_settings(&b, &downgraded, &downgraded); // command intact, only failClosed flipped
+        let r = check_one(&b).unwrap();
+        assert_eq!(r.kind, DriftKind::FailModeDrift);
+        assert_eq!(r.expected_fail_closed, Some(true));
+        assert_eq!(r.observed_fail_closed, Some(false));
+    }
+
+    #[test]
+    fn missing_precedence_beats_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = cursor_baseline(dir.path(), true);
+        let drifted = format!(
+            r#"{{"command":"{} --capture raw","failClosed":true}}"#,
+            b.command
+        );
+        write_cursor_settings(&b, &drifted, ""); // shell drifted, mcp missing → report EntryMissing
+        assert_eq!(check_one(&b).unwrap().kind, DriftKind::EntryMissing);
     }
 }

--- a/crates/sigil-hook/tests/install_cursor_enforce.rs
+++ b/crates/sigil-hook/tests/install_cursor_enforce.rs
@@ -1,11 +1,11 @@
-//! CLI e2e (#100): `sigil-hook install --agent cursor --enforce --write` must
+//! CLI e2e (#100, #120): `sigil-hook install --agent cursor --enforce --write` must
 //! actually write both Cursor gate events with the enforce command (+failClosed
-//! when closed), and must NOT write an install baseline for cursor (spec D6).
+//! when closed), and must write a per-agent baseline (hook-registration-cursor.json).
 #![cfg(unix)]
 use std::process::Command;
 
 #[test]
-fn cursor_enforce_install_writes_both_events_and_no_baseline() {
+fn cursor_enforce_install_writes_both_events_and_writes_baseline() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
     let state = home.join("state");
@@ -46,9 +46,19 @@ fn cursor_enforce_install_writes_both_events_and_no_baseline() {
         );
     }
 
-    // D6: no baseline written for cursor.
+    // #120: cursor now writes a per-agent baseline (the #119 D6 gate is removed).
+    let baseline = state.join("sigil/hook-registration-cursor.json");
     assert!(
-        !state.join("sigil/hook-registration.json").exists(),
-        "cursor install must not write a verify baseline"
+        baseline.exists(),
+        "cursor install must write its per-agent baseline"
+    );
+    let b: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&baseline).unwrap()).unwrap();
+    assert_eq!(b["agent"], "cursor");
+    // installed with --on-failure closed
+    assert_eq!(
+        b["fail_closed"],
+        serde_json::json!(true),
+        "baseline must record fail_closed=true when installed with --on-failure closed"
     );
 }

--- a/crates/sigil-hook/tests/verify_cursor_e2e.rs
+++ b/crates/sigil-hook/tests/verify_cursor_e2e.rs
@@ -138,3 +138,27 @@ fn cursor_verify_baseline_absent_exits_3() {
         String::from_utf8_lossy(&v.stdout)
     );
 }
+
+/// No-false-positive lock for observe (open) mode: an observe install records
+/// baseline fail_closed=Some(false), and the live entry carries no failClosed
+/// field (=false). PASS 3 must treat absent==false as a match → clean (exit 0).
+#[test]
+fn cursor_verify_observe_install_is_clean() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let state = home.join("state");
+    // observe install (no --enforce): baseline fail_closed=Some(false), live entry has no failClosed
+    let out = sigil(home, &state, &["install", "--agent", "cursor", "--write"]);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v = sigil(home, &state, &["verify", "--agent", "cursor"]);
+    assert_eq!(
+        v.status.code(),
+        Some(0),
+        "observe install must verify clean (no failClosed false-positive): {}",
+        String::from_utf8_lossy(&v.stdout)
+    );
+}

--- a/crates/sigil-hook/tests/verify_cursor_e2e.rs
+++ b/crates/sigil-hook/tests/verify_cursor_e2e.rs
@@ -1,0 +1,140 @@
+//! CLI e2e (#120): install Cursor enforce → verify clean → tamper failClosed →
+//! verify detects fail_mode_drift (exit 2) → delete an event entry → verify
+//! detects entry_missing (exit 2) → unknown agent → usage error (exit 1).
+#![cfg(unix)]
+use std::process::Command;
+
+fn sigil(home: &std::path::Path, state: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .args(args)
+        .env("HOME", home)
+        .env("XDG_STATE_HOME", state)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn cursor_verify_roundtrip_and_tamper() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let state = home.join("state");
+    let hooks = home.join(".cursor/hooks.json");
+
+    // install enforce closed → writes both events (+failClosed) AND the per-agent baseline
+    let out = sigil(
+        home,
+        &state,
+        &[
+            "install",
+            "--agent",
+            "cursor",
+            "--enforce",
+            "--on-failure",
+            "closed",
+            "--write",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // hooks.json and baseline must both exist after install
+    assert!(
+        hooks.exists(),
+        "hooks.json must be written by install --write"
+    );
+    assert!(
+        state.join("sigil/hook-registration-cursor.json").exists(),
+        "baseline must be written by install --write"
+    );
+
+    // clean verify → exit 0
+    let v = sigil(home, &state, &["verify", "--agent", "cursor"]);
+    assert_eq!(
+        v.status.code(),
+        Some(0),
+        "clean verify must exit 0: stdout={} stderr={}",
+        String::from_utf8_lossy(&v.stdout),
+        String::from_utf8_lossy(&v.stderr)
+    );
+
+    // tamper: flip ONLY beforeShellExecution[0].failClosed → false; command intact,
+    // beforeMCPExecution untouched. PASS 1/2 don't fire (both entries present, command
+    // hash matches); PASS 3 fires on the shell event → fail_mode_drift.
+    let raw = std::fs::read_to_string(&hooks).unwrap();
+    let mut j: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    j["hooks"]["beforeShellExecution"][0]["failClosed"] = serde_json::json!(false);
+    std::fs::write(&hooks, serde_json::to_string(&j).unwrap()).unwrap();
+
+    let v = sigil(home, &state, &["verify", "--agent", "cursor"]);
+    assert_eq!(
+        v.status.code(),
+        Some(2),
+        "fail-mode drift must exit 2: stdout={} stderr={}",
+        String::from_utf8_lossy(&v.stdout),
+        String::from_utf8_lossy(&v.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&v.stdout).contains("fail_mode_drift"),
+        "stdout must contain 'fail_mode_drift', got: {}",
+        String::from_utf8_lossy(&v.stdout)
+    );
+
+    // tamper harder: wipe beforeMCPExecution to []. beforeShellExecution still holds
+    // the prior-tamper entry, but the MCP event is now empty → PASS 1 short-circuits on
+    // the missing MCP entry → entry_missing (precedence over the lingering shell drift).
+    let raw = std::fs::read_to_string(&hooks).unwrap();
+    let mut j: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    j["hooks"]["beforeMCPExecution"] = serde_json::json!([]);
+    std::fs::write(&hooks, serde_json::to_string(&j).unwrap()).unwrap();
+
+    let v = sigil(home, &state, &["verify", "--agent", "cursor"]);
+    assert_eq!(
+        v.status.code(),
+        Some(2),
+        "entry_missing must exit 2: stdout={} stderr={}",
+        String::from_utf8_lossy(&v.stdout),
+        String::from_utf8_lossy(&v.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&v.stdout).contains("entry_missing"),
+        "stdout must contain 'entry_missing', got: {}",
+        String::from_utf8_lossy(&v.stdout)
+    );
+
+    // unknown agent → usage error (exit 1), not a drift code
+    let v = sigil(home, &state, &["verify", "--agent", "bogus"]);
+    assert_eq!(
+        v.status.code(),
+        Some(1),
+        "unknown agent must exit 1 (usage error): stdout={} stderr={}",
+        String::from_utf8_lossy(&v.stdout),
+        String::from_utf8_lossy(&v.stderr)
+    );
+    // lock the usage path itself, not just the exit code: cmd_verify emits
+    // "sigil-hook verify: unsupported --agent '...'" to stderr.
+    assert!(
+        String::from_utf8_lossy(&v.stderr).contains("unsupported"),
+        "bogus agent stderr: {}",
+        String::from_utf8_lossy(&v.stderr)
+    );
+}
+
+/// Completes the exit-code matrix (0 clean / 2 drift / 1 usage / 3 absent):
+/// with no install, no baseline exists on disk → BaselineAbsent → exit 3.
+#[test]
+fn cursor_verify_baseline_absent_exits_3() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let state = home.join("state");
+    // no install → no baseline on disk
+    let v = sigil(home, &state, &["verify", "--agent", "cursor"]);
+    assert_eq!(
+        v.status.code(),
+        Some(3),
+        "missing baseline must exit 3 (baseline_absent): {}",
+        String::from_utf8_lossy(&v.stdout)
+    );
+}

--- a/crates/sigil-hook/tests/verify_e2e.rs
+++ b/crates/sigil-hook/tests/verify_e2e.rs
@@ -25,7 +25,7 @@ fn setup(state: &std::path::Path, settings: &std::path::Path, matcher: &str, set
     let dir = state.join("sigil");
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(
-        dir.join("hook-registration.json"),
+        dir.join("hook-registration-claude-code.json"),
         serde_json::to_vec(&baseline).unwrap(),
     )
     .unwrap();


### PR DESCRIPTION
## Summary

Generalizes `sigil-hook verify` from a single global, claude-shaped tamper-evidence baseline to **per-agent, format-aware** baselines. This gives **Cursor first-class drift detection** — including a `failClosed` downgrade signal — and fixes a latent **claude↔codex baseline clobber** (both previously wrote the same `hook-registration.json`).

Closes the enforce/tamper-evidence asymmetry: Cursor enforce shipped in #119, but had no verify counterpart until now.

Fixes #120.

## What changed

- **Per-agent baseline file** `hook-registration-<agent>.json` (replaces the single global file). The `<agent>` slug is validated via `agent_format` before path interpolation, so a raw `--agent` value can never path-traverse.
- **`DriftKind::FailModeDrift`** (sigil-core) — a Cursor `failClosed` downgrade is a distinct tamper kind, separate from command drift. Reaches the sigil-manager consumer purely as the serde string `"fail_mode_drift"`; **no wire-struct change** (`HookConfigDriftReport` is untouched).
- **Format-aware verify dispatch** — `check(agent)` reads the per-agent baseline and dispatches on `agent_format`:
  - claude/codex → the existing PreToolUse logic, preserved **verbatim** (`check_one_claude`).
  - cursor → new `check_one_cursor`, a 3-pass check over **both** gate events (`beforeShellExecution` + `beforeMCPExecution`) with worst-first precedence: **missing > command > fail-mode**.
- **`fail_closed` in the record** — `Some(enforce && on_failure == "closed")` for Cursor, `null` for claude/codex. The open/observe case (`Some(false)` vs a live entry with `failClosed` absent) verifies clean — no false positive.
- **`cmd_verify(--agent)`** now flows the real agent through, maps it to `AiTool`, and returns a usage error (**exit 1**) for an unknown agent — distinct from drift (2) / baseline-absent (3) / clean (0).
- **Un-gated** the cursor baseline write (the #119 D6 exclusion is removed now that cursor is verifiable).

## Exit-code matrix (cursor, locked by e2e)

| Outcome | Exit |
|---|---|
| clean | 0 |
| unknown `--agent` (usage) | 1 |
| drift (entry_missing / command / fail_mode) | 2 |
| baseline absent | 3 |

## Testing

- New unit tests in `verify.rs` (cursor clean / entry-missing-in-one-event / command-drift / fail-mode-drift / missing-beats-command precedence) and `install.rs` (per-agent path validation + no-clobber + `fail_closed`).
- New CLI e2e `tests/verify_cursor_e2e.rs` against the real binary: install → clean verify → `failClosed` flip → `fail_mode_drift` → delete event → `entry_missing` → unknown agent → exit 1 → baseline-absent → exit 3 → observe-mode clean.
- `cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test -p sigil-core -p sigil-hook` all green. Full-workspace test green except the pre-existing FSEvents flake `basic_events::it_emits_modified_event` (#108, unrelated).

## Migration (clean break, D7)

Baselines written by a prior `sigil-hook` (un-suffixed `hook-registration.json`, no `fail_closed`) are simply no longer read → `verify` reports `BaselineAbsent` (exit 3) until re-install. Non-crashing; a stale file on disk is never mistakenly read.

## Review workflow

codex adversarial spec review (rev2: visibility / matcher-keep / path-traversal all adopted) → 6-task subagent-driven TDD (per-task spec + code-quality review) → holistic Opus review (ready-to-PR, no blockers/majors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
