### PR TITLE
docs(install-personal): agent-only, arch-pinned package globs (#143)

### DIFF
--- a/docs/install-personal.md
+++ b/docs/install-personal.md
@@ -36,8 +36,20 @@ SIGIL_PROFILE=personal curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubu
 The `sigil` package bundles `sigil-mcp` and `sigil-hook` — installing it gives you the full personal set:
 
 ```sh
-sudo dnf install ./sigil-*.rpm
+# RHEL / Rocky / Fedora. `sigil-[0-9]…` selects only the agent package: the
+# fleet packages (sigil-sender / sigil-server / sigil-signer) have a letter
+# after `sigil-`, so they are excluded. Arch-pinned so a second downloaded
+# architecture isn't pulled in.
+sudo dnf install ./sigil-[0-9]*.$(uname -m).rpm
+
+# Debian / Ubuntu. The agent .deb is `sigil_<ver>…` (underscore), which already
+# excludes the `sigil-…` fleet packages; arch-pinned likewise.
+sudo apt install ./sigil_*_$(dpkg --print-architecture).deb
 ```
+
+These globs select only the agent package even if you downloaded the whole
+release into one directory. For the packaged install you do **not** need to
+create the config directory by hand — see below.
 
 ### Create the config directory
 


### PR DESCRIPTION
Fixes #143.

## Problem
`docs/install-personal.md` told personal users to run `sudo dnf install ./sigil-*.rpm`, but that glob matches **all four** rpms in a release dir — `sigil-0.5.1-1.x86_64.rpm` (the agent) plus `sigil-sender`/`sigil-server`/`sigil-signer` (the fleet), and both architectures. A personal install silently pulled in the server/sender/signer binaries. Same glob footgun class as #138, in user-facing docs.

## Fix
Agent-only, arch-pinned, version-agnostic globs:

```sh
sudo dnf install ./sigil-[0-9]*.$(uname -m).rpm            # RHEL / Rocky / Fedora
sudo apt install ./sigil_*_$(dpkg --print-architecture).deb # Debian / Ubuntu
```

- `sigil-[0-9]…` — the agent version starts with a digit, so the `sigil-<name>` fleet packages (letter after `sigil-`) are excluded.
- `sigil_<ver>…` (underscore) — the agent `.deb` naming already excludes the `sigil-…` fleet debs.
- Both arch-pinned so a second downloaded architecture isn't pulled in.
- Adds the apt line the ".rpm / .deb" heading promised but omitted.

## Verification
Against the real v0.5.1 asset names, the new globs match **only** the agent package (rpm and deb), while the old `sigil-*.rpm` matched all five (both arches + 3 fleet packages). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)