### PR TITLE
chore(release): bump workspace version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "sigil-sender"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Minor release bump (`0.5.1` → `0.6.0`), single workspace version field + Cargo.lock.

Tagging `v0.6.0` after this merges triggers `release.yml` to build artifacts.

## Changes since v0.5.1

**Features**
- assess pre-flight risk check — CLI + MCP tool (#150)
- OpenClaw skill + Hermes toolset glue for assess (#152)
- TrustFall: project-scope MCP auto-execution detection (#153)
- AI Guard scans agent instruction files for injection directives (#155)
- Antigravity install is static-posture-only by default (#157)
- Windows hook-decide over named pipe — enforce works on Windows (#163)

**Fixes**
- rule-packs.yaml watcher re-arm + transient empty read (#142)
- non-root XDG fallback for state-db/events/policy paths (#160)
- newcomer-UX papercuts: clean-machine doctor, pathful errors, `--version` (#164)

## Verification
- No hardcoded version strings in source/tests → bump is snapshot-safe.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace` (exit 0) — all green locally.
- main HEAD CI (13ba776) green before cutting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)