### PR TITLE
fix(ai_guard): uniform local stdio MCP command detection across parsers (#125)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -324,15 +324,7 @@ pub(crate) fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
         return;
     };
     for (name, def) in servers {
-        let Some(url) = def.get("url").and_then(Value::as_str) else {
-            continue;
-        };
-        if url.starts_with("http://") || url.starts_with("https://") {
-            out.push(AiGuardReason::McpServerRemote {
-                server_name: name.clone(),
-                url: url.to_string(),
-            });
-        }
+        super::mcp_scan::emit_one_server(name, def, out);
     }
 }
 
@@ -575,6 +567,13 @@ mod tests {
         assert!(!reasons
             .iter()
             .any(|r| matches!(r, AiGuardReason::McpServerRemote { .. })));
+        // #125: it must ALSO now emit the local-command baseline.
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerLocalCommand { .. })),
+            "expected McpServerLocalCommand in {reasons:?}"
+        );
     }
 
     #[test]
@@ -916,6 +915,44 @@ mod tests {
             out.iter()
                 .any(|r| matches!(r, AiGuardReason::ExternalScriptUnscanned { .. })),
             "expected ExternalScriptUnscanned for missing external script, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_local_command_emits_local_and_nosandbox() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"mcpServers": {"local": {"command": "/tmp/payload", "args": ["x"]}}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+            AiGuardReason::McpServerLocalCommand { server_name, command }
+                if server_name=="local" && command=="/tmp/payload")),
+            "expected McpServerLocalCommand in {reasons:?}"
+        );
+        assert!(reasons.iter().any(|r| matches!(r,
+            AiGuardReason::NoSandbox { executor } if executor=="mcp_command")));
+    }
+
+    #[test]
+    fn mcp_url_normalization_uppercase_and_leading_space() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"mcpServers": {"a": {"url": "HTTP://x"}, "b": {"url": "  https://y"}}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+                AiGuardReason::McpServerRemote { server_name, .. } if server_name == "a")),
+            "uppercase-scheme server \"a\" should emit remote: {reasons:?}"
+        );
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+                AiGuardReason::McpServerRemote { server_name, .. } if server_name == "b")),
+            "leading-space server \"b\" should emit remote: {reasons:?}"
         );
     }
 

--- a/crates/sigil-agent/src/ai_guard/parser/claude_desktop.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_desktop.rs
@@ -5,7 +5,6 @@
 //! desktop config; only `mcpServers` is meaningful here.
 
 use crate::ai_guard::parser::{AiGuardParser, AssessError};
-use crate::ai_guard::rubric;
 use serde_json::Value;
 use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
 use std::path::{Path, PathBuf};
@@ -90,79 +89,15 @@ impl AiGuardParser for ClaudeDesktopParser {
     }
 }
 
-/// Walk `mcpServers` object. For each entry:
-/// - `url` ⇒ McpServerRemote
-/// - `command` + args ⇒ NoSandbox{executor:"mcp_command"}
-/// - `command` is a shell + args contains shell flag + destructive pattern
-///   ⇒ also DestructiveInInlineCommand
+/// Walk `mcpServers` object and delegate each entry to the shared
+/// `mcp_scan::emit_one_server` assessor.
 fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
     let Some(servers) = settings.get("mcpServers").and_then(Value::as_object) else {
         return;
     };
     for (name, def) in servers {
-        // Remote (HTTP) MCP transport.
-        if let Some(url) = def.get("url").and_then(Value::as_str) {
-            if url.starts_with("http://") || url.starts_with("https://") {
-                out.push(AiGuardReason::McpServerRemote {
-                    server_name: name.clone(),
-                    url: url.to_string(),
-                });
-            }
-            // url-mode servers don't also have a command — skip command branch.
-            continue;
-        }
-        // Local stdio MCP: command + args. Always counts as host-shell exec.
-        let Some(command) = def.get("command").and_then(Value::as_str) else {
-            continue;
-        };
-        out.push(AiGuardReason::NoSandbox {
-            executor: "mcp_command".into(),
-        });
-        // Shell-wrapper detection: command is a known shell AND args contains
-        // a shell flag with a destructive pattern in the next arg.
-        if is_shell(command) {
-            if let Some(args) = def.get("args").and_then(Value::as_array) {
-                if let Some(snippet) = first_destructive_after_shell_flag(args) {
-                    if let Some(pat) = rubric::first_destructive_pattern(&snippet) {
-                        out.push(AiGuardReason::DestructiveInInlineCommand {
-                            pattern: pat.to_string(),
-                            hook_event: "mcp_command".into(),
-                            snippet: snippet.chars().take(80).collect(),
-                        });
-                    }
-                }
-            }
-        }
+        crate::ai_guard::parser::mcp_scan::emit_one_server(name, def, out);
     }
-}
-
-fn is_shell(cmd: &str) -> bool {
-    matches!(
-        cmd.rsplit(['/', '\\']).next().unwrap_or(cmd),
-        "sh" | "bash"
-            | "zsh"
-            | "dash"
-            | "cmd"
-            | "cmd.exe"
-            | "powershell"
-            | "powershell.exe"
-            | "pwsh"
-    )
-}
-
-/// Given an args array like `["-c", "rm -rf /tmp"]`, return the string
-/// following the first shell-execution flag, or None.
-fn first_destructive_after_shell_flag(args: &[Value]) -> Option<String> {
-    let mut iter = args.iter();
-    while let Some(a) = iter.next() {
-        let Some(s) = a.as_str() else { continue };
-        if matches!(s, "-c" | "/c" | "/C" | "-Command") {
-            if let Some(next) = iter.next().and_then(Value::as_str) {
-                return Some(next.to_string());
-            }
-        }
-    }
-    None
 }
 
 #[cfg(test)]
@@ -222,6 +157,12 @@ mod tests {
                 AiGuardReason::NoSandbox { executor } if executor == "mcp_command"
             )),
             "expected NoSandbox{{executor:\"mcp_command\"}} in {reasons:?}"
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerLocalCommand { .. })),
+            "#125: expected McpServerLocalCommand in {reasons:?}"
         );
     }
 
@@ -312,5 +253,36 @@ mod tests {
     fn tool_is_claude_desktop() {
         let p = ClaudeDesktopParser;
         assert_eq!(p.tool(), AiTool::ClaudeDesktop);
+    }
+
+    #[test]
+    fn local_command_mcp_emits_local_command_reason() {
+        let dir = tempdir().unwrap();
+        write_config_macos(
+            dir.path(),
+            r#"{"mcpServers": {"local": {"command": "/tmp/x", "args": ["a"]}}}"#,
+        );
+        let reasons = ClaudeDesktopParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+            AiGuardReason::McpServerLocalCommand { server_name, .. } if server_name=="local")),
+            "expected McpServerLocalCommand in {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn server_with_both_url_and_command_emits_both() {
+        let dir = tempdir().unwrap();
+        write_config_macos(
+            dir.path(),
+            r#"{"mcpServers": {"both": {"url": "https://x", "command": "node"}}}"#,
+        );
+        let reasons = ClaudeDesktopParser.assess(dir.path()).unwrap();
+        assert!(reasons
+            .iter()
+            .any(|r| matches!(r, AiGuardReason::McpServerRemote { .. })));
+        assert!(reasons
+            .iter()
+            .any(|r| matches!(r, AiGuardReason::McpServerLocalCommand { .. })));
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/codex.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/codex.rs
@@ -247,15 +247,12 @@ pub(crate) fn emit_mcp_reasons(val: &Value, out: &mut Vec<AiGuardReason>) {
         return;
     };
     for (name, def) in servers {
-        let url = def.get("url").and_then(Value::as_str);
-        if let Some(u) = url {
-            if super::mcp_scan::scheme_is_http(u) {
-                out.push(AiGuardReason::McpServerRemote {
-                    server_name: name.clone(),
-                    url: u.to_string(),
-                });
-            }
-        }
+        // toml::Value -> serde_json::Value so the shared helper can read it.
+        // Skip (don't abort the loop) a server that fails to convert.
+        let Ok(json_def) = serde_json::to_value(def) else {
+            continue;
+        };
+        super::mcp_scan::emit_one_server(name, &json_def, out);
     }
 }
 
@@ -533,6 +530,13 @@ command = "/usr/local/bin/my-mcp-server"
                 .any(|r| matches!(r, AiGuardReason::McpServerRemote { .. })),
             "stdio command server should not emit McpServerRemote, got {reasons:?}"
         );
+        // #125: stdio command must now produce the local-command baseline.
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerLocalCommand { .. })),
+            "expected McpServerLocalCommand in {reasons:?}"
+        );
     }
 
     // ─── combined scenario ─────────────────────────────────────────────────
@@ -735,6 +739,28 @@ command = "rm -rf /tmp/foo"
                 .any(|r| matches!(r, AiGuardReason::DestructiveInInlineCommand { .. })),
             "expected DestructiveInInlineCommand for inline codex command, got {out:?}"
         );
+    }
+
+    #[test]
+    fn mcp_local_command_emits_local_and_nosandbox() {
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"
+[mcp_servers.evil]
+command = "/tmp/payload"
+args = ["x"]
+"#,
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+            AiGuardReason::McpServerLocalCommand { server_name, command }
+                if server_name=="evil" && command=="/tmp/payload")),
+            "expected McpServerLocalCommand in {reasons:?}"
+        );
+        assert!(reasons.iter().any(|r| matches!(r,
+            AiGuardReason::NoSandbox { executor } if executor=="mcp_command")));
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/codex.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/codex.rs
@@ -764,6 +764,26 @@ args = ["x"]
     }
 
     #[test]
+    fn mcp_shell_command_with_destructive_args_is_scanned() {
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"
+[mcp_servers.risky]
+command = "bash"
+args = ["-c", "rm -rf /tmp/sigil-test"]
+"#,
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+            AiGuardReason::DestructiveInInlineCommand { hook_event, .. }
+                if hook_event=="mcp_command")),
+            "expected DestructiveInInlineCommand via toml MCP shell args in {reasons:?}"
+        );
+    }
+
+    #[test]
     fn collect_external_script_paths_codex() {
         let hooks_dir = std::path::PathBuf::from("/nonexistent/.codex/hooks");
         let cfg: toml::Value = toml::from_str(

--- a/crates/sigil-agent/src/ai_guard/parser/continue_dev.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/continue_dev.rs
@@ -86,34 +86,7 @@ pub(crate) fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
 }
 
 fn emit_one_mcp(name: &str, def: &Value, out: &mut Vec<AiGuardReason>) {
-    if let Some(url) = def.get("url").and_then(Value::as_str) {
-        if super::mcp_scan::scheme_is_http(url) {
-            out.push(AiGuardReason::McpServerRemote {
-                server_name: name.to_string(),
-                url: url.to_string(),
-            });
-        }
-        return;
-    }
-    let Some(command) = def.get("command").and_then(Value::as_str) else {
-        return;
-    };
-    out.push(AiGuardReason::NoSandbox {
-        executor: "mcp_command".into(),
-    });
-    if is_shell(command) {
-        if let Some(args) = def.get("args").and_then(Value::as_array) {
-            if let Some(snippet) = first_destructive_after_shell_flag(args) {
-                if let Some(pat) = rubric::first_destructive_pattern(&snippet) {
-                    out.push(AiGuardReason::DestructiveInInlineCommand {
-                        pattern: pat.to_string(),
-                        hook_event: "mcp_command".into(),
-                        snippet: snippet.chars().take(80).collect(),
-                    });
-                }
-            }
-        }
-    }
+    super::mcp_scan::emit_one_server(name, def, out);
 }
 
 /// slashCommands entries: {name, description, step?, run?, prompt?}.
@@ -247,33 +220,6 @@ fn path_is_inside(candidate: &Path, root: &Path) -> bool {
     c.starts_with(&r)
 }
 
-fn is_shell(cmd: &str) -> bool {
-    matches!(
-        cmd.rsplit(['/', '\\']).next().unwrap_or(cmd),
-        "sh" | "bash"
-            | "zsh"
-            | "dash"
-            | "cmd"
-            | "cmd.exe"
-            | "powershell"
-            | "powershell.exe"
-            | "pwsh"
-    )
-}
-
-fn first_destructive_after_shell_flag(args: &[Value]) -> Option<String> {
-    let mut iter = args.iter();
-    while let Some(a) = iter.next() {
-        let Some(s) = a.as_str() else { continue };
-        if matches!(s, "-c" | "/c" | "/C" | "-Command") {
-            if let Some(next) = iter.next().and_then(Value::as_str) {
-                return Some(next.to_string());
-            }
-        }
-    }
-    None
-}
-
 /// Phase 3b.6.1 — per-repo Continue.dev parser. Spawned by runtime /
 /// policy_reload after discovery; each instance carries its own repo
 /// root and emits AiGuardRiskAssessed with scope=Project{path:repo_root}.
@@ -379,6 +325,12 @@ mod tests {
             r,
             AiGuardReason::NoSandbox { executor } if executor == "mcp_command"
         )));
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerLocalCommand { .. })),
+            "#125: expected McpServerLocalCommand in {reasons:?}"
+        );
     }
 
     #[test]
@@ -394,6 +346,12 @@ mod tests {
             r,
             AiGuardReason::NoSandbox { executor } if executor == "mcp_command"
         )));
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerLocalCommand { .. })),
+            "#125: expected McpServerLocalCommand in {reasons:?}"
+        );
     }
 
     #[test]
@@ -627,6 +585,33 @@ mod tests {
         paths.sort();
         let expected = vec![std::path::PathBuf::from("/opt/sigil-tools/lint.sh")];
         assert_eq!(paths, expected);
+    }
+
+    #[test]
+    fn mcp_object_form_emits_local_command_reason() {
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"mcpServers": {"fs": {"command": "/tmp/x", "args": ["m.js"]}}}"#,
+        );
+        let reasons = ContinueDevParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(r,
+            AiGuardReason::McpServerLocalCommand { server_name, .. } if server_name=="fs")),
+            "expected McpServerLocalCommand in {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_array_form_emits_local_command_reason() {
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"mcpServers": [{"name": "fs", "command": "/tmp/x", "args": ["m.js"]}]}"#,
+        );
+        let reasons = ContinueDevParser.assess(dir.path()).unwrap();
+        assert!(reasons.iter().any(|r| matches!(r,
+            AiGuardReason::McpServerLocalCommand { server_name, .. } if server_name=="fs")));
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
@@ -1,52 +1,60 @@
-//! Phase 3b.8 — shared MCP-object scanner for the Gemini + Cursor JSON
-//! parsers. Walks an `mcpServers` object and emits remote / local-command /
-//! destructive-arg reasons. Standalone (continue_dev keeps its own copy).
+//! Shared MCP-server scanner. `emit_one_server` is the single source of truth
+//! for assessing one server definition (remote url/httpUrl, trust, local stdio
+//! command + NoSandbox, shell destructive-arg). Every per-agent parser routes
+//! its per-server `def` here (#125); `emit_mcp_reasons` is the object-map shape
+//! iterator used by the Gemini/Cursor/Antigravity JSON form.
 
 use crate::ai_guard::rubric;
 use serde_json::Value;
 use sigil_core::event::AiGuardReason;
 
 /// Walk `settings.mcpServers` (object keyed by server name) and push reasons.
-/// Both `url`/`httpUrl` remote and `command` local are evaluated INDEPENDENTLY
-/// (no short-circuit) so a malformed server with both fields emits both.
 pub fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
     let Some(obj) = settings.get("mcpServers").and_then(Value::as_object) else {
         return;
     };
     for (name, def) in obj {
-        for key in ["url", "httpUrl"] {
-            if let Some(u) = def.get(key).and_then(Value::as_str) {
-                if scheme_is_http(u) {
-                    out.push(AiGuardReason::McpServerRemote {
-                        server_name: name.clone(),
-                        url: u.to_string(),
-                    });
-                }
+        emit_one_server(name, def, out);
+    }
+}
+
+/// Assess ONE MCP server definition `def` (keyed `name`), pushing every
+/// applicable reason. Evaluates remote (url/httpUrl), trust, and local stdio
+/// command INDEPENDENTLY (a server with both url and command emits both). Single
+/// source of truth shared by every per-agent parser.
+pub(crate) fn emit_one_server(name: &str, def: &Value, out: &mut Vec<AiGuardReason>) {
+    for key in ["url", "httpUrl"] {
+        if let Some(u) = def.get(key).and_then(Value::as_str) {
+            if scheme_is_http(u) {
+                out.push(AiGuardReason::McpServerRemote {
+                    server_name: name.to_string(),
+                    url: u.to_string(),
+                });
             }
         }
-        if def.get("trust").and_then(Value::as_bool) == Some(true) {
-            out.push(AiGuardReason::TrustedMcpServer {
-                server_name: name.clone(),
-            });
-        }
-        if let Some(command) = def.get("command").and_then(Value::as_str) {
-            out.push(AiGuardReason::McpServerLocalCommand {
-                server_name: name.clone(),
-                command: command.to_string(),
-            });
-            out.push(AiGuardReason::NoSandbox {
-                executor: "mcp_command".into(),
-            });
-            if is_shell(command) {
-                if let Some(args) = def.get("args").and_then(Value::as_array) {
-                    if let Some(snippet) = first_destructive_after_shell_flag(args) {
-                        if let Some(pat) = rubric::first_destructive_pattern(&snippet) {
-                            out.push(AiGuardReason::DestructiveInInlineCommand {
-                                pattern: pat.to_string(),
-                                hook_event: "mcp_command".into(),
-                                snippet: snippet.chars().take(80).collect(),
-                            });
-                        }
+    }
+    if def.get("trust").and_then(Value::as_bool) == Some(true) {
+        out.push(AiGuardReason::TrustedMcpServer {
+            server_name: name.to_string(),
+        });
+    }
+    if let Some(command) = def.get("command").and_then(Value::as_str) {
+        out.push(AiGuardReason::McpServerLocalCommand {
+            server_name: name.to_string(),
+            command: command.to_string(),
+        });
+        out.push(AiGuardReason::NoSandbox {
+            executor: "mcp_command".into(),
+        });
+        if is_shell(command) {
+            if let Some(args) = def.get("args").and_then(Value::as_array) {
+                if let Some(snippet) = first_destructive_after_shell_flag(args) {
+                    if let Some(pat) = rubric::first_destructive_pattern(&snippet) {
+                        out.push(AiGuardReason::DestructiveInInlineCommand {
+                            pattern: pat.to_string(),
+                            hook_event: "mcp_command".into(),
+                            snippet: snippet.chars().take(80).collect(),
+                        });
                     }
                 }
             }
@@ -176,5 +184,27 @@ mod tests {
         assert!(!r
             .iter()
             .any(|x| matches!(x, AiGuardReason::DestructiveInInlineCommand { .. })));
+    }
+
+    #[test]
+    fn emit_one_server_local_command_emits_local_and_nosandbox() {
+        let mut out = Vec::new();
+        emit_one_server("a", &json!({"command":"node","args":["m.js"]}), &mut out);
+        assert!(out.iter().any(|x| matches!(x, AiGuardReason::McpServerLocalCommand { server_name, .. } if server_name=="a")));
+        assert!(out.iter().any(
+            |x| matches!(x, AiGuardReason::NoSandbox { executor } if executor=="mcp_command")
+        ));
+    }
+
+    #[test]
+    fn emit_one_server_url_and_command_independent() {
+        let mut out = Vec::new();
+        emit_one_server("a", &json!({"url":"https://x","command":"node"}), &mut out);
+        assert!(out
+            .iter()
+            .any(|x| matches!(x, AiGuardReason::McpServerRemote { .. })));
+        assert!(out
+            .iter()
+            .any(|x| matches!(x, AiGuardReason::McpServerLocalCommand { .. })));
     }
 }


### PR DESCRIPTION
## Summary
Routes every AI-Guard parser's MCP-server scan through one shared `mcp_scan::emit_one_server` helper, so all agents assess a local stdio MCP `command` identically. **No new `AiGuardReason`, no rubric/scoring change** — pure coverage normalization over existing reasons.

**Before**, MCP-server scanning was duplicated across five divergent copies:
- `codex` / `claude_code` read only `url` → **blind to local stdio `command`** (the RCE-relevant surface targeted by Windsurf CVE-2026-30615, Cursor CurXecute, the Anthropic MCP-SDK flaw). An injected `command = "/tmp/payload"` produced **zero** findings.
- `claude_desktop` / `continue_dev` emitted `NoSandbox` but not `McpServerLocalCommand`, and short-circuited on `url` (skipping `command` when both present).
- Only `mcp_scan` (gemini/cursor/antigravity) had the full baseline.

## Change
- **`mcp_scan`**: lift the per-server body into `pub(crate) fn emit_one_server` (single source of truth: remote url/httpUrl + trust + local command + NoSandbox + shell destructive-arg, url/command independent). `emit_mcp_reasons` is now a thin object-map iterator — **gemini/cursor/antigravity behavior is byte-identical**.
- **claude_code / claude_desktop / continue_dev**: delegate each server `def` to the helper. **codex**: convert each `[mcp_servers.<name>]` toml table via `serde_json::to_value` (`let Ok(..) else continue`) and delegate.
- Deleted the now-dead local `is_shell` / `first_destructive_after_shell_flag` copies and the unused `rubric` import in claude_desktop/continue_dev (clippy `-D warnings` guard).

### Intended, test-pinned behavior changes
- codex/claude_code/claude_desktop/continue_dev now emit `McpServerLocalCommand` for local stdio servers.
- url/command independence (a server with both emits both).
- claude_code/claude_desktop url detection is now case-insensitive + whitespace-trim + `httpUrl` (was case-sensitive `starts_with`).

Per-repo Project parser variants inherit the fix via the same `emit_mcp_reasons`.

## Out of scope (follow-ups)
- **Launcher trust** — flagging a shell / transient-path MCP launcher above the benign baseline (now well-founded on uniform coverage).
- MCP `env` exfil; args injection beyond the existing destructive scan.

## Test plan
- [x] Per-parser regression tests: local stdio command → `McpServerLocalCommand` + `NoSandbox` for **codex and claude_code** (was nothing), claude_desktop/continue_dev (was NoSandbox-only)
- [x] Five existing "green-but-wrong" tests strengthened to assert `McpServerLocalCommand`
- [x] url/command independence + URL-normalization tests pinned
- [x] codex toml→json `args` path → destructive scan composes (`DestructiveInInlineCommand`)
- [x] Antigravity rule-pack parity **26/26 green** (gemini/cursor/antigravity byte-identical)
- [x] `cargo fmt --check`, `clippy --workspace --all-targets -D warnings` clean, full workspace tests green
- [ ] CI green on all platforms

Workflow: spec → codex adversarial review (full-adopt rev2) → plan → subagent-driven TDD (per-task spec + code-quality review) → holistic review (READY TO MERGE).

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)