### PR TITLE
feat(sigil-hook): Antigravity install is static-posture-only by default (#112)

### DIFF
--- a/crates/sigil-hook/src/adapters/antigravity.rs
+++ b/crates/sigil-hook/src/adapters/antigravity.rs
@@ -10,6 +10,8 @@ use sigil_core::hook_proto::*;
 /// also defensively handle Gemini-carryover tool names
 /// (`run_shell_command` / `write_file` / `replace`) in case Antigravity still
 /// emits any of them. Unknown tools degrade to `Other { label }`.
+/// NOTE (#112): this adapter is not reachable from current agy command-hooks
+/// (they do not fire); it is retained for parser / forced-bundle compatibility.
 pub struct Antigravity;
 
 impl HookAdapter for Antigravity {

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -10,6 +10,8 @@ pub mod grok;
 /// deny response, if any) and the process exit code. claude-code/codex/
 /// antigravity: the JSON rides stdout with exit 0; the exit_code field lets a
 /// future agent whose deny path needs a non-zero exit express that.
+/// (antigravity: this deny contract is NOT reachable on current agy — its
+/// command-hooks do not fire; #112).
 pub struct DenyOutput {
     pub stdout: Option<String>,
     pub exit_code: i32,

--- a/crates/sigil-hook/src/install_antigravity.rs
+++ b/crates/sigil-hook/src/install_antigravity.rs
@@ -1,22 +1,25 @@
-// Antigravity (Google `agy` CLI) install. Unlike the JSON-settings agents in
-// install.rs, Antigravity loads hooks ONLY from an imported plugin — on-hardware
-// verification (real `agy` 1.0.4) showed settings.json hooks are silently
-// ignored, while a plugin bundle handed to `agy plugin install <dir>` is loaded
-// (`agy plugin validate` reports "hooks: 1 processed").
+// Antigravity (Google `agy` CLI) install. Antigravity loads hooks from an
+// imported plugin bundle (`agy plugin install <dir>`), NOT settings.json.
 //
-// Canonical bundle layout, verified three ways (`agy plugin validate`, a full
-// install→list→uninstall cycle, and the official `google-antigravity-sdk` /
-// `chrome-devtools-plugin` plugins under ~/.gemini/config/plugins):
+// VERSION CAVEAT (#112): agy 1.0.4 accepted and loaded this `hooks/hooks.json`
+// bundle (`agy plugin validate` reported "hooks: 1 processed"), but agy
+// 1.0.7/1.0.8 do NOT fire `agy plugin install` PreToolUse command-hooks —
+// `agy plugin validate` reports "hooks: skipped (not found)", `plugin list`
+// shows components: null, and an always-deny probe hook fired 0 times on
+// hardware. So on current agy this registration is a no-op. `sigil-hook install
+// --agent antigravity` therefore does NOT install by default (see
+// cmd_install_antigravity); this module's bundle path is reached only under
+// `--force` (experimental / for a future agy that restores command-hooks).
+//
+// Canonical bundle layout (as accepted by agy 1.0.4; `hooks/` subdir required —
+// root-level hooks.json, inline `hooks` in plugin.json, and hooks.toml were all
+// reported "hooks: not found"):
 //
 //   <dir>/plugin.json        {name, version, description, license, keywords}
 //   <dir>/hooks/hooks.json   {PreToolUse:[{matcher, hooks:[{type, command}]}]}
 //
-// The `hooks/` subdirectory is required: a root-level hooks.json, an inline
-// `hooks` field in plugin.json, and a hooks.toml are all reported as
-// "hooks: not found". Only `hooks/hooks.json` is processed.
-//
-// `agy plugin install` copies the bundle into ~/.gemini/config/plugins/<name>/
-// and records it in `agy plugin list`; `agy plugin uninstall <name>` reverses it.
+// `agy plugin install` copies the bundle into ~/.gemini/config/plugins/<name>/;
+// `agy plugin uninstall <name>` reverses it.
 
 use serde_json::{json, Value};
 use std::io;
@@ -46,7 +49,7 @@ pub fn plugin_json() -> Value {
     json!({
         "name": PLUGIN_NAME,
         "version": env!("CARGO_PKG_VERSION"),
-        "description": "Sigil runtime observer — emits AI agent tool-call events to the local sigil-agent.",
+        "description": "Sigil runtime observer (NOTE: current agy may not invoke this command-hook — sigil #112).",
         "license": "Apache-2.0",
         "keywords": ["sigil", "security", "observability", "antigravity"],
     })
@@ -111,7 +114,9 @@ pub fn render_block(exe: &str, capture: &str) -> String {
     let hj = serde_json::to_string_pretty(&hooks_json(exe, capture)).unwrap_or_default();
     format!(
         "// Antigravity registers hooks via an imported plugin, not a settings file.\n\
-         // `sigil-hook install --agent antigravity --write` writes this bundle to\n\
+         // NOTE: current agy (>=1.0.7) does NOT fire this command-hook (sigil #112);\n\
+         // `install --agent antigravity` is a no-op unless you pass --force.\n\
+         // Under --force, --write writes this bundle to\n\
          //   {dir_s}\n\
          // then runs: agy plugin install {dir_s}\n\
          //\n\

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -226,6 +226,10 @@ enum Cmd {
         /// Fail mode baked into the enforce command. Default open.
         #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
         on_failure: OnFailureArg,
+        /// Force the Antigravity command-hook install even though it does not
+        /// fire on current agy (see #112). No effect for other agents.
+        #[arg(long)]
+        force: bool,
     },
 
     /// Remove the sigil-hook registration from an agent's settings.
@@ -410,7 +414,8 @@ fn main() {
             capture,
             enforce,
             on_failure,
-        } => cmd_install(&agent, write, capture, enforce, on_failure),
+            force,
+        } => cmd_install(&agent, write, capture, enforce, on_failure, force),
         Cmd::Uninstall { agent, write } => cmd_uninstall(&agent, write),
         Cmd::Verify { agent } => std::process::exit(cmd_verify(&agent)),
     }
@@ -430,6 +435,7 @@ fn cmd_install(
     capture: CaptureArg,
     enforce: bool,
     on_failure: OnFailureArg,
+    force: bool,
 ) {
     let capture_str = match capture {
         CaptureArg::Redacted => "redacted",
@@ -445,7 +451,16 @@ fn cmd_install(
     // Antigravity is not a settings-merge agent: it installs as an `agy` plugin
     // bundle. Route it through the dedicated path.
     if agent == "antigravity" {
-        return cmd_install_antigravity(&exe, write, capture_str);
+        // #112 (C1) — Antigravity enforce is not available: current agy does not
+        // fire plugin command-hooks, so there is no deny path to register.
+        if enforce {
+            eprintln!(
+                "error: Antigravity enforce is not available — current agy does not fire \
+                 plugin command-hooks (sigil #112). Use static posture scanning; omit --enforce."
+            );
+            std::process::exit(2);
+        }
+        return cmd_install_antigravity(&exe, write, capture_str, force);
     }
 
     // Grok is not a settings-merge agent: it writes a dedicated
@@ -675,9 +690,45 @@ fn cmd_uninstall_grok(write: bool) {
     }
 }
 
+/// #112 — current agy (>=1.0.7) does not fire `agy plugin install` PreToolUse
+/// command-hooks; installing one is a no-op that gives false assurance. Skip by
+/// default; only proceed under `--force` (preserves the path for a future agy
+/// that restores command-hooks).
+#[derive(Debug, PartialEq, Eq)]
+enum AntigravityInstallDisposition {
+    NotSupported,
+    Proceed,
+}
+
+fn antigravity_install_disposition(force: bool) -> AntigravityInstallDisposition {
+    if force {
+        AntigravityInstallDisposition::Proceed
+    } else {
+        AntigravityInstallDisposition::NotSupported
+    }
+}
+
+// C6 — must begin with "NOT installed" + "no files written, agy not invoked"
+// so the message never drifts into "installed" language; asserted by tests.
+const ANTIGRAVITY_NOT_SUPPORTED_MSG: &str =
+    "sigil-hook: Antigravity runtime hooks NOT installed (no files written, agy not invoked).\n\
+     Current Antigravity (agy >=1.0.7) does not fire `agy plugin install` PreToolUse \
+     command-hooks (verified — sigil #112), so installing one would be a no-op that \
+     falsely implies runtime protection.\n\
+     Sigil covers Antigravity via STATIC configuration posture scanning \
+     (sandbox / permission settings) instead.\n\
+     If a future agy restores command-hooks, re-run with --force to install anyway.";
+
 /// Antigravity install: materialize the plugin bundle, then register it with
 /// `agy plugin install`. Without `--write`, print the bundle + command preview.
-fn cmd_install_antigravity(exe: &str, write: bool, capture: &str) {
+fn cmd_install_antigravity(exe: &str, write: bool, capture: &str, force: bool) {
+    if antigravity_install_disposition(force) == AntigravityInstallDisposition::NotSupported {
+        // Both preview (!write) and apply (--write) paths: do nothing but explain.
+        eprintln!("{ANTIGRAVITY_NOT_SUPPORTED_MSG}");
+        return;
+    }
+    // --force: legacy bundle path preserved (may still be a no-op on current agy).
+    eprintln!("sigil-hook: --force set; installing Antigravity command-hook anyway (may not fire on current agy — #112).");
     if !write {
         print!("{}", install_antigravity::render_block(exe, capture));
         return;
@@ -844,5 +895,27 @@ mod tests {
         assert_eq!(drift_exit_code(CommandDrift), 2);
         assert_eq!(drift_exit_code(MatcherDrift), 2);
         assert_eq!(drift_exit_code(FailModeDrift), 2);
+    }
+
+    #[test]
+    fn antigravity_disposition_gates_on_force() {
+        assert_eq!(
+            antigravity_install_disposition(false),
+            AntigravityInstallDisposition::NotSupported
+        );
+        assert_eq!(
+            antigravity_install_disposition(true),
+            AntigravityInstallDisposition::Proceed
+        );
+    }
+
+    #[test]
+    fn antigravity_not_supported_msg_is_honest() {
+        let m = ANTIGRAVITY_NOT_SUPPORTED_MSG;
+        assert!(m.contains("NOT installed"));
+        assert!(m.contains("no files written"));
+        assert!(m.contains("#112"));
+        assert!(m.contains("--force"));
+        assert!(m.to_lowercase().contains("static"));
     }
 }

--- a/crates/sigil-hook/tests/install_antigravity_static.rs
+++ b/crates/sigil-hook/tests/install_antigravity_static.rs
@@ -1,0 +1,87 @@
+//! CLI side-effect tests (#112): `install --agent antigravity` is static-posture-only
+//! by default (no bundle written, agy never invoked) and rejects --enforce; only
+//! --force performs the (legacy / no-op-on-current-agy) bundle install.
+#![cfg(unix)]
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// Fake `agy` that records each invocation by touching a marker file.
+fn write_fake_agy(home: &Path) -> PathBuf {
+    let bin = home.join(".local/bin");
+    fs::create_dir_all(&bin).unwrap();
+    let agy = bin.join("agy");
+    let marker = home.join("agy-invoked.marker");
+    fs::write(
+        &agy,
+        format!("#!/bin/sh\necho called >> {}\nexit 0\n", marker.display()),
+    )
+    .unwrap();
+    fs::set_permissions(&agy, fs::Permissions::from_mode(0o755)).unwrap();
+    marker
+}
+
+fn staging(home: &Path) -> PathBuf {
+    home.join(".local/state/sigil/antigravity-plugin/sigil-hook")
+}
+
+#[test]
+fn antigravity_install_no_force_is_static_only_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let marker = write_fake_agy(home);
+    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .args(["install", "--agent", "antigravity", "--write"])
+        .env("HOME", home)
+        .env_remove("XDG_STATE_HOME")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("NOT installed"), "stderr: {stderr}");
+    assert!(!staging(home).exists(), "no bundle should be written");
+    assert!(!marker.exists(), "agy must not be invoked");
+}
+
+#[test]
+fn antigravity_install_force_writes_bundle_and_calls_agy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let marker = write_fake_agy(home);
+    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .args(["install", "--agent", "antigravity", "--write", "--force"])
+        .env("HOME", home)
+        .env_remove("XDG_STATE_HOME")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        staging(home).join("hooks/hooks.json").exists(),
+        "bundle written under --force"
+    );
+    assert!(marker.exists(), "agy invoked under --force");
+}
+
+#[test]
+fn antigravity_enforce_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_fake_agy(home);
+    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .args(["install", "--agent", "antigravity", "--enforce"])
+        .env("HOME", home)
+        .env_remove("XDG_STATE_HOME")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(out.status.code(), Some(2), "stderr: {stderr}");
+    assert!(
+        stderr.contains("enforce is not available"),
+        "stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## What

Makes `sigil-hook install --agent antigravity` **honest about runtime hooks**. On current Antigravity (`agy` >= 1.0.7) the `agy plugin install` PreToolUse command-hook **does not fire** (hardware-verified, #112), so the previous behavior — silently writing a plugin bundle and invoking `agy` — gave false assurance of runtime protection.

New behavior:
- **Default: static-posture-only.** `install --agent antigravity` writes nothing, never invokes `agy`, and prints an honest message explaining that Sigil covers Antigravity via static configuration-posture scanning instead.
- **`--force` gate.** The legacy bundle-install path is preserved behind a new `--force` flag (for a future `agy` that restores command-hooks). It warns that it may still be a no-op.
- **`--agent antigravity --enforce` is rejected** (exit code 2): there is no deny path to register on current `agy`.

No behavior change to the static AI Guard parser, the runtime adapter, or other agents — those edits are comment/preview-string honesty only.

## Why

Hardware verification on real `agy` 1.0.7/1.0.8: `agy plugin validate` reports `hooks: skipped (not found)`, `plugin list` shows `components: null`, and an always-deny probe hook fired **0 times** while the shell command ran normally. agy's hook subsystem is proto/SDK-internal, not an external command-hook plugin component. Full finding recorded on #112.

## Tests

- Unit: disposition gates on `--force`; honest-message invariant (`NOT installed` / `no files written` / `#112` / `--force` / `static`).
- Integration (`tests/install_antigravity_static.rs`, HOME-isolated + fake `agy`): no-`--force` writes no bundle and never invokes agy; `--force` writes the bundle and calls agy; `--enforce` exits 2.
- `cargo fmt` clean · `clippy -D warnings` clean · `cargo test -p sigil-hook` green.

## Follow-up

A separate issue tracks refreshing the Antigravity static parser's expected values (`toolPermission` valid set / `sandbox_mode`) against agy 1.0.8.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
