### PR TITLE
ci(release): make build-provenance attestation non-blocking (#130)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,14 @@ jobs:
           echo ">> signed build manifest:"
           head -c 600 dist/build-manifest.json; echo
 
+      # Supplementary supply-chain attestation. The enforced trust root is the
+      # ed25519 build-manifest signature produced in the build step above; this
+      # GitHub/Sigstore provenance is a best-effort extra. A transient Sigstore
+      # Rekor outage (network timeout fetching a tlog entry) must NOT block
+      # publishing already-built, already-signed artifacts — so this step is
+      # non-blocking. On an outage, re-run the job to (re-)attach attestations. (#130)
       - name: Attest build provenance
+        continue-on-error: true
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: "dist/sigil-*"


### PR DESCRIPTION
## Problem

The v0.4.0 release (`release.yml`, tag push) failed on first run: all 7 build jobs succeeded, but the `publish release` job died at **Attest build provenance** with a transient external error:

```
##[error]InternalError: error fetching tlog entry
FetchError: network timeout at: https://rekor.sigstore.dev/api/v1/log/entries/...
```

Because that step runs *before* **Publish GitHub Release** in the same job, a transient Sigstore/Rekor outage blocked the entire release — no artifacts published — until a manual `gh run rerun --failed` (which then succeeded with no change, confirming it was purely the flaky external dependency).

## Fix

Mark the attestation step `continue-on-error: true`. The **enforced trust root is the ed25519 `build-manifest.json` signature** produced in the build step (`SIGIL_BUILD_SIGNING_KEY`); the GitHub/Sigstore build-provenance attestation is a supplementary supply-chain extra. A transient public-good Rekor outage should not gate publishing already-built, already-signed artifacts. On an outage the attestation is skipped (re-run the job to re-attach it) but the signed release still ships.

Validated with `actionlint` (clean). Workflow only runs on tag push, so this PR's CI does not exercise it; the change is a single non-blocking flag on the existing step.

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)