### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-11
+
+### Added
+
+- **Personal / Fleet install profiles** (#134). Sigil now installs as one of two
+  profiles from a single release. `install.sh` takes `SIGIL_PROFILE=personal|fleet`
+  (default `personal`): **personal** installs `sigil` + `sigil-mcp` + `sigil-hook`
+  for local self-assessment with no server; **fleet** adds `sigil-sender`,
+  `sigil-server`, and `sigil-sign` for the signed server-push path. The `sigil`
+  `.deb`/`.rpm` package now bundles `sigil-mcp` and `sigil-hook` (so installing the
+  `sigil` package is the personal profile). See
+  [docs/install-personal.md](docs/install-personal.md).
+- **Local rule-pack hot-reload** (#134). A dedicated filesystem watcher on
+  `rule-packs.yaml` (beside `policy.yaml`) hot-reloads locally-distributed rule
+  packs — e.g. pulled from a git repository — without a server, honoring `--poll`.
+  Corrupt edits retain the last-good bundle (a broken `git pull` will not drop your
+  active packs); a deliberately removed file clears the bundle layer. The local
+  reload path validates deny-rule IDs and compiles regexes with keep-previous
+  semantics, matching the signed-bundle path minus the signature. Local rule packs
+  are unsigned — their trust boundary is the git repository they come from, and
+  they carry `hook_deny_rules` enforcement authority, so use only trusted sources.
+
+### Changed
+
+- **`install.sh` default now installs three binaries, not six** (#134). A plain
+  `curl … | sh` installs the `personal` set (`sigil`, `sigil-mcp`, `sigil-hook`).
+  Existing users who need the server components must install with
+  `SIGIL_PROFILE=fleet`. Personal is Unix-first (`sigil-mcp` local mode and
+  `sigil-hook` enforce are Unix-only; Windows has partial support via the tarball).
+
+### Fixed
+
+- **Empty / whitespace AI-tool config is treated as clean, not a parse error**
+  (#131). A zero-byte or whitespace-only tool config file (e.g. an empty
+  `~/.gemini/config/mcp_config.json`) no longer drops that tool from assessment
+  with an EOF parse error — closing a silent coverage hole found via two-machine
+  dogfooding. Shared `read_json_optional` helper across the JSON config parsers.
+
+### CI
+
+- **Build-provenance attestation is non-blocking** (#130). A transient Sigstore
+  Rekor outage during the release attestation step no longer blocks publishing
+  already-built, already-signed artifacts; re-run the job to (re-)attach
+  attestations. The enforced trust root remains the ed25519 build-manifest
+  signature.
+
 ## [0.4.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "sigil-sender"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace SemVer 0.4.0 → 0.5.0 and adds the `[0.5.0]` CHANGELOG section. Merge this, then tag `v0.5.0` on main to trigger the release build.

## Since v0.4.0
- **#134** — Personal / Fleet install profiles (`SIGIL_PROFILE=personal|fleet`), the `sigil` package bundling `sigil-mcp`+`sigil-hook`, and local `rule-packs.yaml` git-distributed hot-reload with retain-last-good. ⚠️ The default `curl | sh` now installs 3 binaries (personal), not 6 — fleet users set `SIGIL_PROFILE=fleet`.
- **#131** — empty/whitespace AI-tool config treated as clean (silent coverage hole fix).
- **#130** — build-provenance attestation step made non-blocking (transient Sigstore Rekor outages no longer block publishing).

## Release steps after merge
1. `git tag v0.5.0 <merge-commit> && git push origin v0.5.0` → `release.yml` builds prebuilt binaries (5 targets), `.deb`/`.rpm` (x86_64 + aarch64), SHA256SUMS, the signed build manifest, and the (now non-blocking) provenance attestation.
2. Verify the GitHub Release artifacts.

No version-coupled snapshot tests (schema_version stays 1, decoupled from the crate version). `cargo fmt`/`clippy --workspace -D warnings` clean; full `cargo test --workspace` already green on this code (the #134 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)