### PR TITLE
test(agent): harden FS-watch e2e tests against parallel-load flake (#108)

### DIFF
--- a/crates/sigil-agent/src/test_support.rs
+++ b/crates/sigil-agent/src/test_support.rs
@@ -76,14 +76,27 @@ impl TestAgentBuilder {
         });
         // Wait until the control IPC is listening: the runtime registers every
         // watch root *before* opening the control listener, so the socket file
-        // appearing means all watchers are live. (On Windows the IPC is a named
-        // pipe with no socket file, so this just runs out the deadline — fine,
-        // ReadDirectoryChangesW registration is synchronous and fast.)
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-        while !control_socket.exists() && std::time::Instant::now() < deadline {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        // appearing means all watchers are live. Under the heavy parallel load
+        // of `cargo test --workspace`, the runtime can take several seconds to
+        // bind — a too-short deadline lets `start()` return before the socket
+        // exists, so a later `control()`/`apply_policy()` connect fails (#108).
+        // Budget generously (override via `SIGIL_TEST_IPC_TIMEOUT_SECS`); the
+        // loop returns as soon as the socket appears, so headroom is free.
+        #[cfg(unix)]
+        {
+            let secs = std::env::var("SIGIL_TEST_IPC_TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(20);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+            while !control_socket.exists() && std::time::Instant::now() < deadline {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
         }
         // Small settle window for the OS watcher to start delivering events.
+        // (On Windows the control IPC is a named pipe with no socket file, so we
+        // skip the readiness poll above — ReadDirectoryChangesW registration is
+        // synchronous and fast — and rely on this settle window.)
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         TestAgent {
             td,

--- a/crates/sigil-agent/tests/basic_events.rs
+++ b/crates/sigil-agent/tests/basic_events.rs
@@ -11,9 +11,22 @@ async fn it_emits_modified_event() {
     let policy = policy_for_paths(&[p.to_str().unwrap()], "standard");
     let agent = TestAgentBuilder::new().policy(&policy).start().await;
 
-    std::fs::write(&p, b"first").unwrap();
-    tokio::time::sleep(Duration::from_millis(150)).await;
-    std::fs::write(&p, b"second").unwrap();
+    // Drive the file continuously instead of writing twice with a fixed sleep.
+    // OS watchers (FSEvents, inotify) deliver from "now" and never replay, so a
+    // write that lands in the watcher's startup gap is lost forever — under
+    // heavy parallel load that gap can swallow both fixed writes, hard-failing
+    // regardless of the wait budget (#108). A background writer keeps modifying
+    // the file until the assertion observes a change, guaranteeing a write the
+    // live stream can catch; it's aborted as soon as the event arrives.
+    let writer_path = p.clone();
+    let writer = tokio::spawn(async move {
+        let mut n: u64 = 0;
+        loop {
+            n += 1;
+            let _ = std::fs::write(&writer_path, format!("change-{n}").as_bytes());
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
 
     let event = agent
         .wait_for_event(
@@ -24,8 +37,10 @@ async fn it_emits_modified_event() {
             },
             common::fs_event_timeout(),
         )
-        .await
-        .expect("expected file_change event");
+        .await;
+
+    writer.abort();
+    let event = event.expect("expected file_change event");
 
     assert_eq!(event["schema_version"], 1);
     agent.join.abort();

--- a/crates/sigil-agent/tests/critical_tier.rs
+++ b/crates/sigil-agent/tests/critical_tier.rs
@@ -10,18 +10,31 @@ async fn it_critical_tier_emits_recheck() {
     let policy = policy_for_paths(&[target.to_str().unwrap()], "critical");
     let agent = TestAgentBuilder::new().policy(&policy).start().await;
 
-    // First write — captured immediately (window=0).
-    std::fs::write(&target, b"v2").unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    std::fs::write(&target, b"v3").unwrap();
+    // Drive the file continuously until the watcher observes a change. OS
+    // watchers (FSEvents, inotify) deliver from "now" and never replay, so a
+    // write landing in the watcher's startup gap is lost forever; under heavy
+    // parallel load that gap can swallow both fixed writes, hard-failing
+    // regardless of the wait budget (#108, same family as #25). The background
+    // writer guarantees a write the live stream can catch, then is aborted.
+    let writer_target = target.clone();
+    let writer = tokio::spawn(async move {
+        let mut n: u64 = 0;
+        loop {
+            n += 1;
+            let _ = std::fs::write(&writer_target, format!("v{n}").as_bytes());
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
 
     let event = agent
         .wait_for_event(
             |v| v["evidence"]["kind"] == "file_change" && v["evidence"]["recheck_hash"].is_string(),
             common::fs_event_timeout(),
         )
-        .await
-        .expect("recheck_hash should be populated for critical tier");
+        .await;
+
+    writer.abort();
+    let event = event.expect("recheck_hash should be populated for critical tier");
     assert!(event["evidence"]["recheck_hash"].as_str().unwrap().len() == 64);
     agent.join.abort();
 }

--- a/crates/sigil-agent/tests/large_file.rs
+++ b/crates/sigil-agent/tests/large_file.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::{fs_event_timeout, policy_for_paths, TestAgentBuilder};
+use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn it_large_file_emits_incomplete() {
@@ -8,9 +9,22 @@ async fn it_large_file_emits_incomplete() {
     let policy = policy_for_paths(&[target.to_str().unwrap()], "standard");
     let agent = TestAgentBuilder::new().policy(&policy).start().await;
 
-    // 11 MB file.
+    // 11 MB file (> MAX_HASH_BYTES=10 MB → TooLarge → Incomplete quality).
     let bytes = vec![0u8; 11 * 1024 * 1024];
-    std::fs::write(&target, &bytes).unwrap();
+
+    // Re-write the oversized file until the watcher observes it. A single write
+    // landing in the watcher's startup gap is lost forever (FSEvents/inotify
+    // deliver from "now", no replay), hard-failing under load (#108 family).
+    // Rewrites are paced wider than the small-file tests since each is 11 MB;
+    // every rewrite is the full size, so any observed event satisfies the
+    // size_after assertion. The writer is aborted once the event arrives.
+    let writer_target = target.clone();
+    let writer = tokio::spawn(async move {
+        loop {
+            let _ = std::fs::write(&writer_target, &bytes);
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        }
+    });
 
     let event = agent
         .wait_for_event(
@@ -21,8 +35,10 @@ async fn it_large_file_emits_incomplete() {
             },
             fs_event_timeout(),
         )
-        .await
-        .expect("expected incomplete-quality file_change");
+        .await;
+
+    writer.abort();
+    let event = event.expect("expected incomplete-quality file_change");
     assert!(event["evidence"]["after_hash"].is_null());
     agent.join.abort();
 }

--- a/crates/sigil-agent/tests/policy_reload_e2e.rs
+++ b/crates/sigil-agent/tests/policy_reload_e2e.rs
@@ -45,15 +45,29 @@ async fn apply_policy_reloads_live_watch_targets() {
         .start()
         .await;
 
-    // Sanity: writing X produces a file_change under policy A.
-    std::fs::write(&file_x, b"x1").unwrap();
-    let ev = agent
-        .wait_for_event(
-            |v| v["evidence"]["kind"] == "file_change",
-            common::fs_event_timeout(),
-        )
-        .await
-        .expect("policy A: file_change for X");
+    // Sanity: writing X produces a file_change under policy A. Re-write X until
+    // one lands — a single write can fall in the watcher's startup gap (FSEvents
+    // delivers from "now", no replay) and be lost under parallel load (#108),
+    // mirroring the live-reload retry loop used for Y below.
+    let is_x_change = |v: &serde_json::Value| {
+        v["evidence"]["kind"] == "file_change"
+            && v["subject"]["value"]
+                .as_str()
+                .map(|p| p.ends_with("x.json"))
+                .unwrap_or(false)
+    };
+    let mut ev_x = None;
+    for i in 0..60 {
+        std::fs::write(&file_x, format!("x{i}").as_bytes()).unwrap();
+        if let Some(ev) = agent
+            .wait_for_event(&is_x_change, Duration::from_millis(250))
+            .await
+        {
+            ev_x = Some(ev);
+            break;
+        }
+    }
+    let ev = ev_x.expect("policy A: file_change for X");
     assert_eq!(ev["schema_version"], 1);
 
     // Apply policy B (watch file Y instead) over the real control IPC. The boot


### PR DESCRIPTION
## Summary
Fixes the `#108` family of FS-watch test flakes that hard-fail `cargo test --workspace` under parallel load.

**Root cause:** OS watchers (FSEvents/inotify) deliver events from "now" and never replay history. A single `fs::write` that lands in the watcher's startup gap is lost forever — no `wait_for_event` budget recovers it. Heavy parallel load widens that gap and swallows the fixed write(s), so the watcher-edge tests fail deterministically once the gap exceeds the write window (same family as the previously-seen #25/#66).

## Changes (test-only, no runtime change)
- **Four watcher-edge tests** now drive the target file *continuously* until the live stream observes a change, then abort the writer — mirroring the retry loop already used for the `policy_reload` `y.json` assertion:
  - `basic_events::it_emits_modified_event`
  - `critical_tier::it_critical_tier_emits_recheck`
  - `large_file::it_large_file_emits_incomplete` (paced wider — each write is 11 MB)
  - `policy_reload_e2e` `file_x` sanity assertion (the `file_y` half was already robust)
- **`TestAgentBuilder::start()`**: the control-IPC readiness poll had a 3s deadline that, under load, let `start()` return before the socket bound — a later `control()`/`apply_policy()` connect then failed (~6s, not a watcher timeout). Now budgets 20s (override `SIGIL_TEST_IPC_TIMEOUT_SECS`) on Unix, and skips the poll on Windows (named pipe has no socket file).

Tests that go through the ai_guard heartbeat re-scan path (`rule_pack_*`, `ai_guard_e2e`, `show_events_e2e`) are not watcher-edge dependent and were left unchanged.

## Test Plan
- [x] Each fixed test green in isolation (3× each)
- [x] Full `cargo test --workspace` green **4/4** under repeated parallel load — on a host whose FSEvents was degraded enough to fail these even in isolation beforehand (worst case)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -D warnings` clean
- [ ] CI green on all platforms (incl. windows-2022 + ubuntu/rocky/debian)

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)