### PR TITLE
docs(readme): "What it detects" capabilities banner (TrustFall + agents/features)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@
 the config that decided what your AI coding agent was allowed to do in the
 first place. Sigil measures that surface; it does not block.
 
+## What it detects
+
+⚠️ **TrustFall-style AI agent attacks** — and the misconfigurations that enable
+them: project-scoped MCP servers set to **auto-execute**, **prompt-injection
+directives** planted in agent instruction files, **disabled sandboxes**, silent
+**auto-approve**, overly broad tool permissions, and **remote / shell-launcher
+MCP servers** — scored across the AI coding agents your developers actually run.
+
+**Agents covered**
+&nbsp;&nbsp;✅ Claude Code&nbsp;&nbsp;✅ Codex&nbsp;&nbsp;✅ Cursor&nbsp;&nbsp;✅ Gemini CLI&nbsp;&nbsp;✅ Antigravity&nbsp;&nbsp;✅ Continue.dev&nbsp;&nbsp;✅ Claude Desktop
+
+**Built in**
+&nbsp;&nbsp;✅ SIEM integration&nbsp;&nbsp;✅ MCP support (read-only — host + fleet)&nbsp;&nbsp;✅ fleet monitoring&nbsp;&nbsp;✅ signed policy distribution
+
 ## See it
 
 A security team's view first: **`sigil-manager`** renders the fleet's posture as


### PR DESCRIPTION
Adds a scannable **What it detects** section near the top of the README, per discoverability advice (lead with the **TrustFall** keyword + a ✅ checklist of covered agents and built-in capabilities).

### Why
"TrustFall-style AI agent attacks" is currently the strongest search/keyword hook, and the README buried its agent coverage and capabilities far below the fold. This puts both up top.

### Accuracy
Every claim maps to a shipped feature — nothing aspirational:
- **TrustFall** project-scope MCP auto-execution detection (#153, v0.6.0)
- prompt-injection directives in agent instruction files (#155)
- sandbox-disabled / auto-approve / broad-permission / remote- & launcher-MCP scoring
- 7 agent parsers: Claude Code, Codex, Cursor, Gemini CLI, Antigravity, Continue.dev, Claude Desktop
- SIEM integration, read-only MCP (host + fleet), fleet monitoring, signed policy distribution

Deliberately **omits** tool-poisoning detection — that's #148 (still Future) and would be overclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)