### PR TITLE
fix(release): publish the agent .deb (glob sigil* not sigil-)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,11 @@ jobs:
 
       - name: Checksums
         working-directory: dist
-        run: sha256sum sigil-* | tee SHA256SUMS
+        # `sigil*` (not `sigil-*`): the agent package is named `sigil`, so its
+        # .deb is `sigil_<ver>-1_<arch>.deb` (underscore). A `sigil-*` glob
+        # matches every other artifact (`sigil-sender_…`, the `sigil-…` rpms,
+        # the `sigil-<ver>-…` tarballs) but silently skips the agent .deb. (#138)
+        run: sha256sum sigil* | tee SHA256SUMS
 
       # Phase 3c (#13): sign a per-arch blake3 build manifest with the dedicated
       # build-signing key. Runs only when the secret is set; the freshly-built
@@ -193,7 +197,9 @@ jobs:
         continue-on-error: true
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: "dist/sigil-*"
+          # `sigil*` so the agent .deb (`sigil_<ver>-1_<arch>.deb`, underscore)
+          # is attested too — `sigil-*` would skip it. (#138)
+          subject-path: "dist/sigil*"
 
       - name: Publish GitHub Release
         env:
@@ -262,4 +268,4 @@ jobs:
             --verify-tag \
             $prerelease \
             --notes-file notes.md \
-            dist/sigil-* dist/SHA256SUMS $manifest
+            dist/sigil* dist/SHA256SUMS $manifest


### PR DESCRIPTION
Fixes #138.

## Root cause
The agent package is named `sigil`, so `cargo-deb` emits `sigil_<ver>-1_<arch>.deb` — **underscore** after `sigil`. Every other release artifact is `sigil-…` (**hyphen**): the `sigil-sender_…`/`sigil-server_…`/`sigil-signer_…` debs, the `sigil-<ver>-1.<arch>.rpm` rpms, and the `sigil-<ver>-<target>.tar.gz`/`.zip` archives.

`release.yml` used the glob `sigil-*` in three places, which matches all the hyphenated artifacts but **silently skips the underscore-named agent `.deb`**. So the agent `.deb` was built and collected into `dist/`, but never:
- checksummed (`sha256sum sigil-*`, line 148),
- attested (`subject-path: "dist/sigil-*"`, line 196), nor
- uploaded to the release (`gh release create … dist/sigil-*`, line 265).

This affected **v0.4.0 and v0.5.0** (the agent `.rpm` shipped via the separate `target/generate-rpm/*.rpm` path, masking the gap).

## Fix
Change the three artifact globs from `sigil-*` to `sigil*` (matches both `sigil-…` and `sigil_…`), with comments documenting the underscore gotcha so it doesn't regress. The manifest-signing step uses explicit `sigil-<ver>-<target>.tar.gz` paths (always hyphenated) and is unchanged.

Verified: `sigil*` expands to include `sigil_<ver>-1_<arch>.deb` plus all prior artifacts; `actionlint` clean. Workflow-only change (does not affect `ci.yml`).

## Note
This fixes future releases. The already-published v0.5.0 still lacks the agent `.deb` — it can be backfilled by building the two Linux agent `.deb`s (x86_64 + aarch64 musl) and `gh release upload v0.5.0`-ing them, if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)