### PR TITLE
fix(ai_guard): refresh Antigravity parser to verified agy 1.0.8 reality (#158)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/antigravity.rs
@@ -4,10 +4,19 @@
 //!   - settings (user-global): `~/.gemini/antigravity-cli/settings.json`
 //!   - MCP servers: `~/.gemini/config/mcp_config.json` (`mcpServers`, a separate
 //!     file — unlike Gemini, MCP is not inline in settings.json)
-//!   - terminal sandbox: `enableTerminalSandbox` (boolean, default false)
-//!   - tool permission: `toolPermission` (`request-review` default / `auto-approve`),
-//!     verified against the real `agy` 1.0.4 binary + runtime log. (NOT Gemini's
-//!     `approval_mode` — Antigravity dropped it.)
+//!   - terminal sandbox: `enableTerminalSandbox` (boolean, default false). This
+//!     is the ONLY sandbox knob the settings file carries — `sandbox_mode` /
+//!     `sandbox_type` / `sandbox_allow_network` are internal sandbox-subsystem
+//!     struct fields, NOT CLI settings keys (hardware-verified on agy 1.0.8:
+//!     writing `sandbox_mode` into settings.json is silently ignored, exactly
+//!     like an unknown key — the CLI settings validator never sees it).
+//!   - tool permission: `toolPermission`. Accepted enum (hardware-verified on
+//!     agy 1.0.8): `request-review` (default, safe — agent asks per action),
+//!     `proceed-in-sandbox` (auto-executes inside the sandbox), `always-proceed`
+//!     (auto-executes, NOT sandboxed). The old Gemini `approval_mode`
+//!     (`yolo`/`auto_edit`) was dropped, and the literal `auto-approve` is now
+//!     REJECTED by 1.0.8's settings validator (replaced with the `request-review`
+//!     default at load) — see `emit_approval`.
 //!
 //! UserGlobal scope only for now; the per-repo (`<repo>/.antigravity/settings.json`)
 //! parser needs an `antigravity_workspaces` policy field and is a follow-up.
@@ -51,27 +60,38 @@ pub(crate) fn emit_sandbox(v: &Value, out: &mut Vec<AiGuardReason>) {
     }
 }
 
-/// `toolPermission == "auto-approve"` -> AutoApprovalEnabled (the agent runs
-/// tools without confirmation). `request-review` (the default) is safe.
+/// Flag the `toolPermission` modes that make the agent run tools WITHOUT
+/// per-action review. Hardware-verified against `agy` 1.0.8's settings
+/// validator (`cli_setting_manager.go`, via `CLI settings initialized:
+/// ... toolPermission=<value>` + `unrecognized value` rejections):
+///   - `always-proceed`     -> auto-execute, NOT sandboxed  (highest risk)
+///   - `proceed-in-sandbox` -> auto-execute, confined to the terminal sandbox
+///   - `request-review`     -> the safe default (agent asks); not flagged
 ///
-/// Verified against the real `agy` 1.0.4 binary + runtime log
-/// (`CLI settings initialized: ... toolPermission=request-review`): the key is
-/// `toolPermission`, NOT Gemini's `approval_mode` (`yolo`/`auto_edit`), which
-/// Antigravity dropped. A truthy `permissions.allowAll` is also flagged.
+/// The old literal `auto-approve` is deliberately NOT matched: 1.0.8's validator
+/// rejects it as an unrecognized value and falls back to `request-review`, so a
+/// settings file carrying `auto-approve` is effectively safe at runtime — flagging
+/// it would be a false positive. (Permissive auto-approval without a persisted
+/// setting is reached via the session-scoped `--dangerously-skip-permissions`
+/// CLI flag, which never touches settings.json and so is out of scope here.)
+///
+/// A truthy `permissions.allowAll` is a separate explicit auto-approval signal.
 pub(crate) fn emit_approval(v: &Value, out: &mut Vec<AiGuardReason>) {
-    if v.get("toolPermission").and_then(Value::as_str) == Some("auto-approve") {
-        out.push(AiGuardReason::AutoApprovalEnabled {
-            mode: "auto-approve".into(),
-        });
-    } else if v
-        .get("permissions")
-        .and_then(|p| p.get("allowAll"))
-        .and_then(Value::as_bool)
-        == Some(true)
-    {
-        out.push(AiGuardReason::AutoApprovalEnabled {
-            mode: "allow_all".into(),
-        });
+    match v.get("toolPermission").and_then(Value::as_str) {
+        Some(mode @ ("always-proceed" | "proceed-in-sandbox")) => {
+            out.push(AiGuardReason::AutoApprovalEnabled { mode: mode.into() });
+        }
+        _ if v
+            .get("permissions")
+            .and_then(|p| p.get("allowAll"))
+            .and_then(Value::as_bool)
+            == Some(true) =>
+        {
+            out.push(AiGuardReason::AutoApprovalEnabled {
+                mode: "allow_all".into(),
+            });
+        }
+        _ => {}
     }
 }
 
@@ -189,12 +209,42 @@ mod tests {
             .any(|r| matches!(r, AiGuardReason::SandboxDisabled)));
     }
     #[test]
-    fn auto_approve_emits_auto_approval() {
+    fn sandbox_mode_key_is_ignored() {
+        // `sandbox_mode` is NOT a CLI settings key (agy 1.0.8 silently ignores it,
+        // like any unknown field — #158). Only `enableTerminalSandbox` counts, so a
+        // file carrying solely `sandbox_mode` must not be read as a sandbox signal.
+        let d = tempdir().unwrap();
+        write_settings(d.path(), r#"{"sandbox_mode":"off"}"#);
+        assert!(assess(d.path()).is_empty());
+    }
+    #[test]
+    fn always_proceed_emits_auto_approval() {
+        // agy 1.0.8: unsandboxed auto-execute — the highest-risk persisted mode.
+        let d = tempdir().unwrap();
+        write_settings(d.path(), r#"{"toolPermission":"always-proceed"}"#);
+        assert!(assess(d.path()).iter().any(
+            |r| matches!(r, AiGuardReason::AutoApprovalEnabled { mode } if mode == "always-proceed")
+        ));
+    }
+    #[test]
+    fn proceed_in_sandbox_emits_auto_approval() {
+        // agy 1.0.8: auto-execute confined to the sandbox — still no per-action review.
+        let d = tempdir().unwrap();
+        write_settings(d.path(), r#"{"toolPermission":"proceed-in-sandbox"}"#);
+        assert!(assess(d.path()).iter().any(
+            |r| matches!(r, AiGuardReason::AutoApprovalEnabled { mode } if mode == "proceed-in-sandbox")
+        ));
+    }
+    #[test]
+    fn auto_approve_literal_is_not_flagged() {
+        // agy 1.0.8 rejects `auto-approve` as an unrecognized settings value and
+        // falls back to `request-review`, so the file is safe at runtime —
+        // flagging it would be a false positive. (Hardware-verified, #158.)
         let d = tempdir().unwrap();
         write_settings(d.path(), r#"{"toolPermission":"auto-approve"}"#);
-        assert!(assess(d.path()).iter().any(
-            |r| matches!(r, AiGuardReason::AutoApprovalEnabled { mode } if mode == "auto-approve")
-        ));
+        assert!(!assess(d.path())
+            .iter()
+            .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })));
     }
     #[test]
     fn permissions_allow_all_emits_auto_approval() {
@@ -277,7 +327,7 @@ mod tests {
         std::fs::create_dir_all(repo.join(".antigravity")).unwrap();
         std::fs::write(
             repo.join(".antigravity").join("settings.json"),
-            r#"{"enableTerminalSandbox":false,"toolPermission":"auto-approve"}"#,
+            r#"{"enableTerminalSandbox":false,"toolPermission":"always-proceed"}"#,
         )
         .unwrap();
         let p = AntigravityProjectParser {

--- a/crates/sigil-agent/tests/antigravity_migration_parity.rs
+++ b/crates/sigil-agent/tests/antigravity_migration_parity.rs
@@ -27,8 +27,8 @@ rules:
     on_file: "~/.gemini/antigravity-cli/settings.json"
     format: json
     selector: "$.toolPermission"
-    matcher: { kind: equals, value: "auto-approve" }
-    emit: { kind: auto_approval_enabled, mode: "auto-approve" }
+    matcher: { kind: regex, pattern: '^(always-proceed|proceed-in-sandbox)$' }
+    emit: { kind: auto_approval_enabled, mode: "<selector-value>" }
   - id: s3-allowall
     on_file: "~/.gemini/antigravity-cli/settings.json"
     format: json
@@ -37,7 +37,7 @@ rules:
     emit: { kind: auto_approval_enabled, mode: "allow_all" }
     when:
       - selector: "$.toolPermission"
-        matcher: { kind: equals, value: "auto-approve" }
+        matcher: { kind: regex, pattern: '^(always-proceed|proceed-in-sandbox)$' }
         negate: true
   - id: m1-remote-url
     on_file: "~/.gemini/config/mcp_config.json"
@@ -187,8 +187,12 @@ fn parity_sandbox_false() {
     assert_parity(Some(r#"{"enableTerminalSandbox":false}"#), None);
 }
 #[test]
-fn parity_toolperm_auto_approve() {
-    assert_parity(Some(r#"{"toolPermission":"auto-approve"}"#), None);
+fn parity_toolperm_always_proceed() {
+    assert_parity(Some(r#"{"toolPermission":"always-proceed"}"#), None);
+}
+#[test]
+fn parity_toolperm_proceed_in_sandbox() {
+    assert_parity(Some(r#"{"toolPermission":"proceed-in-sandbox"}"#), None);
 }
 #[test]
 fn parity_allowall_bool_true() {
@@ -264,6 +268,17 @@ fn parity_request_review_silent() {
 fn parity_dropped_gemini_approval_mode_silent() {
     assert_silent(r#"{"approval_mode":"yolo"}"#);
 }
+#[test]
+fn parity_rejected_auto_approve_literal_silent() {
+    // agy 1.0.8 rejects `auto-approve` (-> request-review at runtime), so both the
+    // parser and the pack must stay silent — flagging it would be a false positive.
+    assert_silent(r#"{"toolPermission":"auto-approve"}"#);
+}
+#[test]
+fn parity_unknown_sandbox_mode_key_silent() {
+    // `sandbox_mode` is not a CLI settings key (silently ignored, #158).
+    assert_silent(r#"{"sandbox_mode":"off"}"#);
+}
 
 // ---------------------------------------------------------------------------
 // Task 4 — else-if negate-gate fixture (both toolPermission + allowAll true)
@@ -275,9 +290,11 @@ fn parity_else_if_both_true_emits_single_auto_approve() {
     write_file(
         home.path(),
         ".gemini/antigravity-cli/settings.json",
-        r#"{"toolPermission":"auto-approve","permissions":{"allowAll":true}}"#,
+        r#"{"toolPermission":"always-proceed","permissions":{"allowAll":true}}"#,
     );
-    // Direct parser check: exactly one AutoApprovalEnabled, mode auto-approve.
+    // Direct parser check: exactly one AutoApprovalEnabled — the toolPermission
+    // arm wins and the allowAll branch is gated off (mode is the toolPermission
+    // value, not "allow_all").
     let parser_reasons = AntigravityParser.assess(home.path()).unwrap();
     let approvals: Vec<_> = parser_reasons
         .iter()
@@ -286,7 +303,7 @@ fn parity_else_if_both_true_emits_single_auto_approve() {
     assert_eq!(approvals.len(), 1);
     assert!(matches!(
         approvals[0],
-        AiGuardReason::AutoApprovalEnabled { mode } if mode == "auto-approve"
+        AiGuardReason::AutoApprovalEnabled { mode } if mode == "always-proceed"
     ));
     // Parity: the pack's allow_all rule must be gated off -> no divergence.
     let d = diff(home.path());
@@ -512,7 +529,7 @@ fn every_selector_is_exercised_without_parse_error() {
     write_file(
         home.path(),
         ".gemini/antigravity-cli/settings.json",
-        r#"{"enableTerminalSandbox":false,"toolPermission":"auto-approve","permissions":{"allowAll":true}}"#,
+        r#"{"enableTerminalSandbox":false,"toolPermission":"always-proceed","permissions":{"allowAll":true}}"#,
     );
     write_file(
         home.path(),


### PR DESCRIPTION
Closes #158.

Refreshes the Antigravity static AI Guard parser against what `agy` **1.0.8** actually accepts, verified on hardware (isolated-`HOME` `agy -p` runs reading the `cli_setting_manager.go` validator log — `CLI settings initialized: … toolPermission=<v>` on accept, `unrecognized value "<v>"` on reject).

## What was wrong
The parser flagged the literal `toolPermission: "auto-approve"`. On 1.0.8 that value is **rejected by the settings validator and replaced with `request-review`** at load — so a file carrying it is *safe at runtime*, and flagging it was a **false positive**. The permissive values that actually persist were never pinned.

## Verified `toolPermission` enum (settings.json)
| value | behavior | flagged? |
|---|---|---|
| `request-review` | default — asks per action | no (safe) |
| `proceed-in-sandbox` | auto-executes **inside** the terminal sandbox | ✅ `AutoApprovalEnabled` |
| `always-proceed` | auto-executes, **not** sandboxed (highest risk) | ✅ `AutoApprovalEnabled` |
| `auto-approve` (+ every other guess) | rejected → `request-review` | no (would be a false positive) |

Permissive auto-approval *without* a persisted setting is reached via the session-scoped `--dangerously-skip-permissions` CLI flag — not a settings key, so out of scope for a static file parser.

## Sandbox
`sandbox_mode` / `sandbox_type` / `sandbox_allow_network` are **not** CLI settings keys — writing them into settings.json is silently ignored (identical to an unknown key). `enableTerminalSandbox` (bool) stays the only sandbox knob; its detection is unchanged.

## Changes
- `emit_approval`: match the two real permissive modes, emit the actual value as `mode`; drop the `auto-approve` literal. `permissions.allowAll` else-branch preserved.
- Module + fn doc comments rewritten to the verified 1.0.8 contract (was 1.0.4).
- Migration-parity `PILOT_PACK` updated (regex value-set + `<selector-value>`-interpolated `mode`, negate-gate on the same set) so the declarative pack stays in lockstep with the hardcoded parser.
- Tests: `always_proceed` / `proceed_in_sandbox` emit; negative tests that the rejected `auto-approve` literal and the ignored `sandbox_mode` key stay silent.

Gates: `cargo fmt --all --check`, `cargo clippy -p sigil-agent --all-targets --all-features -D warnings`, `cargo test -p sigil-agent` (exit 0) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)