### PR TITLE
feat: split packaging into Personal (standalone) and Fleet profiles (#134)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,14 @@ jobs:
           echo ">> signed build manifest:"
           head -c 600 dist/build-manifest.json; echo
 
+      # Supplementary supply-chain attestation. The enforced trust root is the
+      # ed25519 build-manifest signature produced in the build step above; this
+      # GitHub/Sigstore provenance is a best-effort extra. A transient Sigstore
+      # Rekor outage (network timeout fetching a tlog entry) must NOT block
+      # publishing already-built, already-signed artifacts — so this step is
+      # non-blocking. On an outage, re-run the job to (re-)attach attestations. (#130)
       - name: Attest build provenance
+        continue-on-error: true
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: "dist/sigil-*"

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -55,6 +55,12 @@ moat. Closed *content* combined with open *mechanism* is the standard
 split for security tooling (cf. Falco/Sysdig, Snort/Talos, Suricata/Pro
 ETPro).
 
+**Trust boundary by distribution form**: Personal installs use *unsigned* local
+rule packs distributed via git — trust derives from the git repository (the pack
+carries enforcement authority via `hook_deny_rules`; only apply packs from repos
+you trust). Fleet installs use *signed* policy bundles verified by the OSS agent
+via `verify_envelope` before any pack is applied.
+
 ---
 
 ## Decision rule for new modules

--- a/README.md
+++ b/README.md
@@ -500,6 +500,15 @@ Windows: download the `.zip` from the
 [latest release](https://github.com/Ju571nK/sigil/releases/latest). (Intel Macs
 aren't shipped as prebuilt binaries — build from source below.)
 
+### Install profiles
+
+| Profile | Binaries | Use |
+|---------|----------|-----|
+| `personal` (default) | `sigil`, `sigil-mcp`, `sigil-hook` | Local self-assessment, no server |
+| `fleet` | + `sigil-sender`, `sigil-server`, `sigil-sign` | Central server + signed rule-pack push |
+
+`SIGIL_PROFILE=fleet curl … | sh` installs the fleet set. See [docs/install-personal.md](docs/install-personal.md).
+
 ### Build from source
 
 Install the Rust toolchain listed in `rust-toolchain.toml`, then build the

--- a/crates/sigil-agent/Cargo.toml
+++ b/crates/sigil-agent/Cargo.toml
@@ -86,6 +86,8 @@ a SIEM. Ships a systemd unit (disabled by default — enable with \
 `systemctl enable --now sigil`)."""
 assets = [
     ["../../target/release/sigil", "usr/bin/", "755"],
+    ["../../target/release/sigil-mcp", "usr/bin/", "755"],
+    ["../../target/release/sigil-hook", "usr/bin/", "755"],
     ["../../config/policy.example.yaml", "etc/sigil/policy.yaml.example", "644"],
     ["../../README.md", "usr/share/doc/sigil/README.md", "644"],
     ["../../LICENSE", "usr/share/doc/sigil/LICENSE", "644"],
@@ -107,6 +109,8 @@ name = "sigil"
 summary = "Watches policy-defined files and emits hash-anchored posture events for your SIEM"
 assets = [
     { source = "../../target/release/sigil", dest = "/usr/bin/sigil", mode = "0755" },
+    { source = "../../target/release/sigil-mcp", dest = "/usr/bin/sigil-mcp", mode = "0755" },
+    { source = "../../target/release/sigil-hook", dest = "/usr/bin/sigil-hook", mode = "0755" },
     { source = "../../packaging/systemd/sigil.service", dest = "/usr/lib/systemd/system/sigil.service", mode = "0644" },
     { source = "../../config/policy.example.yaml", dest = "/etc/sigil/policy.yaml.example", mode = "0644" },
     { source = "../../README.md", dest = "/usr/share/doc/sigil/README.md", mode = "0644", doc = true },

--- a/crates/sigil-agent/src/lib.rs
+++ b/crates/sigil-agent/src/lib.rs
@@ -28,6 +28,7 @@ pub mod platform;
 pub mod policy_apply;
 pub mod policy_expiry_task;
 pub mod policy_reload_task;
+pub mod rule_packs_watch;
 pub mod runtime;
 pub mod sender_offset;
 pub mod show;

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -147,19 +147,33 @@ fn reconcile_rule_packs(
     (added, removed)
 }
 
-/// Task 5 — read + parse the optional distributed rule-pack bundle
-/// (`rule-packs.yaml`, written beside `policy.yaml` by `apply_rule_packs`) into
-/// an `Option<PolicyDocument>`. Only its `.rule_packs` are consumed by `merge`
-/// as the 3rd (bundle) layer. Fail-open: a missing file → `None`; a corrupt
-/// file → warn + `None` (never crashes the agent).
-fn read_bundle_doc(path: &std::path::Path) -> Option<sigil_core::policy::PolicyDocument> {
-    let s = std::fs::read_to_string(path).ok()?;
+/// 번들 파일 3상태. Absent=파일 없음(정상, bundle 레이어 없음),
+/// Present=파스 성공, Corrupt=파일은 있으나 파스 실패(이전 정상 유지 대상).
+/// PolicyDocument is large (~392 B) so we box it to keep the enum small.
+pub(crate) enum BundleState {
+    Absent,
+    Present(Box<sigil_core::policy::PolicyDocument>),
+    Corrupt,
+}
+
+pub(crate) fn read_bundle_state(path: &std::path::Path) -> BundleState {
+    let s = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return BundleState::Absent,
+        Err(e) => {
+            tracing::warn!(error = ?e, path = %path.display(), "rule-packs.yaml read failed");
+            return BundleState::Corrupt; // 읽기 실패도 보수적으로 corrupt(이전 유지)
+        }
+    };
+    if s.trim().is_empty() {
+        return BundleState::Absent;
+    }
     match sigil_core::policy::parse(&s) {
-        Ok(d) => Some(d),
+        Ok(d) => BundleState::Present(Box::new(d)),
         Err(e) => {
             tracing::warn!(error = ?e, path = %path.display(),
-                "rule-packs.yaml parse failed; ignoring bundle layer");
-            None
+                "rule-packs.yaml parse failed; retaining last good bundle");
+            BundleState::Corrupt
         }
     }
 }
@@ -202,6 +216,9 @@ pub struct ReloadCtx {
     /// #115 — shared deny evaluator. reload() rebuilds from
     /// EffectivePolicy.hook_deny_rules and swaps; keep-previous on Err.
     pub shared_evaluator: crate::hook_deny::SharedEvaluator,
+    /// #134 — 마지막으로 성공 파스된 번들 doc. corrupt 시 이를 재사용해
+    /// transient 파스 실패가 번들 룰팩을 drop하지 않게 한다.
+    pub last_good_bundle: Option<sigil_core::policy::PolicyDocument>,
 }
 
 pub async fn run(mut ctx: ReloadCtx) {
@@ -257,9 +274,22 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
             return;
         }
     };
-    // Task 5 — read the distributed rule-pack bundle (3rd merge layer:
-    // defaults < policy < bundle). Missing/corrupt → None (fail-open).
-    let bundle = read_bundle_doc(&ctx.rule_packs_yaml_path);
+    // Task 5 / #134 — read the distributed rule-pack bundle (3rd merge layer:
+    // defaults < policy < bundle).
+    // Corrupt(파일 존재+파스 실패) → retain last good (transient git-pull state protected).
+    // Absent(파일 삭제) → clear cache (deliberate rm honored).
+    let bundle: Option<sigil_core::policy::PolicyDocument> =
+        match read_bundle_state(&ctx.rule_packs_yaml_path) {
+            BundleState::Present(d) => {
+                ctx.last_good_bundle = Some((*d).clone());
+                Some(*d)
+            }
+            BundleState::Corrupt => ctx.last_good_bundle.clone(), // 이전 정상 유지
+            BundleState::Absent => {
+                ctx.last_good_bundle = None; // 의도적 제거 → 캐시 비움
+                None
+            }
+        };
     let mut effective = match sigil_core::policy::merge(
         defaults,
         Some(doc),
@@ -273,14 +303,20 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
         }
     };
 
-    // #115 — rebuild the shared deny evaluator from the freshly-merged policy.
-    // Keep-previous on regex compile failure (fail-open is the previous state).
-    match crate::hook_deny::DenyEvaluator::new(&effective.hook_deny_rules) {
-        Ok(e) => {
-            *ctx.shared_evaluator.write() = std::sync::Arc::new(e);
+    // #115 / #134 — rebuild the shared deny evaluator from the freshly-merged
+    // policy. Keep-previous on deny-id validation failure OR regex compile
+    // failure (fail-open is the previous state).
+    if let Err(e) = sigil_core::policy::validate_deny_rule_ids(&effective.hook_deny_rules) {
+        tracing::warn!(error = %e,
+            "merged hook_deny_rules failed id validation on reload; keeping previous evaluator");
+    } else {
+        match crate::hook_deny::DenyEvaluator::new(&effective.hook_deny_rules) {
+            Ok(ev) => {
+                *ctx.shared_evaluator.write() = std::sync::Arc::new(ev);
+            }
+            Err(e) => tracing::warn!(error = ?e,
+                "hook deny rules failed to compile on reload; keeping previous evaluator"),
         }
-        Err(e) => tracing::warn!(error = ?e,
-            "hook deny rules failed to compile on reload; keeping previous evaluator"),
     }
 
     // Phase 3b.6.2 — re-discover all 5 tools and reconcile each via the
@@ -660,6 +696,7 @@ mod tests {
                 shared_evaluator: Arc::new(parking_lot::RwLock::new(Arc::new(
                     crate::hook_deny::DenyEvaluator::new(&[]).unwrap(),
                 ))),
+                last_good_bundle: None,
             },
             plat,
             targets_rx,
@@ -723,6 +760,7 @@ mod tests {
                 shared_evaluator: Arc::new(parking_lot::RwLock::new(Arc::new(
                     crate::hook_deny::DenyEvaluator::new(&[]).unwrap(),
                 ))),
+                last_good_bundle: None,
             },
             plat,
             targets_rx,
@@ -1339,6 +1377,45 @@ mod tests {
             has_bundle,
             "expected bundle-pack from rule-packs.yaml after reload"
         );
+    }
+
+    // #134 — BundleState 3-way state machine: Absent / Present / Corrupt.
+    #[test]
+    fn bundle_state_distinguishes_missing_valid_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("rule-packs.yaml");
+        assert!(matches!(read_bundle_state(&p), BundleState::Absent));
+        std::fs::write(
+            &p,
+            "version: 1\nhost_id_strategy: machine_id\ntargets: []\n",
+        )
+        .unwrap();
+        assert!(matches!(read_bundle_state(&p), BundleState::Present(_)));
+        std::fs::write(&p, "}{not yaml").unwrap();
+        assert!(matches!(read_bundle_state(&p), BundleState::Corrupt));
+    }
+
+    // #134 — corrupt bundle retains the last successfully parsed bundle doc.
+    #[test]
+    fn corrupt_bundle_retains_last_good() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("rule-packs.yaml");
+        std::fs::write(
+            &p,
+            "version: 1\nhost_id_strategy: machine_id\ntargets: []\n",
+        )
+        .unwrap();
+        let mut cache: Option<sigil_core::policy::PolicyDocument> = None;
+        if let BundleState::Present(d) = read_bundle_state(&p) {
+            cache = Some(*d);
+        }
+        assert!(cache.is_some());
+        std::fs::write(&p, "}{bad").unwrap();
+        let retained = match read_bundle_state(&p) {
+            BundleState::Corrupt => cache.clone(),
+            _ => None,
+        };
+        assert!(retained.is_some(), "corrupt must retain last good");
     }
 
     // Task 5 — when policy.yaml and the distributed bundle both carry a pack

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -147,8 +147,9 @@ fn reconcile_rule_packs(
     (added, removed)
 }
 
-/// 번들 파일 3상태. Absent=파일 없음(정상, bundle 레이어 없음),
-/// Present=파스 성공, Corrupt=파일은 있으나 파스 실패(이전 정상 유지 대상).
+/// Three states for the rule-pack bundle file. `Absent` = file missing (normal,
+/// no bundle layer); `Present` = parsed OK; `Corrupt` = file exists but failed
+/// to parse (retain the last-good bundle instead of dropping its packs).
 /// PolicyDocument is large (~392 B) so we box it to keep the enum small.
 pub(crate) enum BundleState {
     Absent,
@@ -165,6 +166,9 @@ pub(crate) fn read_bundle_state(path: &std::path::Path) -> BundleState {
             return BundleState::Corrupt; // 읽기 실패도 보수적으로 corrupt(이전 유지)
         }
     };
+    // A zero-byte / whitespace-only file is treated as Absent (not Corrupt) for
+    // atomic-write resilience: a file briefly empty mid-write — or a deliberately
+    // empty config — should leave no bundle layer, not pin a stale last-good one.
     if s.trim().is_empty() {
         return BundleState::Absent;
     }
@@ -281,8 +285,9 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
     let bundle: Option<sigil_core::policy::PolicyDocument> =
         match read_bundle_state(&ctx.rule_packs_yaml_path) {
             BundleState::Present(d) => {
-                ctx.last_good_bundle = Some((*d).clone());
-                Some(*d)
+                let doc = *d;
+                ctx.last_good_bundle = Some(doc.clone());
+                Some(doc)
             }
             BundleState::Corrupt => ctx.last_good_bundle.clone(), // 이전 정상 유지
             BundleState::Absent => {
@@ -1376,6 +1381,53 @@ mod tests {
         assert!(
             has_bundle,
             "expected bundle-pack from rule-packs.yaml after reload"
+        );
+    }
+
+    // #134 review — reload()-level retain test: a corrupt rule-packs.yaml write
+    // arriving AFTER a good bundle was loaded must keep the bundle's pack live
+    // (via ctx.last_good_bundle), not drop it. Exercises the actual Present →
+    // Corrupt arms in reload(), not just the read_bundle_state state machine.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reload_corrupt_bundle_retains_pack_in_live_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let initial = "version: 1\nhost_id_strategy: machine_id\ntargets:\n  - id: t1\n    description: x\n    tier: standard\n    platform: any\n    paths: [\"/tmp/x\"]\n";
+        let (mut ctx, plat, _trx, parsers, _state) = build_ctx_with_parsers(dir.path(), initial);
+
+        // 1. Valid bundle → pack goes live, cache seeded.
+        let bundle = "version: 1\nrule_packs:\n  - id: retained-pack\n    pack_version: 1\n    tool: gemini\n    scope:\n      kind: user_global\n    watched_paths: []\n    rules: []\n";
+        std::fs::write(&ctx.rule_packs_yaml_path, bundle).unwrap();
+        reload(&mut ctx, &plat);
+
+        let is_live = |parsers: &Arc<
+            parking_lot::RwLock<Vec<Arc<dyn crate::ai_guard::parser::AiGuardParser>>>,
+        >| {
+            parsers.read().iter().any(|p| {
+                p.as_any()
+                    .downcast_ref::<crate::ai_guard::rule_pack::parser::RulePackParser>()
+                    .map(|rpp| rpp.pack.id == "retained-pack")
+                    .unwrap_or(false)
+            })
+        };
+        assert!(is_live(&parsers), "pack should be live after valid bundle");
+        assert!(
+            ctx.last_good_bundle.is_some(),
+            "cache should be seeded after valid bundle"
+        );
+
+        // 2. Corrupt the bundle on disk and reload.
+        std::fs::write(&ctx.rule_packs_yaml_path, "}{not yaml").unwrap();
+        reload(&mut ctx, &plat);
+
+        // 3. The pack MUST still be live (retained from last-good), and the
+        //    cache must still hold it.
+        assert!(
+            is_live(&parsers),
+            "pack must stay live after corrupt reload (retained from last-good)"
+        );
+        assert!(
+            ctx.last_good_bundle.is_some(),
+            "cache must persist across a corrupt reload"
         );
     }
 

--- a/crates/sigil-agent/src/rule_packs_watch.rs
+++ b/crates/sigil-agent/src/rule_packs_watch.rs
@@ -17,7 +17,7 @@
 //! TempDir::new()가 반환하는 경로(비정규)와 notify가 보고하는 이벤트 경로(정규)가
 //! 달라진다. `dunce::canonicalize`로 target과 watch 디렉터리를 정규화해 비교가
 //! 올바르게 이루어지도록 한다.
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, Event, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc as std_mpsc;
 use std::time::Duration;
@@ -25,7 +25,7 @@ use tokio::sync::{mpsc as tokio_mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 /// 이벤트 경로가 감시 대상(rule-packs.yaml)인지 판정.
-pub(crate) fn is_rule_packs_event(target: &Path, evented: &Path) -> bool {
+fn is_rule_packs_event(target: &Path, evented: &Path) -> bool {
     evented == target
 }
 
@@ -41,8 +41,19 @@ fn existing_parent(target: &Path) -> Option<PathBuf> {
 /// `version_tx`에 단조 증가 카운터를 보낸다. 부모 디렉터리가 없으면
 /// 경고만 남기고 종료.
 ///
+/// `poll_interval = Some(d)`이면 메인 watcher와 동일하게 `PollWatcher`를 쓴다
+/// (NFS/virtiofs/9p 등 OS-네이티브 FS 이벤트가 신뢰 불가한 호스트, `--poll`).
+/// `None`이면 OS-네이티브 `RecommendedWatcher`. runtime은 메인 watcher와
+/// 동일한 값을 넘겨, 운영자가 깨졌다고 선언한 FS 이벤트에 hot-reload가
+/// 의존하지 않도록 한다.
+///
 /// notify 이벤트 드레인은 spawn_blocking으로 분리해 tokio 워커를 점유하지 않는다.
-pub async fn run(target: PathBuf, version_tx: watch::Sender<i64>, shutdown: CancellationToken) {
+pub async fn run(
+    target: PathBuf,
+    version_tx: watch::Sender<i64>,
+    poll_interval: Option<Duration>,
+    shutdown: CancellationToken,
+) {
     let parent = match existing_parent(&target) {
         Some(p) => p,
         None => {
@@ -71,25 +82,43 @@ pub async fn run(target: PathBuf, version_tx: watch::Sender<i64>, shutdown: Canc
     let (tok_tx, mut tok_rx) = tokio_mpsc::channel::<()>(8);
 
     let target_for_cb = canonical_target.clone();
-    let mut watcher = match RecommendedWatcher::new(
-        move |res: notify::Result<Event>| {
-            if let Ok(ev) = res {
-                if ev
-                    .paths
-                    .iter()
-                    .any(|p| is_rule_packs_event(&target_for_cb, p))
-                {
-                    let _ = std_tx.send(());
+    // Mirror the main watcher's callback: log backend errors instead of
+    // silently dropping them. If inotify watch-limit / kqueue fd exhaustion
+    // hits, hot-reload would otherwise die with no trace.
+    let on_event = move |res: notify::Result<Event>| match res {
+        Ok(ev) => {
+            if ev
+                .paths
+                .iter()
+                .any(|p| is_rule_packs_event(&target_for_cb, p))
+            {
+                let _ = std_tx.send(());
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "rule-packs watcher backend error");
+        }
+    };
+    // `--poll` (poll_interval = Some) → PollWatcher, matching the main watcher.
+    // Otherwise the OS-native RecommendedWatcher. `Box<dyn Watcher>` lets both
+    // backends share the rest of the function (only watch()/drop() are needed).
+    let mut watcher: Box<dyn Watcher + Send> = match poll_interval {
+        Some(interval) => {
+            match PollWatcher::new(on_event, Config::default().with_poll_interval(interval)) {
+                Ok(w) => Box::new(w),
+                Err(e) => {
+                    tracing::error!(error = ?e, "rule-packs poll watcher init failed");
+                    return;
                 }
             }
-        },
-        notify::Config::default(),
-    ) {
-        Ok(w) => w,
-        Err(e) => {
-            tracing::error!(error = ?e, "rule-packs watcher init failed");
-            return;
         }
+        None => match RecommendedWatcher::new(on_event, Config::default()) {
+            Ok(w) => Box::new(w),
+            Err(e) => {
+                tracing::error!(error = ?e, "rule-packs watcher init failed");
+                return;
+            }
+        },
     };
     // Canonicalize the watch directory so FSEvents on macOS receives the real
     // path (not the /var → /private/var symlink). Without this, FSEvents may
@@ -125,6 +154,12 @@ pub async fn run(target: PathBuf, version_tx: watch::Sender<i64>, shutdown: Canc
         }
     });
 
+    // Drop our retained sender so the `None` arm below becomes genuinely
+    // reachable: once `tok_tx_clone` in the drain thread also drops (on its own
+    // exit), `tok_rx.recv()` returns None and the loop ends. Normal shutdown
+    // still flows through the CancellationToken arm.
+    drop(tok_tx);
+
     // Async event loop — receives debounced signals from the drain thread.
     let mut counter = *version_tx.borrow();
     loop {
@@ -137,7 +172,8 @@ pub async fn run(target: PathBuf, version_tx: watch::Sender<i64>, shutdown: Canc
                         let _ = version_tx.send(counter);
                         tracing::debug!(counter, "rule-packs.yaml changed; reload triggered");
                     }
-                    None => break, // drain loop exited
+                    // Drain thread exited (its sender dropped); nothing more to do.
+                    None => break,
                 }
             }
         }
@@ -171,5 +207,57 @@ mod tests {
             !is_rule_packs_event(&target, Path::new("/other/dir/rule-packs.yaml")),
             "same filename in different dir should return false"
         );
+    }
+
+    /// Poll-path coverage (#134 review item 2): with `poll_interval = Some(..)`
+    /// the watcher builds a `PollWatcher` (not the native backend) and still
+    /// bumps `version_tx` when rule-packs.yaml is written. Polling is backend-
+    /// independent, so this is fast and deterministic on every OS/CI.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poll_watcher_triggers_version_bump() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dunce::canonicalize(dir.path()).unwrap();
+        let target = root.join("rule-packs.yaml");
+        std::fs::write(&target, "version: 1\n").unwrap();
+
+        let (tx, mut rx) = watch::channel(0i64);
+        let shutdown = CancellationToken::new();
+
+        // Short poll interval so the test completes quickly.
+        let handle = tokio::spawn(run(
+            target.clone(),
+            tx,
+            Some(Duration::from_millis(100)),
+            shutdown.clone(),
+        ));
+
+        // Repeatedly mutate the file (growing content so mtime + size change)
+        // while waiting for the counter to advance past its initial 0. The loop
+        // tolerates the registration window and any poll-tick alignment so the
+        // test stays deterministic regardless of timer phase.
+        let bumped = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut n = 2u32;
+            loop {
+                std::fs::write(&target, format!("version: {n}\n")).unwrap();
+                n += 1;
+                tokio::select! {
+                    r = rx.changed() => {
+                        if r.is_err() {
+                            break false;
+                        }
+                        if *rx.borrow() > 0 {
+                            break true;
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(200)) => {}
+                }
+            }
+        })
+        .await
+        .expect("poll watcher should bump version within 10s");
+        assert!(bumped, "version_tx counter should advance on file change");
+
+        shutdown.cancel();
+        let _ = handle.await;
     }
 }

--- a/crates/sigil-agent/src/rule_packs_watch.rs
+++ b/crates/sigil-agent/src/rule_packs_watch.rs
@@ -1,0 +1,175 @@
+//! rule-packs.yaml 전용 fsnotify watcher (#134).
+//! 메인 watcher는 normalizer가 policy target에 안 맞는 경로를 drop하므로
+//! 재사용 불가. 이 모듈은 rule-packs.yaml의 부모 디렉터리를 감시하고,
+//! 대상 파일 변경 시 rule_packs_version_tx에 트리거 카운터를 보내
+//! policy_reload_task의 rule_packs_version_rx.changed()를 깨운다.
+//!
+//! ## 구현 노트 — spawn_blocking
+//!
+//! notify의 RecommendedWatcher는 내부적으로 std::sync::mpsc 채널을 사용하며,
+//! recv_timeout은 blocking 호출이다. tokio 워커 스레드를 blocking으로 점유하면
+//! async 런타임이 stall할 수 있으므로, 이벤트 드레인 루프를 spawn_blocking으로
+//! 분리하고 tokio::sync::mpsc를 통해 async 컨텍스트와 통신한다.
+//!
+//! ## 구현 노트 — 경로 정규화
+//!
+//! macOS에서 /var → /private/var, /tmp → /private/tmp 심볼릭 링크로 인해
+//! TempDir::new()가 반환하는 경로(비정규)와 notify가 보고하는 이벤트 경로(정규)가
+//! 달라진다. `dunce::canonicalize`로 target과 watch 디렉터리를 정규화해 비교가
+//! 올바르게 이루어지도록 한다.
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc as std_mpsc;
+use std::time::Duration;
+use tokio::sync::{mpsc as tokio_mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+/// 이벤트 경로가 감시 대상(rule-packs.yaml)인지 판정.
+pub(crate) fn is_rule_packs_event(target: &Path, evented: &Path) -> bool {
+    evented == target
+}
+
+/// 부모 디렉터리가 존재하면 그 경로, 없으면 None.
+fn existing_parent(target: &Path) -> Option<PathBuf> {
+    target
+        .parent()
+        .filter(|p| p.exists())
+        .map(|p| p.to_path_buf())
+}
+
+/// 전용 watcher 태스크. 부모 디렉터리를 감시하고 대상 파일 변경 시
+/// `version_tx`에 단조 증가 카운터를 보낸다. 부모 디렉터리가 없으면
+/// 경고만 남기고 종료.
+///
+/// notify 이벤트 드레인은 spawn_blocking으로 분리해 tokio 워커를 점유하지 않는다.
+pub async fn run(target: PathBuf, version_tx: watch::Sender<i64>, shutdown: CancellationToken) {
+    let parent = match existing_parent(&target) {
+        Some(p) => p,
+        None => {
+            tracing::warn!(path = %target.display(),
+                "rule-packs.yaml parent dir absent; dedicated watcher not started");
+            return;
+        }
+    };
+    // Canonicalize target so notify event paths (always canonical on macOS/Linux
+    // where /tmp → /private/tmp, /var → /private/var) compare correctly.
+    // If the file doesn't exist yet (first boot before any rule-packs.yaml is
+    // written), fall back to canonicalizing the parent and re-joining the filename.
+    let canon_parent = dunce::canonicalize(&parent).unwrap_or_else(|_| parent.clone());
+    let canonical_target = if target.exists() {
+        dunce::canonicalize(&target).unwrap_or_else(|_| target.clone())
+    } else {
+        target
+            .file_name()
+            .map(|name| canon_parent.join(name))
+            .unwrap_or(target.clone())
+    };
+
+    // std::sync::mpsc for notify callback → blocking drain loop.
+    let (std_tx, std_rx) = std_mpsc::channel::<()>();
+    // tokio::sync::mpsc to ferry "something changed" signals to async context.
+    let (tok_tx, mut tok_rx) = tokio_mpsc::channel::<()>(8);
+
+    let target_for_cb = canonical_target.clone();
+    let mut watcher = match RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            if let Ok(ev) = res {
+                if ev
+                    .paths
+                    .iter()
+                    .any(|p| is_rule_packs_event(&target_for_cb, p))
+                {
+                    let _ = std_tx.send(());
+                }
+            }
+        },
+        notify::Config::default(),
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!(error = ?e, "rule-packs watcher init failed");
+            return;
+        }
+    };
+    // Canonicalize the watch directory so FSEvents on macOS receives the real
+    // path (not the /var → /private/var symlink). Without this, FSEvents may
+    // not deliver events when the watch path is a symlink target.
+    if let Err(e) = watcher.watch(&canon_parent, RecursiveMode::NonRecursive) {
+        tracing::error!(error = ?e, dir = %canon_parent.display(), "rule-packs watch failed");
+        return;
+    }
+    tracing::info!(
+        dir = %canon_parent.display(),
+        target = %canonical_target.display(),
+        "rule-packs.yaml dedicated watcher started"
+    );
+
+    // Blocking drain loop — runs on a dedicated thread pool thread so the tokio
+    // workers stay free. Debounces bursts by draining the channel after each hit.
+    // Sends a single () on tok_tx per debounced event group.
+    let tok_tx_clone = tok_tx.clone();
+    let _drain_handle = tokio::task::spawn_blocking(move || {
+        loop {
+            match std_rx.recv_timeout(Duration::from_millis(300)) {
+                Ok(()) => {
+                    // Drain any additional events queued during the bounce window.
+                    while std_rx.recv_timeout(Duration::from_millis(50)).is_ok() {}
+                    // Best-effort: if receiver is gone, stop the drain loop.
+                    if tok_tx_clone.blocking_send(()).is_err() {
+                        break;
+                    }
+                }
+                Err(std_mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    });
+
+    // Async event loop — receives debounced signals from the drain thread.
+    let mut counter = *version_tx.borrow();
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            msg = tok_rx.recv() => {
+                match msg {
+                    Some(()) => {
+                        counter += 1;
+                        let _ = version_tx.send(counter);
+                        tracing::debug!(counter, "rule-packs.yaml changed; reload triggered");
+                    }
+                    None => break, // drain loop exited
+                }
+            }
+        }
+    }
+    // Keep `watcher` alive until the loop exits so notify keeps firing.
+    drop(watcher);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_target_file_only() {
+        let target = PathBuf::from("/some/dir/rule-packs.yaml");
+
+        // Exact match → true.
+        assert!(
+            is_rule_packs_event(&target, Path::new("/some/dir/rule-packs.yaml")),
+            "exact match should return true"
+        );
+
+        // Sibling file (policy.yaml in the same dir) → false.
+        assert!(
+            !is_rule_packs_event(&target, Path::new("/some/dir/policy.yaml")),
+            "sibling policy.yaml should return false"
+        );
+
+        // Same filename but different directory → false.
+        assert!(
+            !is_rule_packs_event(&target, Path::new("/other/dir/rule-packs.yaml")),
+            "same filename in different dir should return false"
+        );
+    }
+}

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -125,6 +125,20 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     // it as the 3rd layer (defaults < policy < bundle). MUST stay identical to
     // `ApplyContext.rule_packs_yaml_path` so apply writes where boot/reload read.
     let rule_packs_yaml_path = policy_path_for_apply.with_file_name("rule-packs.yaml");
+    // #134 review — ensure the config dir exists so the dedicated rule-packs
+    // watcher can arm itself on first boot (it watches the parent dir; a missing
+    // dir keeps the watcher permanently dead until restart).  Best-effort: on
+    // error we log a warning and continue — the dir may be unwritable (e.g.
+    // /etc/sigil without root) for packaged installs where it already exists.
+    if let Some(dir) = policy_path_for_apply.parent() {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            tracing::warn!(
+                error = ?e,
+                path = %dir.display(),
+                "could not create config dir; rule-packs watcher may not arm if dir is absent"
+            );
+        }
+    }
     // Fail-open: missing/corrupt rule-packs.yaml → None (no bundle packs).
     let bundle_doc = std::fs::read_to_string(&rule_packs_yaml_path)
         .ok()

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -420,6 +420,11 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     // `rule_packs_version_tx` into the reload task below so an `apply_rule_packs`
     // bump re-runs the 3-layer merge live.
     let (rule_packs_version_tx, rule_packs_version_rx) = watch::channel(0i64);
+    // #134 — clone before apply_ctx moves rule_packs_version_tx; dedicated FS
+    // watcher uses this clone to trigger reload when rule-packs.yaml changes on
+    // disk (e.g. via git pull), bypassing the main normalizer which would drop
+    // the event because rule-packs.yaml is not a policy target.
+    let rule_packs_version_tx_fs = rule_packs_version_tx.clone();
     let apply_ctx = Arc::new(crate::policy_apply::ApplyContext {
         keystore: keystore.clone(),
         cache: cache.clone(),
@@ -550,6 +555,9 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     // Live policy reload: on a successful `apply_policy`, re-derive watch
     // targets/roots from the new policy.yaml and apply them to the running
     // pipeline + watcher (no restart). Owns the watcher handle + targets sender.
+    // #134 — clone rule_packs_yaml_path before policy_reload moves it;
+    // the dedicated FS watcher task needs the same path.
+    let rule_packs_yaml_path_for_fs = rule_packs_yaml_path.clone();
     sup.track(
         "policy_reload",
         tokio::spawn(crate::policy_reload_task::run(
@@ -569,6 +577,19 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                 rubric: rubric_handle.clone(),
                 shared_evaluator: shared_evaluator.clone(),
             },
+        )),
+    );
+
+    // #134 — dedicated fsnotify watcher for rule-packs.yaml hot-reload.
+    // Bypasses the main normalizer (which drops non-target paths) and sends
+    // directly on rule_packs_version_tx so policy_reload_task re-reads the
+    // bundle layer when rule-packs.yaml changes on disk (e.g. via git pull).
+    sup.track(
+        "rule_packs_watch",
+        tokio::spawn(crate::rule_packs_watch::run(
+            rule_packs_yaml_path_for_fs,
+            rule_packs_version_tx_fs,
+            sup.shutdown.clone(),
         )),
     );
 

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -576,6 +576,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                 ext_scripts: ext_scripts_registry.clone(),
                 rubric: rubric_handle.clone(),
                 shared_evaluator: shared_evaluator.clone(),
+                last_good_bundle: None,
             },
         )),
     );

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -584,11 +584,15 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     // Bypasses the main normalizer (which drops non-target paths) and sends
     // directly on rule_packs_version_tx so policy_reload_task re-reads the
     // bundle layer when rule-packs.yaml changes on disk (e.g. via git pull).
+    // Passes the SAME poll_interval as the main watcher so a `--poll` host
+    // (NFS/virtiofs/9p) drives rule-packs hot-reload via polling too, instead
+    // of the native FS events the operator declared unreliable.
     sup.track(
         "rule_packs_watch",
         tokio::spawn(crate::rule_packs_watch::run(
             rule_packs_yaml_path_for_fs,
             rule_packs_version_tx_fs,
+            poll_interval,
             sup.shutdown.clone(),
         )),
     );

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -136,6 +136,11 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                 None
             }
         });
+    // #134 review — seed the reload retain cache with the boot-parsed bundle so
+    // a corrupt rule-packs.yaml write arriving BEFORE the first successful reload
+    // (e.g. a fast git-pull right after startup) retains the boot packs instead
+    // of dropping them. Clone before `merge` consumes `bundle_doc`.
+    let bundle_doc_for_ctx = bundle_doc.clone();
     let mut effective = merge(defaults()?, user_doc, bundle_doc, current_platform())?;
     // (host_id resolution moved up above; effective.host_id_strategy is no longer consulted)
 
@@ -576,7 +581,7 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
                 ext_scripts: ext_scripts_registry.clone(),
                 rubric: rubric_handle.clone(),
                 shared_evaluator: shared_evaluator.clone(),
-                last_good_bundle: None,
+                last_good_bundle: bundle_doc_for_ctx,
             },
         )),
     );

--- a/crates/sigil-agent/tests/rule_packs_hot_reload.rs
+++ b/crates/sigil-agent/tests/rule_packs_hot_reload.rs
@@ -1,0 +1,142 @@
+//! e2e: writing rule-packs.yaml on disk triggers a live hot-reload via the
+//! dedicated fsnotify watcher added in #134, WITHOUT requiring a server or IPC
+//! call. The new pack's rule fires via the normal ai_guard file-change path
+//! after reload, emitting an `AiGuardRiskAssessed` event. The test also
+//! verifies that NO `file_change` posture event was emitted for the
+//! `rule-packs.yaml` path itself (proving the normalizer was bypassed, not fed).
+//!
+//! Unix only + operator-cli feature (control socket used for start-up readiness
+//! detection).
+//!
+//! ## Design note (reload → assessment trigger)
+//!
+//! The `ai_guard_task` runs a boot scan then re-assesses only on:
+//! (a) file-change broadcasts from the hasher, or (b) heartbeat (24 h in prod).
+//! After hot-reload the new parser is live in `parsers`, but the task won't
+//! re-scan spontaneously. We therefore add the config file to `policy.yaml`
+//! as a standard target AND to the rule pack's `watched_paths`. After writing
+//! `rule-packs.yaml` we poll: wait for reload to land (we verify via a
+//! `reload_policy` control call that the new parser is active), then rewrite the
+//! config so the hasher broadcasts it → `ai_guard_task` picks it up and emits
+//! `AiGuardRiskAssessed` from the new pack. This matches real-world usage: a
+//! `git pull` on `rule-packs.yaml` is usually followed by a config change (or
+//! the user expects the next heartbeat to pick it up).
+#![cfg(all(unix, feature = "operator-cli"))]
+
+mod common;
+use common::{fs_event_timeout, TestAgentBuilder};
+use std::time::Duration;
+
+/// Policy that watches `config_path` as a standard target so the main watcher
+/// tracks it. No rule packs — they arrive via rule-packs.yaml hot-reload.
+fn base_policy(config_path: &str) -> String {
+    let id = format!("hot-reload-target-{}", uuid::Uuid::new_v4().simple());
+    format!(
+        "version: 1\nhost_id_strategy: machine_id\ntargets:\n  - id: {id}\n    description: hot-reload test target\n    tier: standard\n    platform: any\n    paths:\n      - '{config_path}'\n    recursive: false\n    follow_symlinks: false\n"
+    )
+}
+
+/// A minimal rule-pack bundle YAML whose `my-hot-pack` UserGlobal pack watches
+/// `config_path` and emits `permissions_deny_empty` whenever `$.enabled`
+/// exists — a deterministic marker for test assertions.
+fn hot_reload_bundle(config_path: &str) -> String {
+    format!(
+        "version: 1\nrule_packs:\n  - id: my-hot-pack\n    pack_version: 1\n    tool: other\n    tool_label: hot-reload-test\n    scope:\n      kind: user_global\n    watched_paths:\n      - '{config_path}'\n    rules:\n      - id: r0\n        on_file: '{config_path}'\n        format: json\n        selector: '$.enabled'\n        matcher:\n          kind: exists\n        emit:\n          kind: permissions_deny_empty\n"
+    )
+}
+
+/// Writing rule-packs.yaml on disk hot-reloads the live agent (bypassing the
+/// main normalizer), the new pack's rule fires on the next file-change event
+/// for the pack's watched config, and no `file_change` posture event is
+/// produced for `rule-packs.yaml` itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rule_packs_yaml_write_triggers_reload_and_emits_pack_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(dir.path()).unwrap();
+
+    // The JSON config file: both a policy target (so the hasher watches it) and
+    // the file the new rule pack will assess.
+    let config_dir = root.join("hot");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.json");
+    std::fs::write(&config_path, r#"{"enabled": true}"#).unwrap();
+    let config_str = config_path.display().to_string();
+
+    // Start with a policy that watches config.json but has no rule packs.
+    let policy = base_policy(&config_str);
+    let agent = TestAgentBuilder::new().policy(&policy).start().await;
+
+    // rule-packs.yaml lives beside policy.yaml in the TestAgent tempdir.
+    let rule_packs_path = agent.policy_file.with_file_name("rule-packs.yaml");
+    let bundle_yaml = hot_reload_bundle(&config_str);
+
+    // Write rule-packs.yaml and then poll for the AiGuardRiskAssessed event.
+    //
+    // The dedicated watcher (#134) might not be active immediately after agent
+    // start (the FSEvents backend on macOS can take several seconds to register).
+    // We re-write rule-packs.yaml periodically inside the loop so the watcher
+    // catches it even if the first write races the watcher setup. We also
+    // re-write config.json to trigger the ai_guard_task via the hasher's
+    // file-change broadcast once the pack has been hot-reloaded.
+    let timeout = fs_event_timeout();
+    let is_hot_pack_event = |v: &serde_json::Value| {
+        v["evidence"]["kind"] == "ai_guard_risk_assessed"
+            && v["evidence"]["rule_pack_id"] == "my-hot-pack"
+    };
+
+    let deadline = std::time::Instant::now() + timeout;
+    let mut found = false;
+    let mut iteration = 0u32;
+    while std::time::Instant::now() < deadline {
+        // Re-write rule-packs.yaml on every iteration so the dedicated watcher
+        // catches it even if the first write raced the watcher setup window.
+        std::fs::write(&rule_packs_path, &bundle_yaml).unwrap();
+
+        // Brief settle: give the watcher time to deliver the rule-packs.yaml
+        // event and policy_reload_task time to reload the new pack before we
+        // prod the hasher with a config.json change.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        // Rewrite config so the hasher broadcasts it → ai_guard_task runs the
+        // newly-loaded rule pack parser.
+        std::fs::write(
+            &config_path,
+            format!(r#"{{"enabled": true, "iter": {iteration}}}"#),
+        )
+        .unwrap();
+        iteration += 1;
+
+        if let Some(_ev) = agent
+            .wait_for_event(&is_hot_pack_event, Duration::from_millis(800))
+            .await
+        {
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "expected AiGuardRiskAssessed from my-hot-pack after hot-reload + config touch"
+    );
+
+    // Small drain window so any stray normalizer events can arrive before we
+    // snapshot the event log.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Assert NO file_change posture event was emitted for rule-packs.yaml
+    // itself (the dedicated watcher bypasses the normalizer entirely).
+    let rule_packs_path_str = rule_packs_path.display().to_string();
+    let got_file_change_for_rp = agent.read_all_events().into_iter().any(|v| {
+        v["evidence"]["kind"] == "file_change"
+            && v["subject"]["value"]
+                .as_str()
+                .map(|p| p == rule_packs_path_str || p.ends_with("rule-packs.yaml"))
+                .unwrap_or(false)
+    });
+    assert!(
+        !got_file_change_for_rp,
+        "rule-packs.yaml must not produce a file_change posture event (normalizer bypass)"
+    );
+
+    agent.join.abort();
+}

--- a/docs/install-personal.md
+++ b/docs/install-personal.md
@@ -11,7 +11,7 @@ The **personal profile** installs everything you need to monitor your own machin
 | `sigil` (agent daemon) | Watches AI agent config files, scores risk, evaluates rules |
 | `sigil-mcp` (local mode) | Exposes `my_risk` / `my_guard_detail` MCP tools to an AI client |
 | `sigil-hook` | PreToolUse hook — observe tool calls and optionally enforce deny rules |
-| `sigil-rules-basic` (built-in) | Baseline rule pack compiled into the agent; active with no config needed |
+| `sigil-rules-basic` (built-in) | Built-in parsers that assess AI-tool config files and produce risk scores / posture — active with no config needed. **No built-in `hook_deny_rules`**: enforcement (sigil-hook blocking) requires you to supply a `rule-packs.yaml`. |
 
 Rule evaluation is **daemon-centric**: all rules run inside the `sigil` daemon. `sigil-mcp` and `sigil-hook` are thin clients of the daemon's Unix sockets and do nothing without it.
 
@@ -91,6 +91,13 @@ git -C ~/sigil-rules pull
 cp ~/sigil-rules/rule-packs.yaml ~/.config/sigil/rule-packs.yaml
 ```
 
+For larger packs, prefer an atomic rename so the agent never sees a partially-written file:
+
+```sh
+cp ~/sigil-rules/rule-packs.yaml ~/.config/sigil/.rule-packs.yaml.tmp && \
+  mv ~/.config/sigil/.rule-packs.yaml.tmp ~/.config/sigil/rule-packs.yaml
+```
+
 **Prefer plain `cp` over symlinks.** The watcher monitors the config directory; replacing the file in place is reliably detected. An in-place edit of a symlink target in another directory may not be picked up.
 
 **Fault tolerance:** If you save a corrupt `rule-packs.yaml`, the agent retains the last known-good bundle (your active packs stay loaded). Deliberately removing the file clears the bundle layer.
@@ -98,7 +105,11 @@ cp ~/sigil-rules/rule-packs.yaml ~/.config/sigil/rule-packs.yaml
 For the packaged install, the config directory is `/etc/sigil`:
 
 ```sh
+# simple
 cp ~/sigil-rules/rule-packs.yaml /etc/sigil/rule-packs.yaml
+# atomic (recommended for larger packs)
+cp ~/sigil-rules/rule-packs.yaml /etc/sigil/.rule-packs.yaml.tmp && \
+  mv /etc/sigil/.rule-packs.yaml.tmp /etc/sigil/rule-packs.yaml
 ```
 
 ---

--- a/docs/install-personal.md
+++ b/docs/install-personal.md
@@ -1,0 +1,185 @@
+# Personal Install — Local Self-Assessment with Sigil
+
+The **personal profile** installs everything you need to monitor your own machine's AI agent posture and enforce local deny rules, with no server required.
+
+---
+
+## What you get
+
+| Component | Role |
+|-----------|------|
+| `sigil` (agent daemon) | Watches AI agent config files, scores risk, evaluates rules |
+| `sigil-mcp` (local mode) | Exposes `my_risk` / `my_guard_detail` MCP tools to an AI client |
+| `sigil-hook` | PreToolUse hook — observe tool calls and optionally enforce deny rules |
+| `sigil-rules-basic` (built-in) | Baseline rule pack compiled into the agent; active with no config needed |
+
+Rule evaluation is **daemon-centric**: all rules run inside the `sigil` daemon. `sigil-mcp` and `sigil-hook` are thin clients of the daemon's Unix sockets and do nothing without it.
+
+---
+
+## Install
+
+### Script (macOS / Linux)
+
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/Ju571nK/sigil/main/install.sh | sh
+```
+
+`personal` is the default profile, so no environment variable is required. You can be explicit:
+
+```sh
+SIGIL_PROFILE=personal curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/Ju571nK/sigil/main/install.sh | sh
+```
+
+### Linux package (.rpm / .deb)
+
+The `sigil` package bundles `sigil-mcp` and `sigil-hook` — installing it gives you the full personal set:
+
+```sh
+sudo dnf install ./sigil-*.rpm
+```
+
+### Create the config directory
+
+The rule-pack watcher monitors the config directory; it must exist before or at install time.
+
+For a user-session install:
+
+```sh
+mkdir -p ~/.config/sigil
+```
+
+For a packaged install the directory is `/etc/sigil` (created by the package).
+
+---
+
+## Run the daemon
+
+**Packaged install (systemd):**
+
+```sh
+sudo systemctl enable --now sigil
+```
+
+**User session (no systemd):**
+
+```sh
+sigil run
+```
+
+The daemon must be running for `sigil-mcp` and `sigil-hook` to function. Both are clients of the daemon's Unix sockets — they have no independent capability without it.
+
+---
+
+## Local rule packs via git
+
+The agent has a dedicated watcher on `rule-packs.yaml` in the config directory. Editing or replacing that file hot-reloads the local rule packs without restarting the daemon or touching a server.
+
+**Initial setup:**
+
+```sh
+git clone <your-rules-repo> ~/sigil-rules
+cp ~/sigil-rules/rule-packs.yaml ~/.config/sigil/rule-packs.yaml
+```
+
+The agent detects the new file and loads the packs immediately.
+
+**Updating:**
+
+```sh
+git -C ~/sigil-rules pull
+cp ~/sigil-rules/rule-packs.yaml ~/.config/sigil/rule-packs.yaml
+```
+
+**Prefer plain `cp` over symlinks.** The watcher monitors the config directory; replacing the file in place is reliably detected. An in-place edit of a symlink target in another directory may not be picked up.
+
+**Fault tolerance:** If you save a corrupt `rule-packs.yaml`, the agent retains the last known-good bundle (your active packs stay loaded). Deliberately removing the file clears the bundle layer.
+
+For the packaged install, the config directory is `/etc/sigil`:
+
+```sh
+cp ~/sigil-rules/rule-packs.yaml /etc/sigil/rule-packs.yaml
+```
+
+---
+
+## Using it
+
+### Check posture
+
+```sh
+sigil show risk
+```
+
+Queries the running daemon and prints the current AI Guard risk assessment for each detected tool. Add `--tool claude-code` (or `codex`, etc.) to filter to one tool.
+
+### MCP client integration
+
+`sigil-mcp` in local mode (auto-detected when no server URL is configured) registers as **`sigil-check`** and exposes three read-only tools to an AI client such as Claude Desktop or Claude Code:
+
+- `my_risk` — per-tool risk band and score
+- `my_guard_detail` — rubric breakdown and reasons
+- `my_findings` — full finding list
+
+Point your MCP client at `sigil-mcp` with no server URL to use local mode. See [`crates/sigil-mcp/README.md`](../crates/sigil-mcp/README.md) for registration details.
+
+### Hook enforcement (PreToolUse)
+
+`sigil-hook --enforce` asks the daemon to allow or deny a tool call against the `hook_deny_rules` in the loaded rule packs. Register it as a `PreToolUse` hook in your agent's settings.
+
+Example for Claude Code (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sigil-hook claude-code --enforce --on-failure open"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**`--on-failure` defaults to `open` (fail-open):** if the daemon socket is absent or the verdict times out, the hook allows the command and does not block. To opt into fail-closed behavior (block when the daemon is unreachable):
+
+```sh
+sigil-hook claude-code --enforce --on-failure closed
+```
+
+Choose fail-closed only when you are confident the daemon will always be running; an unexpected daemon outage will block all matched tool calls.
+
+The four ways rules manifest at runtime:
+
+1. The daemon auto-assesses AI agent config files on change → posture events in the event log.
+2. `sigil show risk` queries the daemon and prints the current score.
+3. `sigil-mcp` local mode exposes `my_risk` / `my_guard_detail` to an AI client.
+4. `sigil-hook --enforce` (PreToolUse) asks the daemon to allow or deny a command against `hook_deny_rules`.
+
+---
+
+## Trust model
+
+**Local `rule-packs.yaml` is unsigned.** Its trust boundary is the git repository you clone it from.
+
+This matters for security: `hook_deny_rules` inside a rule pack carry **enforcement authority** — in enforce mode, a matching rule blocks tool execution in your AI coding agent. This is not passive self-assessment data. A malicious or compromised rule pack could deny legitimate tool calls or be crafted to allow harmful ones.
+
+**Only use rule packs from a git repository you trust.** Signed commits are recommended so you can verify that the YAML you are applying is what the author intended. Inspect the `hook_deny_rules` section before deploying any pack.
+
+For comparison, the fleet path (signed bundles) uses `verify_envelope` to cryptographically verify every rule pack before the agent applies it, with the signing key as the trust anchor. The local git path has no equivalent cryptographic gate — the git repo's own access controls and commit signing are the trust boundary.
+
+A future optional community-pubkey gate for local packs is out of scope for this release.
+
+---
+
+## Platform
+
+The personal profile is **Unix-first**. `sigil-mcp` local mode and `sigil-hook` enforce are Unix-only; on non-Unix platforms these fall back to a stub / no-verdict path. Windows gets partial support via tarball install and fsnotify-based watching; full parity with the Unix personal profile is out of scope for this release.
+
+For the fleet profile (central server, signed rule-pack push, `sigil-sender`, `sigil-server`, `sigil-sign`), install with `SIGIL_PROFILE=fleet`.

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@
 # Environment overrides:
 #   SIGIL_VERSION       pin a release tag (default: latest), e.g. v0.1.0
 #   SIGIL_INSTALL_DIR   install directory (default: $HOME/.local/bin)
+#   SIGIL_PROFILE       personal (default) | fleet
+#                       personal = sigil + sigil-mcp + sigil-hook (local self-assessment)
+#                       fleet    = + sigil-sender + sigil-server + sigil-sign
 #
 # Provenance: every release archive also carries a GitHub build-provenance
 # attestation. To verify it (optional, needs the gh CLI):
@@ -14,11 +17,24 @@
 set -eu
 
 REPO="Ju571nK/sigil"
-BINARIES="sigil sigil-sender sigil-server sigil-sign sigil-mcp sigil-hook"
 INSTALL_DIR="${SIGIL_INSTALL_DIR:-$HOME/.local/bin}"
 
 say() { printf 'sigil-install: %s\n' "$1" >&2; }
 err() { printf 'sigil-install: error: %s\n' "$1" >&2; exit 1; }
+
+PROFILE="${SIGIL_PROFILE:-personal}"
+case "$PROFILE" in
+  personal) BINARIES="sigil sigil-mcp sigil-hook" ;;
+  fleet)    BINARIES="sigil sigil-mcp sigil-hook sigil-sender sigil-server sigil-sign" ;;
+  *) err "unknown SIGIL_PROFILE '$PROFILE' (expected: personal | fleet)" ;;
+esac
+
+# dry-run hook: print the resolved binary set and exit before any network I/O.
+# Used by tests/install_profile_test.sh to verify profile->binaries mapping.
+if [ "${SIGIL_PROFILE_DRYRUN:-}" = "1" ]; then
+  printf '%s\n' "$BINARIES"
+  exit 0
+fi
 
 # --- tooling ---------------------------------------------------------------
 command -v uname >/dev/null 2>&1 || err "missing required tool: uname"
@@ -94,6 +110,7 @@ for b in $BINARIES; do
 done
 
 say "installed into $INSTALL_DIR: $BINARIES"
+say "profile: $PROFILE — start the agent with 'sigil run' (sigil-mcp/sigil-hook need the running daemon)"
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;
   *) say "note: add $INSTALL_DIR to your PATH to run 'sigil' directly" ;;

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -74,6 +74,16 @@ case "$WHAT" in
     signer) CRATES="sigil-signer" ;;
 esac
 
+# BUILD_PKGS is a superset of CRATES: the sigil package (sigil-agent metadata)
+# now bundles sigil-mcp and sigil-hook binaries, so we must compile them too
+# even though they have no package metadata of their own.
+BUILD_PKGS="$CRATES"
+case "$WHAT" in
+    agent|all) BUILD_PKGS="$BUILD_PKGS sigil-mcp sigil-hook" ;;
+esac
+# shellcheck disable=SC2086
+BUILD_PKGS=$(printf '%s\n' $BUILD_PKGS | sort -u | tr '\n' ' ')
+
 # crate -> binary name (the agent ships `sigil`, the signer ships `sigil-sign`).
 bin_for() {
     case "$1" in
@@ -97,10 +107,11 @@ if [ -n "$TARGET" ]; then
     esac
 fi
 
-# Single release build for everything we'll package.
-echo ">> building release binaries for: $CRATES${TARGET:+ (target: $TARGET)}"
+# Single release build for everything we'll package (including extra binaries
+# bundled into the sigil package: sigil-mcp, sigil-hook).
+echo ">> building release binaries for: $BUILD_PKGS${TARGET:+ (target: $TARGET)}"
 BUILD_ARGS=""
-for c in $CRATES; do
+for c in $BUILD_PKGS; do
     BUILD_ARGS="$BUILD_ARGS -p $c"
 done
 # shellcheck disable=SC2086
@@ -108,12 +119,20 @@ cargo build --release $BUILD_ARGS $TARGET_ARG --manifest-path "$ROOT/Cargo.toml"
 
 # For a cross target, stage each binary into target/release so the crate asset
 # paths (`../../target/release/<bin>`) resolve to the cross-built binary.
+# Stage packaged crates via bin_for(), plus the extra mcp/hook binaries when
+# they were part of the build.
 if [ -n "$TARGET" ]; then
     mkdir -p "$ROOT/target/release"
     for c in $CRATES; do
         b=$(bin_for "$c")
         cp -f "$ROOT/target/$TARGET/release/$b" "$ROOT/target/release/$b"
     done
+    case "$WHAT" in
+        agent|all)
+            cp -f "$ROOT/target/$TARGET/release/sigil-mcp"  "$ROOT/target/release/sigil-mcp"
+            cp -f "$ROOT/target/$TARGET/release/sigil-hook" "$ROOT/target/release/sigil-hook"
+            ;;
+    esac
 fi
 
 mkdir -p "$ROOT/target/generate-rpm"

--- a/packaging/selinux/sigil.fc
+++ b/packaging/selinux/sigil.fc
@@ -5,6 +5,12 @@
 /usr/bin/sigil          --      gen_context(system_u:object_r:sigil_agent_exec_t,s0)
 /usr/bin/sigil-sender   --      gen_context(system_u:object_r:sigil_sender_exec_t,s0)
 /usr/bin/sigil-server   --      gen_context(system_u:object_r:sigil_server_exec_t,s0)
+# sigil-mcp (local mode) and sigil-hook are short-lived, user/AI-tool-invoked
+# clients, not daemons. They run in the caller's domain (e.g. unconfined_t),
+# so they keep the generic bin_t label rather than a dedicated sigil exec type.
+# Their access to the agent's /run/sigil sockets is handled in sigil.te.
+/usr/bin/sigil-mcp      --      gen_context(system_u:object_r:bin_t,s0)
+/usr/bin/sigil-hook     --      gen_context(system_u:object_r:bin_t,s0)
 
 /etc/sigil(/.*)?                gen_context(system_u:object_r:sigil_conf_t,s0)
 

--- a/packaging/selinux/sigil.te
+++ b/packaging/selinux/sigil.te
@@ -113,6 +113,18 @@ allow sigil_agent_t var_run_t:sock_file manage_sock_file_perms;
 allow sigil_agent_t self:unix_stream_socket { create bind listen accept getattr getopt setopt };
 
 ########################################
+# Client access to the agent sockets (#134).
+# sigil-mcp (local mode) and sigil-hook connect to the agent's control and
+# hook-decide stream sockets under /run/sigil (var_run_t, owned by
+# sigil_agent_t). They run in the CALLER's domain (unconfined_t on a targeted
+# desktop/CLI, which is already permitted). A site that invokes them from a
+# CONFINED domain <caller_t> must grant, mirroring the sender:
+#     allow <caller_t> var_run_t:sock_file { getattr write };
+#     allow <caller_t> sigil_agent_t:unix_stream_socket connectto;
+# We do NOT hard-code unconfined_t rules here; that is the distro policy's job.
+########################################
+
+########################################
 # Sender — reads the agent spool, connects the control socket, ships over the
 # network (mTLS), writes its own state/dead-letter.
 ########################################

--- a/tests/install_profile_test.sh
+++ b/tests/install_profile_test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# install.sh의 프로파일→BINARIES 매핑을 dry-run으로 검증 (#134).
+set -eu
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SH="$ROOT/install.sh"
+
+run() { SIGIL_PROFILE="$1" SIGIL_PROFILE_DRYRUN=1 sh "$SH" 2>/dev/null; }
+
+fail=0
+assert_eq() { # $1=desc $2=expected $3=actual
+  if [ "$2" != "$3" ]; then printf 'FAIL: %s\n  want: %s\n  got:  %s\n' "$1" "$2" "$3"; fail=1
+  else printf 'ok: %s\n' "$1"; fi
+}
+
+assert_eq "personal subset" "sigil sigil-mcp sigil-hook" "$(run personal)"
+assert_eq "fleet superset" "sigil sigil-mcp sigil-hook sigil-sender sigil-server sigil-sign" "$(run fleet)"
+assert_eq "default is personal" "sigil sigil-mcp sigil-hook" "$(SIGIL_PROFILE_DRYRUN=1 sh "$SH" 2>/dev/null)"
+
+if SIGIL_PROFILE=bogus SIGIL_PROFILE_DRYRUN=1 sh "$SH" >/dev/null 2>&1; then
+  echo "FAIL: bogus profile should exit non-zero"; fail=1
+else echo "ok: bogus profile rejected"; fi
+
+exit $fail

--- a/tests/package_personal_assets_test.sh
+++ b/tests/package_personal_assets_test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"; cd "$ROOT"
+if ! command -v rpm >/dev/null 2>&1 || ! command -v cargo-generate-rpm >/dev/null 2>&1; then
+  echo "SKIP: rpm/cargo-generate-rpm not available (run on Linux CI)"; exit 0
+fi
+packaging/build.sh agent rpm
+RPM=$(find target/generate-rpm -maxdepth 1 -name 'sigil-*.rpm' 2>/dev/null | head -1)
+[ -n "$RPM" ] || { echo "FAIL: no sigil rpm produced"; exit 1; }
+LIST=$(rpm -qlp "$RPM" 2>/dev/null)
+echo "$LIST" | grep -q '/usr/bin/sigil-mcp'  || { echo "FAIL: rpm missing sigil-mcp"; exit 1; }
+echo "$LIST" | grep -q '/usr/bin/sigil-hook' || { echo "FAIL: rpm missing sigil-hook"; exit 1; }
+echo "ok: sigil rpm bundles mcp+hook"


### PR DESCRIPTION
Fixes #134.

Splits Sigil into two install profiles from one codebase/release, so a personal user can run local self-assessment without any server, while fleet keeps the signed server-push path unchanged.

## What's in each profile
| Profile | Binaries | Rule packs |
|---------|----------|-----------|
| `personal` (default) | `sigil` + `sigil-mcp` + `sigil-hook` | built-in parsers + local **unsigned** `rule-packs.yaml` (git-distributed, fsnotify hot-reload) |
| `fleet` | + `sigil-sender` + `sigil-server` + `sigil-sign` | + signed bundles via `/v1/rule-packs` → `verify_envelope` (unchanged) |

## Changes
- **install.sh**: `SIGIL_PROFILE=personal|fleet` (default `personal`), validated before any download. ⚠️ **Breaking**: the default `curl | sh` now installs 3 binaries (was 6); fleet users set `SIGIL_PROFILE=fleet`.
- **Packaging**: the `sigil` `.deb`/`.rpm` now bundles `sigil-mcp` + `sigil-hook` (= Personal); `packaging/build.sh` builds them for the `agent`/`all` paths.
- **Agent — dedicated fsnotify watcher** (`rule_packs_watch.rs`): the main watcher's normalizer drops non-policy-target paths, so a separate watcher on `rule-packs.yaml`'s parent dir triggers the existing reload. Honors `--poll`, logs backend errors. Config dir is created at boot so the watcher arms.
- **Agent — retain-last-good**: corrupt `rule-packs.yaml` keeps the previous packs (seeded from the boot bundle); a deliberately-removed file clears them. Local reload now also runs `validate_deny_rule_ids` + regex compile with keep-previous — security parity with the signed path, minus the signature.
- **SELinux**: `bin_t` labels for mcp/hook (caller-domain clients) + documented agent-socket connect contract.
- **Docs**: `docs/install-personal.md` (install, git rule-pack workflow, daemon-centric model, fail-open hook default, trust model), README profiles table, LICENSING trust-boundary note.

## Trust model (important)
Personal local rule packs are **unsigned** — trust boundary is the git repo you clone. They carry `hook_deny_rules` with **enforcement authority** (can block tool execution), so this is not passive data: only use packs from a trusted source. Documented prominently.

## Testing
- `cargo fmt` / `clippy --workspace -D warnings` / `cargo test --workspace` all green (0 failures).
- New: dedicated-watcher unit + e2e (hot-reload + normalizer-bypass + `--poll`), `BundleState` state machine + reload-level retain test, install.sh profile dry-run test, packaging asset smoke test (skips off-Linux).
- rpm/deb asset assertion + SELinux enforcing (AVC 0) validation run in Linux CI / the Rocky SELinux box.

## Follow-up
- #135 — re-arm the watcher if the config dir is created/replaced after boot (edge; boot-time dir creation covers the normal flows).

Personal is Unix-first (`sigil-mcp` local mode + `sigil-hook` enforce are Unix-only; Windows partial via tarball + fsnotify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)