### PR TITLE
fix: newcomer-UX papercuts — clean-machine doctor, pathful errors, --version (#161)

### DIFF
--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -201,6 +201,7 @@ pub fn run(policy_override: Option<PathBuf>, state_db_override: Option<PathBuf>)
 
     let env = EnvLookup;
     let mut total_paths = 0usize;
+    let mut absent_paths = 0usize;
     for t in &effective.targets {
         for path_template in &t.paths {
             let results = expand_per_user(path_template, &users, &env);
@@ -208,12 +209,16 @@ pub fn run(policy_override: Option<PathBuf>, state_db_override: Option<PathBuf>)
                 match r {
                     Ok(p) => {
                         if !p.exists() {
+                            // Expected on a personal machine: not every covered AI
+                            // tool is installed, so its config file is simply
+                            // absent. Informational — it must NOT gate the exit
+                            // code or alarm a healthy setup (#161).
                             println!(
-                                "[WARN] target {}: path does not exist: {}",
+                                "[INFO] target {}: not present (no file at {})",
                                 t.id,
                                 p.display()
                             );
-                            warn_count += 1;
+                            absent_paths += 1;
                         }
                         total_paths += 1;
                     }
@@ -226,32 +231,47 @@ pub fn run(policy_override: Option<PathBuf>, state_db_override: Option<PathBuf>)
         }
     }
     println!("[OK]   total expanded paths: {total_paths}");
+    if absent_paths > 0 {
+        println!(
+            "[INFO] {absent_paths} target path(s) absent (tool not installed — simply not watched)"
+        );
+    }
 
     // Phase 2: show persisted host_id from state.db. Honor the `--state-db`
     // override (matching `sigil show`); fall back to the default path.
     let state_db_path = state_db_override.unwrap_or_else(crate::runtime::default_state_db_path);
-    match sigil_core::state::HashCache::open(&state_db_path) {
-        Ok(cache) => match cache.host_meta_get() {
-            Ok(meta) => {
-                let host_id_display = meta
-                    .host_id
-                    .clone()
-                    .unwrap_or_else(|| "<not yet generated>".into());
-                println!("[OK]   host_id: {host_id_display} (UUIDv4, persisted in state.db)");
-                let rp_ver = meta.last_applied_rule_packs_version;
-                println!("[INFO] rule-pack bundle version: {rp_ver}");
-            }
+    if !state_db_path.exists() {
+        // Fresh install: the daemon creates state.db on its first `sigil run`.
+        // Absent-before-first-run is expected, not a degradation (#161) — so it
+        // stays informational and does NOT gate the exit code.
+        println!(
+            "[INFO] state.db not yet present (created on first 'sigil run'): {}",
+            state_db_path.display()
+        );
+    } else {
+        match sigil_core::state::HashCache::open(&state_db_path) {
+            Ok(cache) => match cache.host_meta_get() {
+                Ok(meta) => {
+                    let host_id_display = meta
+                        .host_id
+                        .clone()
+                        .unwrap_or_else(|| "<not yet generated>".into());
+                    println!("[OK]   host_id: {host_id_display} (UUIDv4, persisted in state.db)");
+                    let rp_ver = meta.last_applied_rule_packs_version;
+                    println!("[INFO] rule-pack bundle version: {rp_ver}");
+                }
+                Err(e) => {
+                    println!("[WARN] host_meta_get failed: {e}");
+                    warn_count += 1;
+                }
+            },
             Err(e) => {
-                println!("[WARN] host_meta_get failed: {e}");
+                println!(
+                    "[WARN] state.db unavailable for host_id read: {e} (path: {})",
+                    state_db_path.display()
+                );
                 warn_count += 1;
             }
-        },
-        Err(e) => {
-            println!(
-                "[WARN] state.db unavailable for host_id read: {e} (path: {})",
-                state_db_path.display()
-            );
-            warn_count += 1;
         }
     }
 

--- a/crates/sigil-agent/src/runtime.rs
+++ b/crates/sigil-agent/src/runtime.rs
@@ -11,6 +11,7 @@ use crate::{
     supervisor::Supervisor,
     watcher,
 };
+use anyhow::Context;
 use parking_lot::Mutex;
 use sigil_core::policy::expand::{expand_per_user, EnvLookup, UserEnumerator};
 use sigil_core::policy::pubkeys::Keystore;
@@ -55,9 +56,13 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
 
     // Open state.db FIRST — host_id resolution depends on it.
     if let Some(dir) = cfg.state_db_path.parent() {
-        std::fs::create_dir_all(dir)?;
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("creating state.db directory {}", dir.display()))?;
     }
-    let cache = Arc::new(Mutex::new(HashCache::open(&cfg.state_db_path)?));
+    let cache = Arc::new(Mutex::new(
+        HashCache::open(&cfg.state_db_path)
+            .with_context(|| format!("opening state.db {}", cfg.state_db_path.display()))?,
+    ));
 
     // Resolve persisted host_id (UUIDv4, generated on first run).
     let host_id = {
@@ -336,7 +341,8 @@ pub async fn run(cfg: RuntimeConfig) -> anyhow::Result<i32> {
     perform_warmup(&effective, &expanded_paths, &cache)?;
 
     // 4. Open sink.
-    let sink = JsonlSink::open(&cfg.events_dir, OffsetDateTime::now_utc())?;
+    let sink = JsonlSink::open(&cfg.events_dir, OffsetDateTime::now_utc())
+        .with_context(|| format!("opening events directory {}", cfg.events_dir.display()))?;
 
     // 5. Bootstrap channels and tasks.
     let (tx_norm, rx_norm) = mpsc::channel::<NormalizedEvent>(512);

--- a/crates/sigil-agent/tests/doctor.rs
+++ b/crates/sigil-agent/tests/doctor.rs
@@ -21,6 +21,32 @@ fn it_show_paths_prints_targets() {
     assert!(stdout.contains("# "));
 }
 
+// #161: a missing state.db (fresh install, before the first `sigil run`) is
+// reported as INFO and does NOT emit the degradation WARN — so a clean machine
+// isn't told it has a problem just because the daemon hasn't created the DB yet.
+#[test]
+fn doctor_absent_state_db_is_info_not_warn() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing_db = tmp.path().join("nope").join("state.db");
+    assert!(!missing_db.exists());
+    let bin = env!("CARGO_BIN_EXE_sigil");
+    let out = Command::new(bin)
+        .arg("doctor")
+        .arg("--state-db")
+        .arg(&missing_db)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("state.db not yet present"),
+        "doctor should report a missing state.db as INFO. Output:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("state.db unavailable for host_id read"),
+        "a missing state.db must not produce the degradation WARN. Output:\n{stdout}"
+    );
+}
+
 // Phase 3b.5 Task 6: doctor AI Guard section coverage.
 //
 // These tests assert observable doctor output:

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -143,6 +143,7 @@ fn hook_decide_socket_path() -> PathBuf {
 #[derive(Parser)]
 #[command(
     name = "sigil-hook",
+    version,
     about = "Runtime observer at the AI agent tool boundary"
 )]
 struct Cli {

--- a/crates/sigil-hook/tests/version_flag.rs
+++ b/crates/sigil-hook/tests/version_flag.rs
@@ -1,0 +1,33 @@
+//! #161: `sigil-hook --version` / `-V` print the package version and exit 0
+//! (clap `version` attr), instead of being treated as an unknown invocation.
+use std::process::Command;
+
+fn run(flag: &str) -> (i32, String) {
+    let exe = env!("CARGO_BIN_EXE_sigil-hook");
+    let out = Command::new(exe).arg(flag).output().unwrap();
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    (code, stdout)
+}
+
+#[test]
+fn long_flag_prints_version_and_exits_0() {
+    let (code, stdout) = run("--version");
+    assert_eq!(code, 0, "expected exit 0, stdout={stdout:?}");
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version output {stdout:?} missing {}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn short_flag_prints_version_and_exits_0() {
+    let (code, stdout) = run("-V");
+    assert_eq!(code, 0, "expected exit 0, stdout={stdout:?}");
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version output {stdout:?} missing {}",
+        env!("CARGO_PKG_VERSION")
+    );
+}

--- a/crates/sigil-mcp/src/main.rs
+++ b/crates/sigil-mcp/src/main.rs
@@ -14,6 +14,19 @@ use rmcp::transport::stdio;
 use rmcp::ServiceExt;
 use std::sync::Arc;
 
+/// Handle `--version` / `-V` before any server setup (#161): a bare invocation
+/// starts the MCP server, so the version flag must be intercepted explicitly or
+/// it would silently launch the server instead of printing a version.
+fn handle_version() -> Option<i32> {
+    match std::env::args().nth(1).as_deref() {
+        Some("--version") | Some("-V") => {
+            println!("sigil-mcp {}", env!("CARGO_PKG_VERSION"));
+            Some(0)
+        }
+        _ => None,
+    }
+}
+
 /// Handle `--print-config [client]` before any async/server setup. Returns
 /// `Some(exit_code)` when the flag was handled (the caller then exits), else
 /// `None` to start the server as usual.
@@ -43,6 +56,9 @@ fn handle_print_config() -> Option<i32> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    if let Some(code) = handle_version() {
+        std::process::exit(code);
+    }
     if let Some(code) = handle_print_config() {
         std::process::exit(code);
     }

--- a/crates/sigil-mcp/tests/version_flag.rs
+++ b/crates/sigil-mcp/tests/version_flag.rs
@@ -1,0 +1,34 @@
+//! #161: `sigil-mcp --version` / `-V` print the package version and exit 0
+//! (handled by `handle_version()` before the server starts), instead of
+//! silently launching the MCP server on a bare flag.
+use std::process::Command;
+
+fn run(flag: &str) -> (i32, String) {
+    let exe = env!("CARGO_BIN_EXE_sigil-mcp");
+    let out = Command::new(exe).arg(flag).output().unwrap();
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    (code, stdout)
+}
+
+#[test]
+fn long_flag_prints_version_and_exits_0() {
+    let (code, stdout) = run("--version");
+    assert_eq!(code, 0, "expected exit 0, stdout={stdout:?}");
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version output {stdout:?} missing {}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn short_flag_prints_version_and_exits_0() {
+    let (code, stdout) = run("-V");
+    assert_eq!(code, 0, "expected exit 0, stdout={stdout:?}");
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version output {stdout:?} missing {}",
+        env!("CARGO_PKG_VERSION")
+    );
+}


### PR DESCRIPTION
Closes #161.

Three first-run friction points found during fresh-install verification of the newcomer path.

## 1. `sigil doctor` on a clean personal machine no longer exits 1
- Target paths for **uninstalled** agent tools → `[INFO] … tool not installed — simply not watched` (was `[WARN]`), with an absent-count summary line. Does **not** gate the exit code.
- A `state.db` that **doesn't exist yet** (the daemon creates it on the first `sigil run`) → `[INFO] state.db not yet present (created on first 'sigil run')` instead of the degradation `[WARN]`.
- A **present-but-unopenable** state.db still warns (real problem, unchanged).
- Net: a healthy fresh install now reports **"All checks passed."** (exit 0).

## 2. Pathful startup errors
`sigil run` startup IO failures now name the path + operation via `anyhow` context (state.db dir creation, `HashCache::open`, `JsonlSink::open`) instead of a bare `Permission denied (os error 13)`.

## 3. `--version` support
- `sigil-hook --version` / `-V` via clap `version` attr.
- `sigil-mcp --version` / `-V` handled before server start (a bare invocation otherwise launches the MCP server).

## Tests
- `doctor_absent_state_db_is_info_not_warn` (integration, uses `--state-db` at a nonexistent path).
- `version_flag` integration tests for both `sigil-hook` and `sigil-mcp` (long + short flag).

## Hardware verification (macOS)
- Clean-env `sigil doctor` (isolated `HOME`/`XDG_*`): exits **0**, "All checks passed."
- All four `--version` invocations print `<bin> 0.5.1`.

Gates: `cargo fmt --all`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` (sigil-agent/-hook/-mcp) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)