### PR TITLE
fix(agent): non-root XDG fallback for state-db/events/policy paths (#159)

### DIFF
--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -229,7 +229,7 @@ pub fn run(policy_override: Option<PathBuf>, state_db_override: Option<PathBuf>)
 
     // Phase 2: show persisted host_id from state.db. Honor the `--state-db`
     // override (matching `sigil show`); fall back to the default path.
-    let state_db_path = state_db_override.unwrap_or_else(default_state_db_path);
+    let state_db_path = state_db_override.unwrap_or_else(crate::runtime::default_state_db_path);
     match sigil_core::state::HashCache::open(&state_db_path) {
         Ok(cache) => match cache.host_meta_get() {
             Ok(meta) => {
@@ -474,29 +474,6 @@ fn print_static_rubric(effective: &sigil_core::policy::EffectivePolicy) {
         for k in &rubric.unknown_override_keys {
             println!("[WARN] rubric override ignored — unknown reason kind: '{k}'");
         }
-    }
-}
-
-/// Default state.db path matching the daemon's runtime default. Mirrors
-/// the convention used by the CLI when `--state-db` is not provided.
-fn default_state_db_path() -> PathBuf {
-    #[cfg(target_os = "macos")]
-    {
-        PathBuf::from("/var/lib/sigil/state.db")
-    }
-    #[cfg(target_os = "linux")]
-    {
-        PathBuf::from("/var/lib/sigil/state.db")
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::path::PathBuf::from(std::env::var_os("ProgramData").unwrap_or_default())
-            .join("Sigil")
-            .join("state.db")
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        PathBuf::from("/tmp/sigil-state.db")
     }
 }
 

--- a/crates/sigil-agent/src/main.rs
+++ b/crates/sigil-agent/src/main.rs
@@ -6,6 +6,7 @@ use sigil_agent::assess_cli;
 use sigil_agent::control::{default_control_pipe_name, default_control_socket};
 #[cfg(feature = "operator-cli")]
 use sigil_agent::control_client;
+use sigil_agent::runtime::{default_events_dir, default_state_db_path};
 use sigil_agent::{cli, doctor, runtime, show};
 
 fn main() -> anyhow::Result<()> {
@@ -100,25 +101,5 @@ fn reload() -> i32 {
             eprintln!("sigil reload: {e}");
             1
         }
-    }
-}
-
-fn default_state_db_path() -> std::path::PathBuf {
-    if cfg!(any(target_os = "macos", target_os = "linux")) {
-        "/var/lib/sigil/state.db".into()
-    } else {
-        std::path::PathBuf::from(std::env::var_os("ProgramData").unwrap_or_default())
-            .join("Sigil")
-            .join("state.db")
-    }
-}
-
-fn default_events_dir() -> std::path::PathBuf {
-    if cfg!(any(target_os = "macos", target_os = "linux")) {
-        "/var/log/sigil".into()
-    } else {
-        std::path::PathBuf::from(std::env::var_os("ProgramData").unwrap_or_default())
-            .join("Sigil")
-            .join("events")
     }
 }

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -1188,19 +1188,227 @@ mod keystore_path_tests {
 }
 
 /// Default `policy.yaml` location when not overridden via `RuntimeConfig.policy_path`.
-/// TODO: factor out a shared `defaults` module if/when other call sites need this.
+/// Root → system `/etc/sigil`; non-root → `$XDG_CONFIG_HOME/sigil` (else
+/// `$HOME/.config/sigil`) so a non-root personal agent reads policy.yaml — and
+/// the sibling `rule-packs.yaml` it derives (see `rule_packs_yaml_path`) — from
+/// its own config dir, matching `docs/install-personal.md` (#159). Mirrors
+/// `resolve_keystore_path_unix`.
 fn default_policy_yaml_path() -> PathBuf {
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    {
-        PathBuf::from("/etc/sigil/policy.yaml")
-    }
     #[cfg(target_os = "windows")]
     {
         PathBuf::from(r"C:\ProgramData\Sigil\policy.yaml")
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     {
-        PathBuf::from("/etc/sigil/policy.yaml")
+        resolve_policy_yaml_path_unix(
+            crate::control::is_root(),
+            std::env::var("XDG_CONFIG_HOME")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            std::env::var("HOME").ok().filter(|s| !s.is_empty()),
+        )
+    }
+}
+
+/// Pure resolver for the Unix `policy.yaml` default. Root → `/etc/sigil`;
+/// non-root → `$XDG_CONFIG_HOME/sigil` (else `$HOME/.config/sigil`); last-resort
+/// `/etc/sigil`.
+#[cfg(not(target_os = "windows"))]
+fn resolve_policy_yaml_path_unix(
+    is_root: bool,
+    xdg_config: Option<String>,
+    home: Option<String>,
+) -> PathBuf {
+    const FILE: &str = "policy.yaml";
+    if is_root {
+        return PathBuf::from("/etc/sigil").join(FILE);
+    }
+    if let Some(dir) = xdg_config {
+        return PathBuf::from(dir).join("sigil").join(FILE);
+    }
+    if let Some(home) = home {
+        return PathBuf::from(home).join(".config").join("sigil").join(FILE);
+    }
+    PathBuf::from("/etc/sigil").join(FILE)
+}
+
+/// Default `state.db` path when not overridden via `--state-db`. Root →
+/// `/var/lib/sigil/state.db` (systemd deploy); non-root → `$XDG_STATE_HOME/sigil`
+/// (else `$HOME/.local/state/sigil`) so a non-root personal agent starts without
+/// `/var/lib` write access (#159). The daemon `create_dir_all`s the parent at
+/// boot, so the XDG dir need not pre-exist.
+pub fn default_state_db_path() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        PathBuf::from(std::env::var_os("ProgramData").unwrap_or_default())
+            .join("Sigil")
+            .join("state.db")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        resolve_state_db_path_unix(
+            crate::control::is_root(),
+            std::env::var("XDG_STATE_HOME")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            std::env::var("HOME").ok().filter(|s| !s.is_empty()),
+        )
+    }
+}
+
+/// Pure resolver for the Unix `state.db` default. Root → `/var/lib/sigil`;
+/// non-root → `$XDG_STATE_HOME/sigil` (else `$HOME/.local/state/sigil`);
+/// last-resort `/var/lib/sigil`.
+#[cfg(not(target_os = "windows"))]
+fn resolve_state_db_path_unix(
+    is_root: bool,
+    xdg_state: Option<String>,
+    home: Option<String>,
+) -> PathBuf {
+    const FILE: &str = "state.db";
+    if is_root {
+        return PathBuf::from("/var/lib/sigil").join(FILE);
+    }
+    if let Some(dir) = xdg_state {
+        return PathBuf::from(dir).join("sigil").join(FILE);
+    }
+    if let Some(home) = home {
+        return PathBuf::from(home).join(".local/state/sigil").join(FILE);
+    }
+    PathBuf::from("/var/lib/sigil").join(FILE)
+}
+
+/// Default events directory when not overridden via `--events-dir`. Root →
+/// `/var/log/sigil`; non-root → `$XDG_STATE_HOME/sigil/events` (else
+/// `$HOME/.local/state/sigil/events`) so a non-root personal agent starts
+/// without `/var/log` write access (#159). `JsonlSink::open` `create_dir_all`s
+/// it, so the dir need not pre-exist.
+pub fn default_events_dir() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        PathBuf::from(std::env::var_os("ProgramData").unwrap_or_default())
+            .join("Sigil")
+            .join("events")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        resolve_events_dir_unix(
+            crate::control::is_root(),
+            std::env::var("XDG_STATE_HOME")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            std::env::var("HOME").ok().filter(|s| !s.is_empty()),
+        )
+    }
+}
+
+/// Pure resolver for the Unix events-dir default. Root → `/var/log/sigil`;
+/// non-root → `$XDG_STATE_HOME/sigil/events` (else
+/// `$HOME/.local/state/sigil/events`); last-resort `/var/log/sigil`.
+#[cfg(not(target_os = "windows"))]
+fn resolve_events_dir_unix(
+    is_root: bool,
+    xdg_state: Option<String>,
+    home: Option<String>,
+) -> PathBuf {
+    if is_root {
+        return PathBuf::from("/var/log/sigil");
+    }
+    if let Some(dir) = xdg_state {
+        return PathBuf::from(dir).join("sigil").join("events");
+    }
+    if let Some(home) = home {
+        return PathBuf::from(home)
+            .join(".local/state/sigil")
+            .join("events");
+    }
+    PathBuf::from("/var/log/sigil")
+}
+
+#[cfg(all(test, not(target_os = "windows")))]
+mod nonroot_path_tests {
+    use super::{
+        resolve_events_dir_unix, resolve_policy_yaml_path_unix, resolve_state_db_path_unix,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn root_uses_system_paths() {
+        let x = Some("/home/u/.config".to_string());
+        let xs = Some("/home/u/.local/state".to_string());
+        let h = Some("/home/u".to_string());
+        assert_eq!(
+            resolve_policy_yaml_path_unix(true, x, h.clone()),
+            PathBuf::from("/etc/sigil/policy.yaml")
+        );
+        assert_eq!(
+            resolve_state_db_path_unix(true, xs.clone(), h.clone()),
+            PathBuf::from("/var/lib/sigil/state.db")
+        );
+        assert_eq!(
+            resolve_events_dir_unix(true, xs, h),
+            PathBuf::from("/var/log/sigil")
+        );
+    }
+
+    #[test]
+    fn nonroot_prefers_xdg() {
+        assert_eq!(
+            resolve_policy_yaml_path_unix(
+                false,
+                Some("/home/u/.config".into()),
+                Some("/home/u".into())
+            ),
+            PathBuf::from("/home/u/.config/sigil/policy.yaml")
+        );
+        assert_eq!(
+            resolve_state_db_path_unix(
+                false,
+                Some("/home/u/.local/state".into()),
+                Some("/home/u".into())
+            ),
+            PathBuf::from("/home/u/.local/state/sigil/state.db")
+        );
+        assert_eq!(
+            resolve_events_dir_unix(
+                false,
+                Some("/home/u/.local/state".into()),
+                Some("/home/u".into())
+            ),
+            PathBuf::from("/home/u/.local/state/sigil/events")
+        );
+    }
+
+    #[test]
+    fn nonroot_without_xdg_uses_home() {
+        assert_eq!(
+            resolve_policy_yaml_path_unix(false, None, Some("/home/u".into())),
+            PathBuf::from("/home/u/.config/sigil/policy.yaml")
+        );
+        assert_eq!(
+            resolve_state_db_path_unix(false, None, Some("/home/u".into())),
+            PathBuf::from("/home/u/.local/state/sigil/state.db")
+        );
+        assert_eq!(
+            resolve_events_dir_unix(false, None, Some("/home/u".into())),
+            PathBuf::from("/home/u/.local/state/sigil/events")
+        );
+    }
+
+    #[test]
+    fn nonroot_without_xdg_or_home_falls_back_to_system() {
+        assert_eq!(
+            resolve_policy_yaml_path_unix(false, None, None),
+            PathBuf::from("/etc/sigil/policy.yaml")
+        );
+        assert_eq!(
+            resolve_state_db_path_unix(false, None, None),
+            PathBuf::from("/var/lib/sigil/state.db")
+        );
+        assert_eq!(
+            resolve_events_dir_unix(false, None, None),
+            PathBuf::from("/var/log/sigil")
+        );
     }
 }
 

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -45,7 +45,7 @@ pub fn run(
         pretty,
     } = what
     {
-        let events_dir = events_dir_override.unwrap_or_else(default_events_dir);
+        let events_dir = events_dir_override.unwrap_or_else(crate::runtime::default_events_dir);
         return show_events(&events_dir, tail, follow, pretty);
     }
     #[cfg(feature = "operator-cli")]
@@ -260,20 +260,6 @@ fn latest_segment(events_dir: &std::path::Path) -> Option<PathBuf> {
                 .unwrap_or(false)
         })
         .max()
-}
-
-/// Mirror of `main.rs::default_events_dir`. Kept here so `show::run` can
-/// resolve `--events-dir` without main.rs needing to plumb the default in for
-/// every variant.
-#[cfg(feature = "operator-cli")]
-fn default_events_dir() -> PathBuf {
-    if cfg!(any(target_os = "macos", target_os = "linux")) {
-        PathBuf::from("/var/log/sigil")
-    } else {
-        PathBuf::from(std::env::var_os("ProgramData").unwrap_or_default())
-            .join("Sigil")
-            .join("events")
-    }
 }
 
 /// Snapshot or follow the agent's JSONL events. Wrapper around the


### PR DESCRIPTION
## What

Gives `state.db`, the events dir, and `policy.yaml` (and the `rule-packs.yaml` derived from it) the **non-root XDG fallback** that the control socket and keystore already have. Fixes the documented personal/OSS install path on macOS / non-root Linux.

| path | was (all users) | now (non-root) |
|------|-----------------|----------------|
| `state.db` | `/var/lib/sigil/state.db` | `$XDG_STATE_HOME/sigil/state.db` → `~/.local/state/sigil/state.db` |
| events dir | `/var/log/sigil` | `$XDG_STATE_HOME/sigil/events` → `~/.local/state/sigil/events` |
| `policy.yaml` / `rule-packs.yaml` | `/etc/sigil/…` | `$XDG_CONFIG_HOME/sigil/…` → `~/.config/sigil/…` |

Root behavior (systemd/packaged) is unchanged. The three duplicated default-path copies (`main.rs`, `doctor.rs`, `show.rs`) are consolidated into `pub` lib functions with pure, unit-tested resolvers mirroring `resolve_keystore_path_unix`.

## Why (found via fresh-install verification)

Following `docs/install-personal.md` verbatim on a clean macOS machine, the documented `sigil run` (no flags) **aborted with a bare `Permission denied (os error 13)`** — the daemon tried to create `/var/lib/sigil` and `/var/log/sigil` as non-root. Worse, even past that, the rule-packs watcher armed on `/etc/sigil/rule-packs.yaml` (derived from the policy dir) instead of the documented `~/.config/sigil/rule-packs.yaml`, so **hook enforcement silently never loaded the user's rule pack**. All three are the same class: the non-root XDG fallback was applied to the socket/keystore but missed here. Full investigation in #159.

## Verification

Fresh install of the published v0.5.1 binary, then this branch's binary, HOME-isolated, **no path overrides**:
- `sigil run` starts non-root; auto-creates `~/.local/state/sigil/{state.db,events}`.
- rule-packs watcher targets `~/.config/sigil/rule-packs.yaml` (matches the doc).
- `sigil-hook claude-code --enforce` with `rm -rf …` → `permissionDecision: deny`; `ls` → allow (silent).
- `sigil show risk` → assessments; `sigil doctor` host_id now `[OK]` (no more `/var/lib/sigil` warn).

## Tests

`nonroot_path_tests` (root→system / non-root→XDG / →HOME / →system last-resort, ×3 paths). `cargo fmt` clean · workspace `clippy -D warnings` clean · workspace tests green.

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
