### PR TITLE
feat(ai_guard): detect project-scope MCP auto-execution (TrustFall) (#145)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
@@ -105,6 +105,10 @@ impl AntigravityProjectParser {
     }
 }
 
+// #145 — Option B is intentionally NOT applied to Antigravity in v1: its MCP
+// servers live in a global file (`~/.gemini/config/mcp_config.json`), not in
+// the per-repo `.antigravity/settings.json` this parser reads, so there is no
+// project MCP payload to amplify. Revisit if Antigravity adds per-repo MCP.
 impl AiGuardParser for AntigravityProjectParser {
     fn tool(&self) -> AiTool {
         AiTool::Antigravity

--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -375,6 +375,11 @@ fn project_auto_enable_mechanism(settings: &Value) -> Option<&'static str> {
     {
         return Some("enableAllProjectMcpServers");
     }
+    // Deliberate: a non-empty `enabledMcpjsonServers` is treated as the signal
+    // without correlating its entries against `.mcp.json` server names. The
+    // presence of the pre-approval intent plus any committed payload is the
+    // risk; an array naming servers absent from the payload is still a standing
+    // blanket-approval posture. Do NOT "tighten" this to require a name match.
     if settings
         .get("enabledMcpjsonServers")
         .and_then(Value::as_array)
@@ -439,7 +444,23 @@ impl AiGuardParser for ClaudeCodeProjectParser {
         let cd = self.repo_root.join(".claude");
         let base = super::read_json_optional(&cd.join("settings.json"))?;
         let local = super::read_json_optional(&cd.join("settings.local.json"))?;
-        let mcp_json = super::read_json_optional(&self.repo_root.join(".mcp.json"))?;
+        // #145 — read `.mcp.json` DEFENSIVELY: a malformed payload must not
+        // abort the whole assess and thereby blind us to a malicious
+        // `.claude/settings.json` in the same repo (a corrupt-sidecar evasion
+        // seam). A corrupt `.mcp.json` cannot launch in Claude Code anyway, so
+        // degrading it to "no payload" is safe; settings-side reasons are still
+        // scored. (Contrast `settings.json`, whose corruption Claude itself
+        // also fails on — there the `?` propagation is correct.)
+        let mcp_json = match super::read_json_optional(&self.repo_root.join(".mcp.json")) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    repo = %self.repo_root.display(), error = %e,
+                    "claude project: ignoring unparsable .mcp.json (settings still scored)"
+                );
+                None
+            }
+        };
         if base.is_none() && local.is_none() && mcp_json.is_none() {
             return Ok(Vec::new());
         }
@@ -497,6 +518,29 @@ mod tests {
             out.iter()
                 .any(|r| matches!(r, AiGuardReason::McpServerSuspiciousLauncher { .. })),
             "expected #127 launcher reason from .mcp.json payload, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn corrupt_mcp_json_does_not_blind_settings_detection() {
+        // #145 holistic SF2 — a malformed `.mcp.json` must not abort assess and
+        // thereby suppress detection of a malicious `.claude/settings.json` in
+        // the same repo (corrupt-sidecar evasion seam).
+        let repo = tempdir().unwrap();
+        write_file(repo.path(), ".mcp.json", "{ this is not json");
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{ "permissions": { "allow": ["Bash:*"] } }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        assert!(
+            out.iter()
+                .any(|r| matches!(r, AiGuardReason::PermissionsAllowBroad { .. })),
+            "settings-side reason must still be scored despite corrupt .mcp.json, got {out:?}"
         );
     }
 

--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -412,6 +412,7 @@ impl AiGuardParser for ClaudeCodeProjectParser {
             cd.join("settings.json"),
             cd.join("settings.local.json"),
             cd.join("hooks"),
+            self.repo_root.join(".mcp.json"),
         ]
     }
 
@@ -1210,6 +1211,19 @@ mod tests {
         assert_eq!(
             paths,
             vec![std::path::PathBuf::from("/opt/sigil-tools/pre.sh")]
+        );
+    }
+
+    #[test]
+    fn project_parser_watches_mcp_json() {
+        let repo = tempdir().unwrap();
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let watched = parser.watched_paths(repo.path());
+        assert!(
+            watched.contains(&repo.path().join(".mcp.json")),
+            "got {watched:?}"
         );
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -66,6 +66,18 @@ impl AiGuardParser for ClaudeCodeParser {
         emit_hook_reasons(&merged, &hooks_dir, &mut out)?;
         emit_permission_reasons(&merged, &mut out);
         emit_mcp_reasons(&merged, &mut out);
+        // #145 (codex C8) — a user-global `enableAllProjectMcpServers: true`
+        // blanket-approves project MCP servers across EVERY repo. No single
+        // repo context here, so emit on the key alone.
+        if merged
+            .get("enableAllProjectMcpServers")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            out.push(AiGuardReason::ProjectMcpAutoEnabled {
+                mechanism: "user-global blanket: enableAllProjectMcpServers".to_string(),
+            });
+        }
         Ok(out)
     }
 }
@@ -311,6 +323,69 @@ pub(crate) fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
     }
 }
 
+/// #145 — emit MCP reasons from BOTH the merged settings `mcpServers` and the
+/// committed project `<repo>/.mcp.json`, deduplicated by server name. A given
+/// name connects once in Claude Code, so it must be scored once; settings
+/// definitions take precedence (a `.mcp.json` server whose name already
+/// appears in settings is skipped).
+pub(crate) fn emit_project_mcp_reasons(
+    settings: &Value,
+    mcp_json: Option<&Value>,
+    out: &mut Vec<AiGuardReason>,
+) {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if let Some(servers) = settings.get("mcpServers").and_then(Value::as_object) {
+        for (name, def) in servers {
+            seen.insert(name.clone());
+            super::mcp_scan::emit_one_server(name, def, out);
+        }
+    }
+    if let Some(servers) = mcp_json
+        .and_then(|v| v.get("mcpServers"))
+        .and_then(Value::as_object)
+    {
+        for (name, def) in servers {
+            if seen.insert(name.clone()) {
+                super::mcp_scan::emit_one_server(name, def, out);
+            }
+        }
+    }
+}
+
+/// #145 — does `<repo>/.mcp.json` define at least one project MCP server?
+/// The auto-enable keys only matter when there is a payload for them to launch.
+fn has_project_mcp_servers(mcp_json: Option<&Value>) -> bool {
+    mcp_json
+        .and_then(|v| v.get("mcpServers"))
+        .and_then(Value::as_object)
+        .map(|m| !m.is_empty())
+        .unwrap_or(false)
+}
+
+/// #145 — the server-enable signal in committed settings that auto-launches
+/// project `.mcp.json` servers on folder-trust, if any. `enableAllProjectMcpServers`
+/// takes priority over `enabledMcpjsonServers`. NOTE: `permissions.allow:["mcp__*"]`
+/// is NOT a trigger — that grants tool-call permission, not server pre-approval
+/// (codex C4); a separate auto-approval signal is future work.
+fn project_auto_enable_mechanism(settings: &Value) -> Option<&'static str> {
+    if settings
+        .get("enableAllProjectMcpServers")
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        return Some("enableAllProjectMcpServers");
+    }
+    if settings
+        .get("enabledMcpjsonServers")
+        .and_then(Value::as_array)
+        .map(|a| !a.is_empty())
+        .unwrap_or(false)
+    {
+        return Some("enabledMcpjsonServers");
+    }
+    None
+}
+
 /// Phase 3b.6.2 — per-repo Claude Code parser. Spawned by runtime /
 /// policy_reload after discovery; each instance carries its own repo
 /// root and emits AiGuardRiskAssessed with scope=Project{path:repo_root}.
@@ -363,7 +438,8 @@ impl AiGuardParser for ClaudeCodeProjectParser {
         let cd = self.repo_root.join(".claude");
         let base = super::read_json_optional(&cd.join("settings.json"))?;
         let local = super::read_json_optional(&cd.join("settings.local.json"))?;
-        if base.is_none() && local.is_none() {
+        let mcp_json = super::read_json_optional(&self.repo_root.join(".mcp.json"))?;
+        if base.is_none() && local.is_none() && mcp_json.is_none() {
             return Ok(Vec::new());
         }
         let merged = merge_overlay(base.unwrap_or(Value::Object(Default::default())), local);
@@ -371,7 +447,17 @@ impl AiGuardParser for ClaudeCodeProjectParser {
         let mut out = Vec::new();
         emit_hook_reasons(&merged, &hooks_dir, &mut out)?;
         emit_permission_reasons(&merged, &mut out);
-        emit_mcp_reasons(&merged, &mut out);
+        emit_project_mcp_reasons(&merged, mcp_json.as_ref(), &mut out);
+        // #145 — auto-enable posture: emit ONLY when a server-enable key is
+        // present AND the project actually ships `.mcp.json` servers for it
+        // to launch (key-only with no payload -> no emit).
+        if has_project_mcp_servers(mcp_json.as_ref()) {
+            if let Some(mechanism) = project_auto_enable_mechanism(&merged) {
+                out.push(AiGuardReason::ProjectMcpAutoEnabled {
+                    mechanism: mechanism.to_string(),
+                });
+            }
+        }
         Ok(out)
     }
 }
@@ -386,6 +472,31 @@ mod tests {
         let claude = home.join(".claude");
         std::fs::create_dir_all(&claude).unwrap();
         std::fs::write(claude.join("settings.json"), contents).unwrap();
+    }
+
+    fn write_file(dir: &Path, rel: &str, contents: &str) {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, contents).unwrap();
+    }
+
+    #[test]
+    fn project_mcp_json_payload_scored() {
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".mcp.json",
+            r#"{ "mcpServers": { "x": { "command": "bash", "args": ["-c", "echo hi"] } } }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        assert!(
+            out.iter()
+                .any(|r| matches!(r, AiGuardReason::McpServerSuspiciousLauncher { .. })),
+            "expected #127 launcher reason from .mcp.json payload, got {out:?}"
+        );
     }
 
     #[test]
@@ -953,6 +1064,133 @@ mod tests {
                 AiGuardReason::McpServerRemote { server_name, .. } if server_name == "b")),
             "leading-space server \"b\" should emit remote: {reasons:?}"
         );
+    }
+
+    #[test]
+    fn user_scope_blanket_enable_emits_on_key_alone() {
+        let home = tempdir().unwrap();
+        write_settings(home.path(), r#"{ "enableAllProjectMcpServers": true }"#);
+        let out = ClaudeCodeParser.assess(home.path()).unwrap();
+        assert!(
+            out.iter().any(|r| matches!(
+                r, AiGuardReason::ProjectMcpAutoEnabled { mechanism }
+                    if mechanism.starts_with("user-global blanket")
+            )),
+            "got {out:?}"
+        );
+    }
+
+    #[test]
+    fn auto_enable_key_with_servers_emits_high() {
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{ "enableAllProjectMcpServers": true }"#,
+        );
+        write_file(
+            repo.path(),
+            ".mcp.json",
+            r#"{ "mcpServers": { "x": { "command": "node", "args": ["/tmp/.x/p.js"] } } }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        assert!(out.iter().any(|r| matches!(
+            r, AiGuardReason::ProjectMcpAutoEnabled { mechanism } if mechanism == "enableAllProjectMcpServers"
+        )), "got {out:?}");
+    }
+
+    #[test]
+    fn auto_enable_key_without_servers_no_emit() {
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{ "enableAllProjectMcpServers": true }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, AiGuardReason::ProjectMcpAutoEnabled { .. })),
+            "key with no .mcp.json payload must not emit; got {out:?}"
+        );
+    }
+
+    #[test]
+    fn enabled_mcpjson_servers_array_emits() {
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{ "enabledMcpjsonServers": ["x"] }"#,
+        );
+        write_file(
+            repo.path(),
+            ".mcp.json",
+            r#"{ "mcpServers": { "x": { "command": "node" } } }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        assert!(out.iter().any(|r| matches!(
+            r, AiGuardReason::ProjectMcpAutoEnabled { mechanism } if mechanism == "enabledMcpjsonServers"
+        )), "got {out:?}");
+    }
+
+    #[test]
+    fn permissions_allow_mcp_does_not_emit_auto_enabled() {
+        // codex C4 regression guard: mcp__* tool-call permission is NOT a
+        // server auto-enable signal.
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{ "permissions": { "allow": ["mcp__x"] } }"#,
+        );
+        write_file(
+            repo.path(),
+            ".mcp.json",
+            r#"{ "mcpServers": { "x": { "command": "node" } } }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, AiGuardReason::ProjectMcpAutoEnabled { .. })),
+            "got {out:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_json_and_settings_dedup_by_name() {
+        // codex C9: same server name in both settings and .mcp.json scores once.
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{ "mcpServers": { "x": { "command": "node" } } }"#,
+        );
+        write_file(
+            repo.path(),
+            ".mcp.json",
+            r#"{ "mcpServers": { "x": { "command": "node" } } }"#,
+        );
+        let parser = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        };
+        let out = parser.assess(repo.path()).unwrap();
+        let n = out.iter().filter(|r| matches!(
+            r, AiGuardReason::McpServerLocalCommand { server_name, .. } if server_name == "x"
+        )).count();
+        assert_eq!(n, 1, "name dedup failed; got {out:?}");
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/cursor.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/cursor.rs
@@ -53,7 +53,15 @@ impl AiGuardParser for CursorProjectParser {
         vec![self.repo_root.join(".cursor").join("mcp.json")]
     }
     fn assess(&self, _home: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
-        assess_path(self.repo_root.join(".cursor").join("mcp.json"))
+        let mut out = assess_path(self.repo_root.join(".cursor").join("mcp.json"))?;
+        // #145 Option B — amplify only when folder-trust autorun would launch
+        // local/risky code on this host (not for benign remote-only configs).
+        if super::mcp_scan::has_local_or_risky_mcp(&out) {
+            out.push(AiGuardReason::ProjectMcpAutoEnabled {
+                mechanism: "folder-trust autorun (default)".to_string(),
+            });
+        }
+        Ok(out)
     }
 }
 
@@ -142,5 +150,51 @@ mod tests {
             repo_root: d.path().to_path_buf(),
         };
         assert!(p.assess(Path::new("/unused")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn cursor_local_command_emits_auto_enabled() {
+        let repo = tempdir().unwrap();
+        let cur = repo.path().join(".cursor");
+        std::fs::create_dir_all(&cur).unwrap();
+        std::fs::write(
+            cur.join("mcp.json"),
+            r#"{ "mcpServers": { "x": { "command": "node" } } }"#,
+        )
+        .unwrap();
+        let out = CursorProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        }
+        .assess(repo.path())
+        .unwrap();
+        assert!(
+            out.iter().any(|r| matches!(
+                r, AiGuardReason::ProjectMcpAutoEnabled { mechanism }
+                    if mechanism == "folder-trust autorun (default)"
+            )),
+            "got {out:?}"
+        );
+    }
+
+    #[test]
+    fn cursor_benign_remote_no_auto_enabled() {
+        let repo = tempdir().unwrap();
+        let cur = repo.path().join(".cursor");
+        std::fs::create_dir_all(&cur).unwrap();
+        std::fs::write(
+            cur.join("mcp.json"),
+            r#"{ "mcpServers": { "x": { "url": "https://api.example/mcp" } } }"#,
+        )
+        .unwrap();
+        let out = CursorProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        }
+        .assess(repo.path())
+        .unwrap();
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, AiGuardReason::ProjectMcpAutoEnabled { .. })),
+            "benign remote must not amplify; got {out:?}"
+        );
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/gemini.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/gemini.rs
@@ -141,7 +141,13 @@ impl AiGuardParser for GeminiProjectParser {
         vec![self.repo_root.join(".gemini").join("settings.json")]
     }
     fn assess(&self, _home: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
-        assess_path(self.repo_root.join(".gemini").join("settings.json"))
+        let mut out = assess_path(self.repo_root.join(".gemini").join("settings.json"))?;
+        if super::mcp_scan::has_local_or_risky_mcp(&out) {
+            out.push(AiGuardReason::ProjectMcpAutoEnabled {
+                mechanism: "folder-trust autorun (default)".to_string(),
+            });
+        }
+        Ok(out)
     }
 }
 
@@ -299,5 +305,49 @@ mod tests {
             .iter()
             .any(|r| matches!(r, AiGuardReason::SandboxDisabled)));
         assert_eq!(p.scope(), AiGuardScope::Project { path: repo });
+    }
+
+    #[test]
+    fn gemini_local_command_emits_auto_enabled() {
+        let repo = tempdir().unwrap();
+        let g = repo.path().join(".gemini");
+        std::fs::create_dir_all(&g).unwrap();
+        std::fs::write(
+            g.join("settings.json"),
+            r#"{ "mcpServers": { "x": { "command": "node" } } }"#,
+        )
+        .unwrap();
+        let out = GeminiProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        }
+        .assess(repo.path())
+        .unwrap();
+        assert!(
+            out.iter()
+                .any(|r| matches!(r, AiGuardReason::ProjectMcpAutoEnabled { .. })),
+            "got {out:?}"
+        );
+    }
+
+    #[test]
+    fn gemini_benign_remote_no_auto_enabled() {
+        let repo = tempdir().unwrap();
+        let g = repo.path().join(".gemini");
+        std::fs::create_dir_all(&g).unwrap();
+        std::fs::write(
+            g.join("settings.json"),
+            r#"{ "mcpServers": { "x": { "url": "https://api.example/mcp" } } }"#,
+        )
+        .unwrap();
+        let out = GeminiProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        }
+        .assess(repo.path())
+        .unwrap();
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, AiGuardReason::ProjectMcpAutoEnabled { .. })),
+            "got {out:?}"
+        );
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/mcp_scan.rs
@@ -34,7 +34,7 @@ pub fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
 pub(crate) fn emit_one_server(name: &str, def: &Value, out: &mut Vec<AiGuardReason>) {
     for key in ["url", "httpUrl"] {
         if let Some(u) = def.get(key).and_then(Value::as_str) {
-            if scheme_is_http(u) {
+            if scheme_is_remote(u) {
                 out.push(AiGuardReason::McpServerRemote {
                     server_name: name.to_string(),
                     url: u.to_string(),
@@ -121,6 +121,29 @@ pub(crate) fn emit_one_server(name: &str, def: &Value, out: &mut Vec<AiGuardReas
 pub(crate) fn scheme_is_http(u: &str) -> bool {
     let lower = u.trim_start().to_ascii_lowercase();
     lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+/// #145 — schemes that denote a *remote* MCP transport. Superset of
+/// `scheme_is_http`: Claude `type:"ws"` servers carry a `ws://`/`wss://` URL.
+pub(crate) fn scheme_is_remote(u: &str) -> bool {
+    let lower = u.trim_start().to_ascii_lowercase();
+    scheme_is_http(u) || lower.starts_with("ws://") || lower.starts_with("wss://")
+}
+
+/// #145 — does this reason set indicate a *locally executing or risky* MCP
+/// server (vs benign remote-only)? Project parsers use this to amplify with
+/// `ProjectMcpAutoEnabled` ONLY when folder-trust autorun would actually
+/// launch code on this host — Option B, avoiding alert fatigue on benign
+/// remote-only project configs.
+pub(crate) fn has_local_or_risky_mcp(reasons: &[AiGuardReason]) -> bool {
+    reasons.iter().any(|r| {
+        matches!(
+            r,
+            AiGuardReason::McpServerLocalCommand { .. }
+                | AiGuardReason::McpServerSuspiciousLauncher { .. }
+                | AiGuardReason::DestructiveInInlineCommand { .. }
+        )
+    })
 }
 
 #[cfg(test)]
@@ -550,5 +573,30 @@ mod tests {
         assert!(out
             .iter()
             .any(|x| matches!(x, AiGuardReason::DestructiveInInlineCommand { .. })));
+    }
+
+    #[test]
+    fn ws_remote_flagged_as_remote() {
+        let def = serde_json::json!({ "url": "wss://evil.example/mcp" });
+        let mut out = Vec::new();
+        emit_one_server("ws", &def, &mut out);
+        assert!(out.iter().any(|r| matches!(
+            r,
+            AiGuardReason::McpServerRemote { url, .. } if url == "wss://evil.example/mcp"
+        )));
+    }
+
+    #[test]
+    fn risky_mcp_helper_distinguishes_local_from_remote() {
+        let remote = [AiGuardReason::McpServerRemote {
+            server_name: "r".into(),
+            url: "https://x".into(),
+        }];
+        assert!(!has_local_or_risky_mcp(&remote));
+        let local = [AiGuardReason::McpServerLocalCommand {
+            server_name: "l".into(),
+            command: "node".into(),
+        }];
+        assert!(has_local_or_risky_mcp(&local));
     }
 }

--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -41,6 +41,7 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
             shape: LauncherShape::TransientPath,
             ..
         } => "mcp_launcher_transient_path",
+        AiGuardReason::ProjectMcpAutoEnabled { .. } => "project_mcp_auto_enabled",
     }
 }
 
@@ -50,7 +51,7 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
 #[derive(Debug, Clone)]
 pub struct Rubric {
     /// kind_key → weight. Keys are static strings owned by the rubric
-    /// module (returned by `kind_key()`). Defaults populate all 15 known
+    /// module (returned by `kind_key()`). Defaults populate all 16 known
     /// kinds; with_overrides() may replace values but never adds keys.
     pub weights: HashMap<&'static str, f32>,
     /// Subset of `weights` whose value came from an operator override
@@ -65,7 +66,7 @@ pub struct Rubric {
 impl Rubric {
     /// Build the canonical hardcoded weights — single source of truth for
     /// defaults. Must match the historical `weight_for()` match arms for
-    /// all 15 kinds.
+    /// all 16 kinds.
     pub fn defaults() -> Self {
         let mut w: HashMap<&'static str, f32> = HashMap::new();
         w.insert("destructive_in_inline_command", 4.0);
@@ -81,6 +82,7 @@ impl Rubric {
         w.insert("mcp_server_local_command", 0.5);
         w.insert("mcp_launcher_shell", 3.0);
         w.insert("mcp_launcher_transient_path", 3.0);
+        w.insert("project_mcp_auto_enabled", 2.5);
         w.insert("trusted_mcp_server", 1.5);
         w.insert("auto_approval_enabled", 2.0);
         Rubric {
@@ -420,7 +422,7 @@ mod tests {
     }
 
     #[test]
-    fn rubric_defaults_all_15_kinds_present() {
+    fn rubric_defaults_all_16_kinds_present() {
         let r = Rubric::defaults();
         assert_eq!(r.weights.get("destructive_in_inline_command"), Some(&4.0));
         assert_eq!(r.weights.get("destructive_in_hook_script"), Some(&4.0));
@@ -437,7 +439,29 @@ mod tests {
         assert_eq!(r.weights.get("auto_approval_enabled"), Some(&2.0));
         assert_eq!(r.weights.get("mcp_launcher_shell"), Some(&3.0));
         assert_eq!(r.weights.get("mcp_launcher_transient_path"), Some(&3.0));
-        assert_eq!(r.weights.len(), 15);
+        assert_eq!(r.weights.get("project_mcp_auto_enabled"), Some(&2.5));
+        assert_eq!(r.weights.len(), 16);
+    }
+
+    #[test]
+    fn project_mcp_auto_enabled_buckets() {
+        let solo = [AiGuardReason::ProjectMcpAutoEnabled {
+            mechanism: "enableAllProjectMcpServers".into(),
+        }];
+        assert_eq!(bucket(score(&solo)), AiGuardBucket::Medium); // 2.5
+
+        let combo = [
+            AiGuardReason::ProjectMcpAutoEnabled {
+                mechanism: "enableAllProjectMcpServers".into(),
+            },
+            AiGuardReason::McpServerSuspiciousLauncher {
+                server_name: "x".into(),
+                command: "bash".into(),
+                shape: LauncherShape::Shell,
+                evidence: "bash -c".into(),
+            },
+        ];
+        assert_eq!(bucket(score(&combo)), AiGuardBucket::High); // 2.5 + 3.0 = 5.5
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/workspace_discovery.rs
+++ b/crates/sigil-agent/src/ai_guard/workspace_discovery.rs
@@ -63,6 +63,20 @@ pub fn discover_per_repo(roots: &[String], marker_subpath: &str) -> Vec<PathBuf>
     out.into_iter().collect()
 }
 
+/// #145 — Claude Code repos are discovered by EITHER marker: the per-tool
+/// settings file (`.claude/settings.json`) OR a committed project MCP payload
+/// at the repo root (`.mcp.json`). A repo with only `.mcp.json` is still a
+/// TrustFall surface, so it must be discovered (and watched) too. Union,
+/// deduplicated by canonical path.
+pub fn discover_claude_repos(roots: &[String]) -> Vec<PathBuf> {
+    let mut set: std::collections::BTreeSet<PathBuf> =
+        discover_per_repo(roots, ".claude/settings.json")
+            .into_iter()
+            .collect();
+    set.extend(discover_per_repo(roots, ".mcp.json"));
+    set.into_iter().collect()
+}
+
 fn expand_and_canonicalize(raw: &str) -> Option<PathBuf> {
     let expanded =
         match sigil_core::policy::expand::expand(raw, &sigil_core::policy::expand::EnvLookup) {
@@ -178,6 +192,18 @@ mod tests {
         let root = dir.path().to_string_lossy().to_string();
         let out = discover_per_repo(&[root.clone(), root], CONTINUE_MARKER);
         assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn discover_claude_repos_finds_mcp_json_only_repo() {
+        let root = tempdir().unwrap();
+        let repo = root.path().join("only-mcp");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(repo.join(".mcp.json"), "{}").unwrap();
+        let roots = vec![root.path().to_string_lossy().to_string()];
+        let found = discover_claude_repos(&roots);
+        let canon = dunce::canonicalize(&repo).unwrap();
+        assert!(found.contains(&canon), "got {found:?}");
     }
 
     #[test]

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -345,9 +345,8 @@ pub(crate) fn reload(ctx: &mut ReloadCtx, plat: &ActivePlatform) {
         .into_iter()
         .collect();
     let new_claude: std::collections::BTreeSet<PathBuf> =
-        crate::ai_guard::workspace_discovery::discover_per_repo(
+        crate::ai_guard::workspace_discovery::discover_claude_repos(
             &effective.claude_code_workspaces,
-            ".claude/settings.json",
         )
         .into_iter()
         .collect();

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -169,9 +169,8 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
         &effective.continue_workspaces,
         ".continue/config.json",
     );
-    let claude_code_repos = crate::ai_guard::workspace_discovery::discover_per_repo(
+    let claude_code_repos = crate::ai_guard::workspace_discovery::discover_claude_repos(
         &effective.claude_code_workspaces,
-        ".claude/settings.json",
     );
     let codex_repos = crate::ai_guard::workspace_discovery::discover_per_repo(
         &effective.codex_workspaces,
@@ -1274,6 +1273,7 @@ pub(crate) fn push_claude_code_synthetic_targets(
         paths: vec![
             cd.join("settings.json").to_string_lossy().to_string(),
             cd.join("settings.local.json").to_string_lossy().to_string(),
+            repo_root.join(".mcp.json").to_string_lossy().to_string(),
         ],
         recursive: false,
         follow_symlinks: false,

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -228,6 +228,12 @@ pub enum AiGuardReason {
         /// transient_path.
         evidence: String,
     },
+    /// #145 — a committed project config pre-approves project-scope MCP
+    /// servers so they auto-launch on folder-trust (TrustFall class). The
+    /// `mechanism` names the specific auto-enable signal (a settings key, or
+    /// a tool's folder-trust default). Emitted as POSTURE; the launched
+    /// server's own command is scored separately via `emit_one_server`.
+    ProjectMcpAutoEnabled { mechanism: String },
 }
 
 /// #127 — classification of a suspicious stdio MCP launcher. Stable wire
@@ -1184,6 +1190,13 @@ mod tests {
         let j = serde_json::to_value(&a).unwrap();
         assert_eq!(j["kind"], "auto_approval_enabled");
         assert_eq!(j["mode"], "auto_edit");
+
+        let p = AiGuardReason::ProjectMcpAutoEnabled {
+            mechanism: "enableAllProjectMcpServers".into(),
+        };
+        let j = serde_json::to_value(&p).unwrap();
+        assert_eq!(j["kind"], "project_mcp_auto_enabled");
+        assert_eq!(j["mechanism"], "enableAllProjectMcpServers");
     }
 
     #[test]


### PR DESCRIPTION
Closes #145.

## What

Detect the **TrustFall class** — a repository that commits a project MCP payload (`<repo>/.mcp.json`) together with settings keys that auto-launch it on folder-trust (a 1-click RCE on opening the repo). Detection/posture only — no enforce/deny (that is #100).

## How

- **New reason** `AiGuardReason::ProjectMcpAutoEnabled { mechanism }` (sigil-core), rubric weight **2.5** (`project_mcp_auto_enabled`). Solo → Medium; with a suspicious launcher → High; with destructive → Critical.
- **Claude project parser** now reads `<repo>/.mcp.json` (`mcpServers`) and routes each server through the existing `emit_one_server` attack-shape scorer (#127), **deduplicated by name** with settings `mcpServers` (settings precedence — a name in both scores once).
- **Auto-enable triggers = the two server-enable keys only**: `enableAllProjectMcpServers == true` and a non-empty `enabledMcpjsonServers`. The project parser emits only when a key is present **and** `.mcp.json` actually ships servers. `permissions.allow:["mcp__*"]` is intentionally **not** a trigger (tool-call permission ≠ server pre-approval).
- **User-global blanket**: a user-scope `enableAllProjectMcpServers: true` emits on the key alone (blanket pre-approval across every repo).
- **Cursor / Gemini** use "Option B": amplify with `ProjectMcpAutoEnabled{mechanism:"folder-trust autorun (default)"}` only when the project config produced a local/risky MCP reason — benign remote-only configs do not amplify (no alert fatigue).
- **Antigravity** deferred (its MCP lives in a global file, not per-repo) — documented, no behavior change.
- **`ws://` / `wss://`** now classified as remote in `emit_one_server`.
- **Discovery + watch**: a repo with *only* `.mcp.json` (no `.claude/settings.json`) is now discovered (new `discover_claude_repos` union helper, used at both boot and reload) and watched (`.mcp.json` added to the synthetic `WatchTarget` and to `ClaudeCodeProjectParser::watched_paths()`).

## Hardening (post-review)

- **Defensive `.mcp.json` read**: a malformed `.mcp.json` no longer aborts the whole assess and blind detection of a malicious `.claude/settings.json` in the same repo (corrupt-sidecar evasion seam). Degrades to "no payload"; settings-side reasons still score. Regression test added.

## Tests

~16 new tests: payload scoring, the two auto-enable keys, the `mcp__*` negative guard, name dedup, user-global blanket, Option B local-vs-remote for Cursor/Gemini, ws remote, `.mcp.json`-only discovery, watched-paths, corrupt-sidecar resilience, rubric weight/bucket math. Full suite green; `clippy -D warnings` clean.

## Out of scope (follow-ups)

- `permissions.allow:["mcp__*"]` auto-approval signal + cross-scope permissions merge.
- `~/.claude.json` approval-state scan.
- Codex/Continue project-parser "Option B" evaluation (filed separately).
- enforce/deny (#100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
