### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-12
+
+### Fixed
+
+- **The agent `.deb` is published in releases again** (#138). The agent package
+  is named `sigil`, so cargo-deb emits `sigil_<ver>-1_<arch>.deb` (underscore) —
+  and the release job's `sigil-*` (hyphen) artifact globs silently skipped it
+  in the checksums, the provenance attestation, and the release upload, while
+  every other artifact matched. Affected v0.4.0 and v0.5.0 (the agent `.rpm`
+  shipped throughout). The globs are now `sigil*`; this release carries the
+  agent `.deb` for both x86_64 and aarch64, restoring `apt install` of the
+  agent (personal profile: `sigil` + `sigil-mcp` + `sigil-hook`) on
+  Debian/Ubuntu.
+
 ## [0.5.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "sigil-sender"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace SemVer 0.5.0 → 0.5.1 and adds the `[0.5.1]` CHANGELOG section. Merge this, then tag `v0.5.1` on main to trigger the release build.

## Why a patch release
v0.5.0 (and v0.4.0) were published **without the agent `.deb`** — #138: the release job's `sigil-*` globs silently skipped the underscore-named `sigil_<ver>-1_<arch>.deb` in the checksums, attestation, and upload. The glob fix (#140) is on main; this release is the clean backfill — built with the fixed workflow, v0.5.1 will carry the agent `.deb` for x86_64 + aarch64, restoring `apt install` of the agent (personal profile) on Debian/Ubuntu. No code changes beyond the version bump.

## Release steps after merge
1. `git tag v0.5.1 <merge-commit> && git push origin v0.5.1` → release.yml (with the #140 glob fix) publishes all artifacts **including `sigil_0.5.1-1_{amd64,arm64}.deb`**.
2. Verify the agent `.deb` is present in the release assets, SHA256SUMS, and attestation.

`cargo fmt` clean; workspace builds at 0.5.1; no version-coupled snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)