### PR TITLE
fix(ai_guard): treat empty/whitespace config as clean, not a parse error (#131)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
@@ -28,35 +28,14 @@ fn mcp_config_path(home: &Path) -> PathBuf {
     home.join(".gemini").join("config").join("mcp_config.json")
 }
 
-/// Read + parse a JSON file. Missing file -> `Ok(None)` (not an error); IO/parse
-/// failures surface as `AssessError`.
-fn read_json(path: &Path) -> Result<Option<Value>, AssessError> {
-    let text = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => {
-            return Err(AssessError::Io {
-                path: path.to_path_buf(),
-                source,
-            })
-        }
-    };
-    serde_json::from_str(&text)
-        .map(Some)
-        .map_err(|e| AssessError::Parse {
-            path: path.to_path_buf(),
-            message: e.to_string(),
-        })
-}
-
 fn assess_user(home: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
     let mut out = Vec::new();
-    if let Some(settings) = read_json(&settings_path(home))? {
+    if let Some(settings) = super::read_json_optional(&settings_path(home))? {
         emit_sandbox(&settings, &mut out);
         emit_approval(&settings, &mut out);
     }
     // MCP lives in a separate file (shared across Antigravity IDE/CLI).
-    if let Some(mcp) = read_json(&mcp_config_path(home))? {
+    if let Some(mcp) = super::read_json_optional(&mcp_config_path(home))? {
         emit_mcp_reasons(&mcp, &mut out);
     }
     Ok(out)
@@ -140,7 +119,7 @@ impl AiGuardParser for AntigravityProjectParser {
     }
     fn assess(&self, _home: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
         let mut out = Vec::new();
-        if let Some(settings) = read_json(&self.settings())? {
+        if let Some(settings) = super::read_json_optional(&self.settings())? {
             emit_sandbox(&settings, &mut out);
             emit_approval(&settings, &mut out);
         }
@@ -257,6 +236,30 @@ mod tests {
             AntigravityParser.assess(d.path()).unwrap_err(),
             AssessError::Parse { .. }
         ));
+    }
+    #[test]
+    fn empty_config_is_clean() {
+        let d = tempdir().unwrap();
+        write_settings(d.path(), "");
+        assert!(assess(d.path()).is_empty());
+    }
+    #[test]
+    fn whitespace_config_is_clean() {
+        let d = tempdir().unwrap();
+        write_settings(d.path(), "  \n\t ");
+        assert!(assess(d.path()).is_empty());
+    }
+    #[test]
+    fn empty_mcp_config_is_clean() {
+        let d = tempdir().unwrap();
+        write_mcp(d.path(), "");
+        assert!(assess(d.path()).is_empty());
+    }
+    #[test]
+    fn whitespace_mcp_config_is_clean() {
+        let d = tempdir().unwrap();
+        write_mcp(d.path(), "  \n\t ");
+        assert!(assess(d.path()).is_empty());
     }
     #[test]
     fn tool_and_scope() {

--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -29,10 +29,10 @@ impl AiGuardParser for ClaudeCodeParser {
 
     fn collect_external_script_paths(&self, home_dir: &Path) -> Vec<PathBuf> {
         let claude = home_dir.join(".claude");
-        let base = read_json_optional(&claude.join("settings.json"))
+        let base = super::read_json_optional(&claude.join("settings.json"))
             .ok()
             .flatten();
-        let local = read_json_optional(&claude.join("settings.local.json"))
+        let local = super::read_json_optional(&claude.join("settings.local.json"))
             .ok()
             .flatten();
         if base.is_none() && local.is_none() {
@@ -51,8 +51,8 @@ impl AiGuardParser for ClaudeCodeParser {
         let base_path = claude.join("settings.json");
         let local_path = claude.join("settings.local.json");
 
-        let base = read_json_optional(&base_path)?;
-        let local = read_json_optional(&local_path)?;
+        let base = super::read_json_optional(&base_path)?;
+        let local = super::read_json_optional(&local_path)?;
 
         // Missing primary file with no overlay → operator hasn't enabled tool.
         if base.is_none() && local.is_none() {
@@ -67,23 +67,6 @@ impl AiGuardParser for ClaudeCodeParser {
         emit_permission_reasons(&merged, &mut out);
         emit_mcp_reasons(&merged, &mut out);
         Ok(out)
-    }
-}
-
-/// Read + parse a JSON file, treating `NotFound` as `Ok(None)`.
-pub(crate) fn read_json_optional(path: &Path) -> Result<Option<Value>, AssessError> {
-    match std::fs::read_to_string(path) {
-        Ok(s) => serde_json::from_str(&s)
-            .map(Some)
-            .map_err(|e| AssessError::Parse {
-                path: path.to_path_buf(),
-                message: e.to_string(),
-            }),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(source) => Err(AssessError::Io {
-            path: path.to_path_buf(),
-            source,
-        }),
     }
 }
 
@@ -359,10 +342,10 @@ impl AiGuardParser for ClaudeCodeProjectParser {
 
     fn collect_external_script_paths(&self, _home_dir: &Path) -> Vec<PathBuf> {
         let claude = self.repo_root.join(".claude");
-        let base = read_json_optional(&claude.join("settings.json"))
+        let base = super::read_json_optional(&claude.join("settings.json"))
             .ok()
             .flatten();
-        let local = read_json_optional(&claude.join("settings.local.json"))
+        let local = super::read_json_optional(&claude.join("settings.local.json"))
             .ok()
             .flatten();
         if base.is_none() && local.is_none() {
@@ -378,8 +361,8 @@ impl AiGuardParser for ClaudeCodeProjectParser {
 
     fn assess(&self, _home_dir: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
         let cd = self.repo_root.join(".claude");
-        let base = read_json_optional(&cd.join("settings.json"))?;
-        let local = read_json_optional(&cd.join("settings.local.json"))?;
+        let base = super::read_json_optional(&cd.join("settings.json"))?;
+        let local = super::read_json_optional(&cd.join("settings.local.json"))?;
         if base.is_none() && local.is_none() {
             return Ok(Vec::new());
         }
@@ -403,6 +386,22 @@ mod tests {
         let claude = home.join(".claude");
         std::fs::create_dir_all(&claude).unwrap();
         std::fs::write(claude.join("settings.json"), contents).unwrap();
+    }
+
+    #[test]
+    fn empty_config_is_clean() {
+        let dir = tempdir().unwrap();
+        write_settings(dir.path(), "");
+        let p = ClaudeCodeParser;
+        assert!(p.assess(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn whitespace_config_is_clean() {
+        let dir = tempdir().unwrap();
+        write_settings(dir.path(), "  \n\t ");
+        let p = ClaudeCodeParser;
+        assert!(p.assess(dir.path()).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/claude_desktop.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_desktop.rs
@@ -68,6 +68,10 @@ impl AiGuardParser for ClaudeDesktopParser {
         let mut text: Option<(PathBuf, String)> = None;
         for path in candidates {
             match std::fs::read_to_string(&path) {
+                // Empty/whitespace stub → not configured; fall through to the
+                // next candidate rather than short-circuiting (another platform
+                // path may hold the real config). #131.
+                Ok(s) if s.trim().is_empty() => continue,
                 Ok(s) => {
                     text = Some((path, s));
                     break;
@@ -125,6 +129,44 @@ mod tests {
         let p = dir.join("claude_desktop_config.json");
         std::fs::write(&p, contents).unwrap();
         p
+    }
+
+    #[test]
+    fn empty_config_is_clean() {
+        let dir = tempdir().unwrap();
+        write_config_macos(dir.path(), "");
+        let p = ClaudeDesktopParser;
+        assert!(p.assess(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn whitespace_config_is_clean() {
+        let dir = tempdir().unwrap();
+        write_config_macos(dir.path(), "  \n\t ");
+        let p = ClaudeDesktopParser;
+        assert!(p.assess(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_macos_stub_falls_through_to_linux() {
+        // An empty macOS-path stub must NOT short-circuit assessment: the
+        // candidate loop should fall through to the Linux path, which holds
+        // the real config. Regression guard for #131.
+        let dir = tempdir().unwrap();
+        write_config_macos(dir.path(), "");
+        write_config_linux(
+            dir.path(),
+            r#"{"mcpServers": {"remote": {"url": "https://mcp.example.com"}}}"#,
+        );
+        let p = ClaudeDesktopParser;
+        let reasons = p.assess(dir.path()).unwrap();
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerRemote { .. })),
+            "empty macOS stub must fall through to the non-empty Linux config, \
+             got {reasons:?}"
+        );
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/continue_dev.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/continue_dev.rs
@@ -34,10 +34,7 @@ impl AiGuardParser for ContinueDevParser {
     fn collect_external_script_paths(&self, home_dir: &Path) -> Vec<PathBuf> {
         let cd = home_dir.join(".continue");
         let config_path = cd.join("config.json");
-        let Ok(s) = std::fs::read_to_string(&config_path) else {
-            return Vec::new();
-        };
-        let Ok(val) = serde_json::from_str::<Value>(&s) else {
+        let Some(val) = super::read_json_optional(&config_path).ok().flatten() else {
             return Vec::new();
         };
         let hooks_dir = cd.join("hooks");
@@ -46,15 +43,9 @@ impl AiGuardParser for ContinueDevParser {
 
     fn assess(&self, home_dir: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
         let path = home_dir.join(".continue").join("config.json");
-        let text = match std::fs::read_to_string(&path) {
-            Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(source) => return Err(AssessError::Io { path, source }),
+        let Some(val) = super::read_json_optional(&path)? else {
+            return Ok(Vec::new());
         };
-        let val: Value = serde_json::from_str(&text).map_err(|e| AssessError::Parse {
-            path: path.clone(),
-            message: e.to_string(),
-        })?;
         let hooks_dir = home_dir.join(".continue").join("hooks");
         let mut out = Vec::new();
         emit_mcp_reasons(&val, &mut out);
@@ -245,10 +236,7 @@ impl AiGuardParser for ContinueDevProjectParser {
     fn collect_external_script_paths(&self, _home_dir: &Path) -> Vec<PathBuf> {
         let cd = self.repo_root.join(".continue");
         let config_path = cd.join("config.json");
-        let Ok(s) = std::fs::read_to_string(&config_path) else {
-            return Vec::new();
-        };
-        let Ok(val) = serde_json::from_str::<Value>(&s) else {
+        let Some(val) = super::read_json_optional(&config_path).ok().flatten() else {
             return Vec::new();
         };
         let hooks_dir = cd.join("hooks");
@@ -257,15 +245,9 @@ impl AiGuardParser for ContinueDevProjectParser {
 
     fn assess(&self, _home_dir: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
         let path = self.repo_root.join(".continue").join("config.json");
-        let text = match std::fs::read_to_string(&path) {
-            Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(source) => return Err(AssessError::Io { path, source }),
+        let Some(val) = super::read_json_optional(&path)? else {
+            return Ok(Vec::new());
         };
-        let val: Value = serde_json::from_str(&text).map_err(|e| AssessError::Parse {
-            path: path.clone(),
-            message: e.to_string(),
-        })?;
         let hooks_dir = self.repo_root.join(".continue").join("hooks");
         let mut out = Vec::new();
         emit_mcp_reasons(&val, &mut out);
@@ -286,6 +268,22 @@ mod tests {
         let p = dir.join("config.json");
         std::fs::write(&p, contents).unwrap();
         p
+    }
+
+    #[test]
+    fn empty_config_is_clean() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), "");
+        let p = ContinueDevParser;
+        assert!(p.assess(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn whitespace_config_is_clean() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), "  \n\t ");
+        let p = ContinueDevParser;
+        assert!(p.assess(dir.path()).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/cursor.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/cursor.rs
@@ -5,20 +5,13 @@
 
 use crate::ai_guard::parser::mcp_scan::emit_mcp_reasons;
 use crate::ai_guard::parser::{AiGuardParser, AssessError};
-use serde_json::Value;
 use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
 use std::path::{Path, PathBuf};
 
 fn assess_path(path: PathBuf) -> Result<Vec<AiGuardReason>, AssessError> {
-    let text = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(source) => return Err(AssessError::Io { path, source }),
+    let Some(val) = super::read_json_optional(&path)? else {
+        return Ok(Vec::new());
     };
-    let val: Value = serde_json::from_str(&text).map_err(|e| AssessError::Parse {
-        path: path.clone(),
-        message: e.to_string(),
-    })?;
     let mut out = Vec::new();
     emit_mcp_reasons(&val, &mut out);
     Ok(out)
@@ -75,6 +68,18 @@ mod tests {
         std::fs::write(d.join("mcp.json"), body).unwrap();
     }
 
+    #[test]
+    fn empty_config_is_clean() {
+        let d = tempdir().unwrap();
+        write(d.path(), "");
+        assert!(CursorParser.assess(d.path()).unwrap().is_empty());
+    }
+    #[test]
+    fn whitespace_config_is_clean() {
+        let d = tempdir().unwrap();
+        write(d.path(), "  \n\t ");
+        assert!(CursorParser.assess(d.path()).unwrap().is_empty());
+    }
     #[test]
     fn missing_returns_empty() {
         let d = tempdir().unwrap();

--- a/crates/sigil-agent/src/ai_guard/parser/gemini.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/gemini.rs
@@ -13,15 +13,9 @@ use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
 use std::path::{Path, PathBuf};
 
 fn assess_path(path: PathBuf) -> Result<Vec<AiGuardReason>, AssessError> {
-    let text = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(source) => return Err(AssessError::Io { path, source }),
+    let Some(val) = super::read_json_optional(&path)? else {
+        return Ok(Vec::new());
     };
-    let val: Value = serde_json::from_str(&text).map_err(|e| AssessError::Parse {
-        path: path.clone(),
-        message: e.to_string(),
-    })?;
     let mut out = Vec::new();
     emit_sandbox(&val, &mut out);
     emit_mcp_reasons(&val, &mut out);
@@ -165,6 +159,18 @@ mod tests {
         GeminiParser.assess(home).unwrap()
     }
 
+    #[test]
+    fn empty_config_is_clean() {
+        let d = tempdir().unwrap();
+        write(d.path(), "");
+        assert!(assess(d.path()).is_empty());
+    }
+    #[test]
+    fn whitespace_config_is_clean() {
+        let d = tempdir().unwrap();
+        write(d.path(), "  \n\t ");
+        assert!(assess(d.path()).is_empty());
+    }
     #[test]
     fn missing_returns_empty() {
         let d = tempdir().unwrap();

--- a/crates/sigil-agent/src/ai_guard/parser/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mod.rs
@@ -10,6 +10,7 @@ pub mod cursor;
 pub mod gemini;
 pub mod mcp_scan;
 
+use serde_json::Value;
 use sigil_core::event::{AiGuardReason, AiGuardScope, AiTool};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -73,6 +74,34 @@ pub trait AiGuardParser: Send + Sync {
     }
 }
 
+/// Read + parse a JSON config file with the AI Guard's "absent = clean"
+/// convention. A missing file AND an empty / whitespace-only file both map to
+/// `Ok(None)` — the operator hasn't configured anything, which is not a
+/// finding. Non-empty malformed JSON is a real `Parse` error; I/O failures are
+/// `Io`. Single source of truth so every JSON parser treats a 0-byte config
+/// alike (#131).
+pub(crate) fn read_json_optional(path: &Path) -> Result<Option<Value>, AssessError> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(AssessError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+    };
+    if text.trim().is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str(&text)
+        .map(Some)
+        .map_err(|e| AssessError::Parse {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AssessError {
     #[error("read {path}: {source}")]
@@ -83,4 +112,53 @@ pub enum AssessError {
     },
     #[error("parse {path}: {message}")]
     Parse { path: PathBuf, message: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn read_json_optional_missing_file_returns_none() {
+        let d = tempdir().unwrap();
+        let result = read_json_optional(&d.path().join("nonexistent.json"));
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn read_json_optional_empty_file_returns_none() {
+        let d = tempdir().unwrap();
+        let p = d.path().join("empty.json");
+        std::fs::write(&p, "").unwrap();
+        assert!(read_json_optional(&p).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_json_optional_whitespace_only_returns_none() {
+        let d = tempdir().unwrap();
+        let p = d.path().join("ws.json");
+        std::fs::write(&p, "  \n\t ").unwrap();
+        assert!(read_json_optional(&p).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_json_optional_valid_json_returns_some() {
+        let d = tempdir().unwrap();
+        let p = d.path().join("valid.json");
+        std::fs::write(&p, r#"{"key": "value"}"#).unwrap();
+        let val = read_json_optional(&p).unwrap().unwrap();
+        assert_eq!(val.get("key").and_then(Value::as_str), Some("value"));
+    }
+
+    #[test]
+    fn read_json_optional_nonempty_malformed_returns_parse_error() {
+        let d = tempdir().unwrap();
+        let p = d.path().join("bad.json");
+        std::fs::write(&p, "{bad").unwrap();
+        assert!(matches!(
+            read_json_optional(&p).unwrap_err(),
+            AssessError::Parse { .. }
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes **#131** — an empty (0-byte) or whitespace-only AI-tool config file made the JSON parsers fail with `serde_json::from_str("")` → `AssessError::Parse`, which **silently dropped that tool from the entire risk assessment** (the tool vanished from the fleet rollup rather than scoring as "no findings"). A missing file was already handled; an empty file must be treated identically.

Found while dogfooding the **v0.4.0 release in the 2-machine C-S integration test** — the agent host had an empty `~/.gemini/config/mcp_config.json`, so Antigravity errored and disappeared from `/v1/fleet/hosts/<id>`.

## Fix

Single source of truth: a new `read_json_optional(path) -> Result<Option<Value>, AssessError>` in `parser/mod.rs` that maps **both** a missing file and an empty/whitespace-only file → `Ok(None)`. Non-empty malformed JSON still returns `Err(Parse)`; I/O failures still `Err(Io)`. Mirrors the #125 `emit_one_server` consolidation.

All **6 JSON parsers** routed through it: `antigravity`, `claude_code`, `continue_dev` (both assess + collect variants), `cursor`, `gemini`. `claude_desktop` keeps its multi-path candidate loop but now **`continue`s past an empty candidate** (so an empty stub at one platform path falls through to a real config at another — fixes a latent short-circuit the naive guard would have introduced).

**`codex` is exempt**: it reads TOML, and `toml::from_str("")` parses to an empty table (no error).

## Scope correction

The original issue listed `codex` and omitted `claude_desktop`; the actual affected set is the 6 JSON parsers above (codex/TOML unaffected). Noted on the issue.

## Tests

- Helper-level: missing / 0-byte / whitespace-only → None; valid → Some; non-empty malformed → Err(Parse).
- Per-parser: empty + whitespace config → `Ok(empty)`, no error.
- `claude_desktop`: empty macOS stub + real Linux config → still detects the Linux finding (no short-circuit).
- All existing "malformed non-empty → Parse error" regression tests still pass.
- Workspace `cargo fmt` + `clippy -D warnings` + `test` green. Independent codex review: clean.

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)