### PR TITLE
fix(agent): rule-packs.yaml watcher re-arm + transient empty read (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The local `rule-packs.yaml` watcher re-arms when the config dir is recreated
+  at runtime** (#135). The dedicated hot-reload watcher previously gave up
+  permanently if its config directory was absent at start, and a by-inode watch
+  went silent if the directory was deleted and re-created while the agent ran. It
+  now watches the grandparent directory (always present — `~/.config`, `/etc`,
+  `$HOME`) and re-arms the parent-directory watch whenever the config dir
+  (re)appears, so local rule-pack edits keep hot-reloading across a dir recreate.
+- **A transient empty `rule-packs.yaml` read retains the active bundle instead of
+  clearing it** (#135). A non-atomic `cp` truncates the destination to zero bytes
+  before writing; that empty window was treated as "file removed" and momentarily
+  dropped the local rule packs (and their enforcement) until the next reload. A
+  zero-byte / whitespace-only read is now retained as last-good. To deliberately
+  clear the bundle, remove the file (honored as before) or write a valid empty
+  document; only a real removal clears.
+
 ## [0.5.1] - 2026-06-12
 
 ### Fixed

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -147,14 +147,22 @@ fn reconcile_rule_packs(
     (added, removed)
 }
 
-/// Three states for the rule-pack bundle file. `Absent` = file missing (normal,
-/// no bundle layer); `Present` = parsed OK; `Corrupt` = file exists but failed
-/// to parse (retain the last-good bundle instead of dropping its packs).
+/// States for the rule-pack bundle file.
+/// - `Absent` = file genuinely missing (NotFound) → deliberate `rm`, clear the layer.
+/// - `Present` = parsed OK.
+/// - `Corrupt` = file exists but read/parse failed → retain the last-good bundle.
+/// - `Empty` = file is zero-byte / whitespace-only → retain the last-good bundle.
+///   A non-atomic `cp` truncates the destination to zero bytes before writing, so a
+///   transient empty read is ambiguous with a half-finished write; retaining (#135)
+///   never drops enforcement on that race. To intentionally clear the layer, `rm` the
+///   file (→ Absent) or write a valid empty document (→ Present with no packs).
+///
 /// PolicyDocument is large (~392 B) so we box it to keep the enum small.
 pub(crate) enum BundleState {
     Absent,
     Present(Box<sigil_core::policy::PolicyDocument>),
     Corrupt,
+    Empty,
 }
 
 pub(crate) fn read_bundle_state(path: &std::path::Path) -> BundleState {
@@ -166,11 +174,12 @@ pub(crate) fn read_bundle_state(path: &std::path::Path) -> BundleState {
             return BundleState::Corrupt; // 읽기 실패도 보수적으로 corrupt(이전 유지)
         }
     };
-    // A zero-byte / whitespace-only file is treated as Absent (not Corrupt) for
-    // atomic-write resilience: a file briefly empty mid-write — or a deliberately
-    // empty config — should leave no bundle layer, not pin a stale last-good one.
+    // A zero-byte / whitespace-only file is a transient truncate window (non-atomic
+    // cp), NOT a deliberate removal. Treat it as `Empty` → retain last-good (#135),
+    // distinct from NotFound → Absent → clear. Deliberately clearing packs means
+    // `rm` the file or write a valid empty document (which parses to Present).
     if s.trim().is_empty() {
-        return BundleState::Absent;
+        return BundleState::Empty;
     }
     match sigil_core::policy::parse(&s) {
         Ok(d) => BundleState::Present(Box::new(d)),
@@ -281,7 +290,8 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
     // Task 5 / #134 — read the distributed rule-pack bundle (3rd merge layer:
     // defaults < policy < bundle).
     // Corrupt(파일 존재+파스 실패) → retain last good (transient git-pull state protected).
-    // Absent(파일 삭제) → clear cache (deliberate rm honored).
+    // Empty(0바이트/공백, cp 트렁케이트 창) → retain last good (#135, enforcement race 방지).
+    // Absent(파일 NotFound) → clear cache (deliberate rm honored).
     let bundle: Option<sigil_core::policy::PolicyDocument> =
         match read_bundle_state(&ctx.rule_packs_yaml_path) {
             BundleState::Present(d) => {
@@ -289,7 +299,7 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
                 ctx.last_good_bundle = Some(doc.clone());
                 Some(doc)
             }
-            BundleState::Corrupt => ctx.last_good_bundle.clone(), // 이전 정상 유지
+            BundleState::Corrupt | BundleState::Empty => ctx.last_good_bundle.clone(), // 이전 정상 유지
             BundleState::Absent => {
                 ctx.last_good_bundle = None; // 의도적 제거 → 캐시 비움
                 None
@@ -1431,11 +1441,12 @@ mod tests {
         );
     }
 
-    // #134 — BundleState 3-way state machine: Absent / Present / Corrupt.
+    // #134/#135 — BundleState state machine: Absent / Present / Corrupt / Empty.
     #[test]
     fn bundle_state_distinguishes_missing_valid_corrupt() {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join("rule-packs.yaml");
+        // NotFound → Absent (deliberate rm).
         assert!(matches!(read_bundle_state(&p), BundleState::Absent));
         std::fs::write(
             &p,
@@ -1445,6 +1456,42 @@ mod tests {
         assert!(matches!(read_bundle_state(&p), BundleState::Present(_)));
         std::fs::write(&p, "}{not yaml").unwrap();
         assert!(matches!(read_bundle_state(&p), BundleState::Corrupt));
+        // #135 — zero-byte / whitespace-only → Empty (transient truncate), NOT Absent.
+        std::fs::write(&p, "").unwrap();
+        assert!(matches!(read_bundle_state(&p), BundleState::Empty));
+        std::fs::write(&p, "   \n\t\n").unwrap();
+        assert!(matches!(read_bundle_state(&p), BundleState::Empty));
+    }
+
+    // #135 — a transient empty read (cp truncate window) retains the last-good
+    // bundle rather than clearing it, distinct from a NotFound (rm) which clears.
+    #[test]
+    fn empty_bundle_retains_last_good() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("rule-packs.yaml");
+        std::fs::write(
+            &p,
+            "version: 1\nhost_id_strategy: machine_id\ntargets: []\n",
+        )
+        .unwrap();
+        let mut cache: Option<sigil_core::policy::PolicyDocument> = None;
+        if let BundleState::Present(d) = read_bundle_state(&p) {
+            cache = Some(*d);
+        }
+        assert!(cache.is_some());
+        // Truncate to zero bytes (the non-atomic cp window).
+        std::fs::write(&p, "").unwrap();
+        let retained = match read_bundle_state(&p) {
+            BundleState::Empty => cache.clone(),
+            _ => None,
+        };
+        assert!(
+            retained.is_some(),
+            "empty read must retain last good (#135)"
+        );
+        // Contrast: an actual removal clears.
+        std::fs::remove_file(&p).unwrap();
+        assert!(matches!(read_bundle_state(&p), BundleState::Absent));
     }
 
     // #134 — corrupt bundle retains the last successfully parsed bundle doc.

--- a/crates/sigil-agent/src/rule_packs_watch.rs
+++ b/crates/sigil-agent/src/rule_packs_watch.rs
@@ -24,22 +24,16 @@ use std::time::Duration;
 use tokio::sync::{mpsc as tokio_mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
-/// 이벤트 경로가 감시 대상(rule-packs.yaml)인지 판정.
+/// 이벤트 경로가 주어진 경로(rule-packs.yaml 또는 부모 디렉터리)와 일치하는지 판정.
 fn is_rule_packs_event(target: &Path, evented: &Path) -> bool {
     evented == target
 }
 
-/// 부모 디렉터리가 존재하면 그 경로, 없으면 None.
-fn existing_parent(target: &Path) -> Option<PathBuf> {
-    target
-        .parent()
-        .filter(|p| p.exists())
-        .map(|p| p.to_path_buf())
-}
-
-/// 전용 watcher 태스크. 부모 디렉터리를 감시하고 대상 파일 변경 시
-/// `version_tx`에 단조 증가 카운터를 보낸다. 부모 디렉터리가 없으면
-/// 경고만 남기고 종료.
+/// 전용 watcher 태스크. 조부모 디렉터리(항상 존재: `~/.config`, `/etc`, `$HOME`)를
+/// 감시해 부모 디렉터리의 생성/삭제를 관측하고, 부모 디렉터리가 (재)등장하면
+/// 부모 watch를 (재)무장해 대상 파일 변경 시 `version_tx`에 단조 증가 카운터를
+/// 보낸다. 부모가 시작 시점에 없어도 영구 비활성화되지 않는다 (#135).
+/// 조부모 디렉터리마저 없으면 경고만 남기고 종료.
 ///
 /// `poll_interval = Some(d)`이면 메인 watcher와 동일하게 `PollWatcher`를 쓴다
 /// (NFS/virtiofs/9p 등 OS-네이티브 FS 이벤트가 신뢰 불가한 호스트, `--poll`).
@@ -54,27 +48,59 @@ pub async fn run(
     poll_interval: Option<Duration>,
     shutdown: CancellationToken,
 ) {
-    let parent = match existing_parent(&target) {
-        Some(p) => p,
+    // #135 — watch the GRANDPARENT dir (always present: ~/.config, /etc, $HOME),
+    // not just the parent. That lets us (re)arm the parent-dir watch when the
+    // config dir is created — or deleted and re-created — at runtime, instead of
+    // giving up permanently when the parent is absent at start.
+    let parent = match target.parent() {
+        Some(p) => p.to_path_buf(),
         None => {
             tracing::warn!(path = %target.display(),
-                "rule-packs.yaml parent dir absent; dedicated watcher not started");
+                "rule-packs.yaml has no parent dir; dedicated watcher not started");
             return;
         }
     };
-    // Canonicalize target so notify event paths (always canonical on macOS/Linux
-    // where /tmp → /private/tmp, /var → /private/var) compare correctly.
-    // If the file doesn't exist yet (first boot before any rule-packs.yaml is
-    // written), fall back to canonicalizing the parent and re-joining the filename.
-    let canon_parent = dunce::canonicalize(&parent).unwrap_or_else(|_| parent.clone());
-    let canonical_target = if target.exists() {
-        dunce::canonicalize(&target).unwrap_or_else(|_| target.clone())
-    } else {
-        target
-            .file_name()
-            .map(|name| canon_parent.join(name))
-            .unwrap_or(target.clone())
+    let grandparent = match parent.parent() {
+        Some(g) => g.to_path_buf(),
+        None => {
+            tracing::warn!(path = %target.display(),
+                "rule-packs.yaml has no grandparent dir; dedicated watcher not started");
+            return;
+        }
     };
+    if !grandparent.exists() {
+        tracing::warn!(path = %grandparent.display(),
+            "rule-packs.yaml grandparent dir absent; dedicated watcher not started");
+        return;
+    }
+    // Two parent representations are needed because the grandparent and parent
+    // watches report the dir differently:
+    //   * `parent_entry` = the parent as it appears *inside* the (canonical)
+    //     grandparent — `canon_grandparent/<name>`. The grandparent watch reports
+    //     parent-dir create/delete events under this lexical path (a symlinked
+    //     config dir is still listed by its own name in the grandparent), so this
+    //     is the re-arm trigger to compare against.
+    //   * `canon_parent` = the *resolved* parent (`canonicalize(parent)` when it
+    //     exists). The parent watch's target-file events arrive under the resolved
+    //     path on FSEvents and under the registered (canonical) path on inotify, so
+    //     we watch and compare against the canonical form — restoring #134's
+    //     symlinked-parent handling that a lexical grandparent-join would regress.
+    // For a real (non-symlink) dir the two are identical.
+    let canon_grandparent =
+        dunce::canonicalize(&grandparent).unwrap_or_else(|_| grandparent.clone());
+    let parent_entry = parent
+        .file_name()
+        .map(|name| canon_grandparent.join(name))
+        .unwrap_or_else(|| parent.clone());
+    let canon_parent = if parent.exists() {
+        dunce::canonicalize(&parent).unwrap_or_else(|_| parent_entry.clone())
+    } else {
+        parent_entry.clone()
+    };
+    let canonical_target = target
+        .file_name()
+        .map(|name| canon_parent.join(name))
+        .unwrap_or_else(|| target.clone());
 
     // std::sync::mpsc for notify callback → blocking drain loop.
     let (std_tx, std_rx) = std_mpsc::channel::<()>();
@@ -82,16 +108,24 @@ pub async fn run(
     let (tok_tx, mut tok_rx) = tokio_mpsc::channel::<()>(8);
 
     let target_for_cb = canonical_target.clone();
+    let parent_entry_for_cb = parent_entry.clone();
+    let canon_parent_for_cb = canon_parent.clone();
     // Mirror the main watcher's callback: log backend errors instead of
     // silently dropping them. If inotify watch-limit / kqueue fd exhaustion
     // hits, hot-reload would otherwise die with no trace.
+    //
+    // Forward a single "something changed" signal when an event touches the
+    // target file (via the parent watch → drives reload) OR the parent dir
+    // itself (via the grandparent watch → drives re-arm + reload). The parent dir
+    // can be reported as either the grandparent-relative `parent_entry` or the
+    // resolved `canon_parent` depending on backend; match both. #135.
     let on_event = move |res: notify::Result<Event>| match res {
         Ok(ev) => {
-            if ev
-                .paths
-                .iter()
-                .any(|p| is_rule_packs_event(&target_for_cb, p))
-            {
+            if ev.paths.iter().any(|p| {
+                is_rule_packs_event(&target_for_cb, p)
+                    || is_rule_packs_event(&parent_entry_for_cb, p)
+                    || is_rule_packs_event(&canon_parent_for_cb, p)
+            }) {
                 let _ = std_tx.send(());
             }
         }
@@ -120,15 +154,32 @@ pub async fn run(
             }
         },
     };
-    // Canonicalize the watch directory so FSEvents on macOS receives the real
-    // path (not the /var → /private/var symlink). Without this, FSEvents may
-    // not deliver events when the watch path is a symlink target.
-    if let Err(e) = watcher.watch(&canon_parent, RecursiveMode::NonRecursive) {
-        tracing::error!(error = ?e, dir = %canon_parent.display(), "rule-packs watch failed");
+    // Watch the grandparent so parent-dir create/delete is observable (the
+    // re-arm source). Fatal if this fails — without it there is no recovery
+    // path. Canonical path so macOS FSEvents receives the real dir, not a
+    // /var → /private/var symlink.
+    if let Err(e) = watcher.watch(&canon_grandparent, RecursiveMode::NonRecursive) {
+        tracing::error!(error = ?e, dir = %canon_grandparent.display(),
+            "rule-packs grandparent watch failed");
         return;
     }
+    // Watch the parent too when it exists now (the target-file event source).
+    // Non-fatal: if the parent is absent at start, a later parent-create event
+    // re-arms it in the async loop below. `parent_armed` tracks whether the watch
+    // is currently registered so the loop only (re)arms on absent→present edges —
+    // re-watching on every event would grow notify's FSEvents watch list unbounded
+    // (its backend appends rather than dedups). #135.
+    let mut parent_armed = false;
+    if parent_entry.exists() {
+        match watcher.watch(&canon_parent, RecursiveMode::NonRecursive) {
+            Ok(()) => parent_armed = true,
+            Err(e) => tracing::warn!(error = ?e, dir = %canon_parent.display(),
+                "rule-packs parent watch failed; will retry on next event"),
+        }
+    }
     tracing::info!(
-        dir = %canon_parent.display(),
+        grandparent = %canon_grandparent.display(),
+        parent = %canon_parent.display(),
         target = %canonical_target.display(),
         "rule-packs.yaml dedicated watcher started"
     );
@@ -168,6 +219,28 @@ pub async fn run(
             msg = tok_rx.recv() => {
                 match msg {
                     Some(()) => {
+                        // #135 — re-arm the parent watch ONLY on absent→present /
+                        // present→absent transitions, never on every event: notify's
+                        // FSEvents backend appends (does not dedup) on watch(), so
+                        // re-watching per file edit would grow the watch list
+                        // unbounded on macOS. The version bump below runs regardless,
+                        // so reload() always re-reads the file from disk.
+                        let present = parent_entry.exists();
+                        if present && !parent_armed {
+                            // (Re)appeared — unwatch any stale registration first so
+                            // FSEvents keeps a single entry, then arm.
+                            let _ = watcher.unwatch(&canon_parent);
+                            match watcher.watch(&canon_parent, RecursiveMode::NonRecursive) {
+                                Ok(()) => parent_armed = true,
+                                Err(e) => tracing::debug!(error = ?e,
+                                    "rule-packs parent re-arm watch failed"),
+                            }
+                        } else if !present && parent_armed {
+                            // Disappeared — drop the watch so the next appearance
+                            // re-arms cleanly (the reload below reads NotFound).
+                            let _ = watcher.unwatch(&canon_parent);
+                            parent_armed = false;
+                        }
                         counter += 1;
                         let _ = version_tx.send(counter);
                         tracing::debug!(counter, "rule-packs.yaml changed; reload triggered");
@@ -256,6 +329,138 @@ mod tests {
         .await
         .expect("poll watcher should bump version within 10s");
         assert!(bumped, "version_tx counter should advance on file change");
+
+        shutdown.cancel();
+        let _ = handle.await;
+    }
+
+    /// #135 re-arm (absent-at-start): the config dir does NOT exist when the
+    /// watcher starts. It must arm on the grandparent and report changes once
+    /// the dir appears — proving it no longer permanently disables itself.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rearm_when_parent_created_after_start() {
+        let gp = tempfile::tempdir().unwrap();
+        let grandparent = dunce::canonicalize(gp.path()).unwrap();
+        let parent = grandparent.join("sigil");
+        let target = parent.join("rule-packs.yaml");
+
+        let (tx, mut rx) = watch::channel(0i64);
+        let shutdown = CancellationToken::new();
+        let handle = tokio::spawn(run(
+            target.clone(),
+            tx,
+            Some(Duration::from_millis(100)),
+            shutdown.clone(),
+        ));
+
+        let bumped = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut n = 1u32;
+            loop {
+                // Create the config dir (idempotent) and write the file.
+                std::fs::create_dir_all(&parent).unwrap();
+                std::fs::write(&target, format!("version: {n}\n")).unwrap();
+                n += 1;
+                tokio::select! {
+                    r = rx.changed() => {
+                        if r.is_err() {
+                            break false;
+                        }
+                        if *rx.borrow() > 0 {
+                            break true;
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(200)) => {}
+                }
+            }
+        })
+        .await
+        .expect("watcher should arm + report after the config dir appears within 10s");
+        assert!(
+            bumped,
+            "version_tx should advance once the config dir is created"
+        );
+
+        shutdown.cancel();
+        let _ = handle.await;
+    }
+
+    /// #135 re-arm (delete + recreate): the parent exists at start, then is
+    /// deleted and re-created at runtime. A by-inode watch would go silent; the
+    /// grandparent watch must re-arm the parent so changes are reported again.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rearm_when_parent_deleted_and_recreated() {
+        let gp = tempfile::tempdir().unwrap();
+        let grandparent = dunce::canonicalize(gp.path()).unwrap();
+        let parent = grandparent.join("sigil");
+        std::fs::create_dir(&parent).unwrap();
+        let target = parent.join("rule-packs.yaml");
+        std::fs::write(&target, "version: 1\n").unwrap();
+
+        let (tx, mut rx) = watch::channel(0i64);
+        let shutdown = CancellationToken::new();
+        let handle = tokio::spawn(run(
+            target.clone(),
+            tx,
+            Some(Duration::from_millis(100)),
+            shutdown.clone(),
+        ));
+
+        // Phase A — confirm the parent watch is armed. A pre-existing file emits
+        // no event, so mutate until the counter first advances.
+        let armed = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut n = 2u32;
+            loop {
+                std::fs::write(&target, format!("version: {n}\n")).unwrap();
+                n += 1;
+                tokio::select! {
+                    r = rx.changed() => {
+                        if r.is_err() {
+                            break false;
+                        }
+                        if *rx.borrow() > 0 {
+                            break true;
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(200)) => {}
+                }
+            }
+        })
+        .await
+        .expect("parent watch should arm within 10s");
+        assert!(armed, "baseline arm");
+        let baseline = *rx.borrow();
+
+        // Phase B — delete the config dir, let the grandparent poll observe the
+        // absence, then re-create it. The watcher must re-arm and report changes
+        // past the baseline.
+        std::fs::remove_dir_all(&parent).unwrap();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        std::fs::create_dir(&parent).unwrap();
+
+        let rearmed = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut n = 100u32;
+            loop {
+                std::fs::write(&target, format!("version: {n}\n")).unwrap();
+                n += 1;
+                tokio::select! {
+                    r = rx.changed() => {
+                        if r.is_err() {
+                            break false;
+                        }
+                        if *rx.borrow() > baseline {
+                            break true;
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(200)) => {}
+                }
+            }
+        })
+        .await
+        .expect("watcher should re-arm + report after dir re-creation within 10s");
+        assert!(
+            rearmed,
+            "version_tx should advance past baseline after the config dir is re-created"
+        );
 
         shutdown.cancel();
         let _ = handle.await;

--- a/docs/install-personal.md
+++ b/docs/install-personal.md
@@ -100,7 +100,7 @@ cp ~/sigil-rules/rule-packs.yaml ~/.config/sigil/.rule-packs.yaml.tmp && \
 
 **Prefer plain `cp` over symlinks.** The watcher monitors the config directory; replacing the file in place is reliably detected. An in-place edit of a symlink target in another directory may not be picked up.
 
-**Fault tolerance:** If you save a corrupt `rule-packs.yaml`, the agent retains the last known-good bundle (your active packs stay loaded). Deliberately removing the file clears the bundle layer.
+**Fault tolerance:** If you save a corrupt `rule-packs.yaml`, the agent retains the last known-good bundle (your active packs stay loaded). A momentarily empty read — the zero-byte window a non-atomic `cp` opens mid-write — is likewise retained, so a write race never drops your active packs. Only an actual removal (`rm`) clears the bundle layer; to deliberately empty it without removing the file, write a valid empty document (it parses to a bundle with no packs). If the config directory itself is deleted and re-created while the agent runs, the watcher re-arms and resumes hot-reloading.
 
 For the packaged install, the config directory is `/etc/sigil`:
 


### PR DESCRIPTION
Closes #135. Follow-up from the #134 final review (personal/fleet profiles).

## What

Two robustness gaps in the dedicated local `rule-packs.yaml` hot-reload watcher (#134):

### 1. Re-arm when the config dir is created/recreated at runtime
The watcher previously gave up permanently if the config dir was absent at start, and a by-inode watch went silent if the dir was deleted and re-created while the agent ran (boot `create_dir_all` only covered boot-time absence). It now watches the **grandparent** dir — always present (`~/.config`, `/etc`, `$HOME`) — and re-arms the parent-dir watch on the parent's absent→present transitions, so local rule-pack edits keep hot-reloading across a directory recreate.

### 2. Transient empty read retains last-good instead of clearing
A non-atomic `cp` truncates the destination to zero bytes before writing. That empty window was read as `Absent` and momentarily cleared the bundle layer — dropping the local rule packs (and their enforcement) until the next reload. A zero-byte / whitespace-only read is now a distinct `Empty` `BundleState` that **retains** last-good. Only a real removal (`rm` → `Absent`) clears; a deliberately empty config can be expressed as a valid empty document (parses to `Present` with no packs → clears naturally).

## Review notes

- **codex adversarial review** caught that re-arming `watcher.watch(parent)` on *every* event is idempotent on inotify/PollWatcher but **not** on notify's FSEvents backend, which *appends* the path each call → unbounded watch-list growth on macOS. Fixed: re-arm is guarded to absent↔present transitions only (with a best-effort `unwatch` before re-arming), never per file edit. The version bump still runs on every event, so `reload()` always re-reads from disk.
- Parent paths are canonicalized (`canonicalize(parent)` when it exists) so a symlinked config dir's target-file events still match, restoring #134's handling that a lexical grandparent-join would have regressed.

## Tests
- `rearm_when_parent_created_after_start` — absent-at-start → arms when the dir appears.
- `rearm_when_parent_deleted_and_recreated` — armed → disarm on delete → re-arm on recreate.
- `empty_bundle_retains_last_good` — zero-byte read retains; `rm` clears.
- `bundle_state_distinguishes_missing_valid_corrupt` — extended to cover the `Empty` variant.

## Gates
`cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test --workspace` all green (83 test-result sections, 0 failures). Re-arm tests run stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)