### PR TITLE
chore(release): bump workspace version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.6.0"
+version = "0.6.1"
 
 [[package]]
 name = "sigil-sender"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Patch release bump (`0.6.0` → `0.6.1`). Tagging `v0.6.1` after merge triggers `release.yml`.

## Changes since v0.6.0

**Fixes**
- ai_guard: refresh Antigravity parser to verified **agy 1.0.8** reality — flag the real permissive `toolPermission` modes (`always-proceed` / `proceed-in-sandbox`), stop false-positiving the rejected `auto-approve` literal, and confirm `sandbox_mode` is not a settings key (#158, #167)

**Docs**
- README: "What it detects" capabilities banner near the top (#166)

## Verification
- No hardcoded version strings → snapshot-safe.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace` (exit 0) — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)