### PR TITLE
feat(install): one-line Windows installer + fix Linux aarch64 rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,9 +514,17 @@ below). Pin a release with `SIGIL_VERSION`, or change the location with
 gh attestation verify <archive> --repo Ju571nK/sigil
 ```
 
-Windows: download the `.zip` from the
-[latest release](https://github.com/Ju571nK/sigil/releases/latest). (Intel Macs
-aren't shipped as prebuilt binaries — build from source below.)
+### Quick install (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Ju571nK/sigil/main/install.ps1 | iex
+```
+
+Same defaults as the shell installer — **personal** profile to
+`%LOCALAPPDATA%\Programs\sigil` (added to your user PATH), checksum-verified,
+`SIGIL_PROFILE` / `SIGIL_VERSION` / `SIGIL_INSTALL_DIR` honored. Both x64 and
+ARM64 Windows are prebuilt. (Intel Macs aren't shipped as prebuilt binaries —
+build from source below.)
 
 ### Install profiles
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+  Sigil installer (Windows). Downloads the prebuilt binaries from the latest
+  GitHub release, verifies their SHA-256 checksum, and installs them.
+
+  irm https://raw.githubusercontent.com/Ju571nK/sigil/main/install.ps1 | iex
+
+  Environment overrides:
+    SIGIL_VERSION       pin a release tag (default: latest), e.g. v0.6.1
+    SIGIL_INSTALL_DIR   install directory (default: %LOCALAPPDATA%\Programs\sigil)
+    SIGIL_PROFILE       personal (default) | fleet
+                        personal = sigil + sigil-mcp + sigil-hook (local self-assessment)
+                        fleet    = + sigil-sender + sigil-server + sigil-sign
+
+  Provenance: every release archive also carries a GitHub build-provenance
+  attestation. To verify it (optional, needs the gh CLI):
+    gh attestation verify <archive> --repo Ju571nK/sigil
+
+  This is the Windows counterpart to install.sh; the two keep parity (#172).
+#>
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'  # the progress UI throttles Invoke-WebRequest
+# Windows PowerShell 5.1 defaults to TLS 1.0; GitHub requires 1.2+.
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 } catch {}
+
+$Repo = 'Ju571nK/sigil'
+
+function Say($m) { [Console]::Error.WriteLine("sigil-install: $m") }
+function Die($m) { [Console]::Error.WriteLine("sigil-install: error: $m"); exit 1 }
+
+# --- resolve profile -------------------------------------------------------
+$profileName = if ($env:SIGIL_PROFILE) { $env:SIGIL_PROFILE } else { 'personal' }
+switch ($profileName) {
+  'personal' { $binaries = @('sigil', 'sigil-mcp', 'sigil-hook') }
+  'fleet'    { $binaries = @('sigil', 'sigil-mcp', 'sigil-hook', 'sigil-sender', 'sigil-server', 'sigil-sign') }
+  default    { Die "unknown SIGIL_PROFILE '$profileName' (expected: personal | fleet)" }
+}
+
+# dry-run hook: print the resolved binary set and exit before any network I/O.
+# Mirrors install.sh; used by tests to verify profile->binaries mapping.
+if ($env:SIGIL_PROFILE_DRYRUN -eq '1') {
+  Write-Output ($binaries -join ' ')
+  exit 0
+}
+
+# --- detect platform -------------------------------------------------------
+# SIGIL_ARCH_OVERRIDE lets the tests drive arch detection without spoofing the
+# OS; unset in normal use. Values match RuntimeInformation.OSArchitecture.
+$archName = if ($env:SIGIL_ARCH_OVERRIDE) {
+  $env:SIGIL_ARCH_OVERRIDE
+} else {
+  [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+}
+switch ($archName) {
+  'X64'   { $target = 'x86_64-pc-windows-msvc' }
+  'Arm64' { $target = 'aarch64-pc-windows-msvc' }
+  default { Die "unsupported architecture '$archName' — see https://github.com/$Repo#installation" }
+}
+
+# dry-run hook: print the resolved release target and exit before any network I/O.
+if ($env:SIGIL_TARGET_DRYRUN -eq '1') {
+  Write-Output $target
+  exit 0
+}
+
+# --- resolve version -------------------------------------------------------
+$ver = $env:SIGIL_VERSION
+if (-not $ver) {
+  try {
+    $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+      -Headers @{ 'User-Agent' = 'sigil-install' }
+    $ver = $rel.tag_name
+  } catch {
+    Die "could not resolve the latest release (set SIGIL_VERSION to pin one)"
+  }
+}
+if (-not $ver) { Die "could not resolve the latest release (set SIGIL_VERSION to pin one)" }
+$verN = $ver -replace '^v', ''
+$asset = "sigil-$verN-$target.zip"
+$base = "https://github.com/$Repo/releases/download/$ver"
+
+# --- download + verify -----------------------------------------------------
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sigil-install-" + [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+try {
+  $zip = Join-Path $tmp $asset
+  $sums = Join-Path $tmp 'SHA256SUMS'
+
+  Say "downloading $asset ($ver)"
+  try { Invoke-WebRequest -Uri "$base/$asset"  -OutFile $zip  -UseBasicParsing }
+  catch { Die "download failed: $base/$asset" }
+  try { Invoke-WebRequest -Uri "$base/SHA256SUMS" -OutFile $sums -UseBasicParsing }
+  catch { Die "download failed: $base/SHA256SUMS" }
+
+  Say "verifying checksum"
+  $expected = $null
+  foreach ($line in Get-Content $sums) {
+    # sha256sum format: "<hex>  <filename>"
+    $parts = $line -split '\s+', 2
+    if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $asset) { $expected = $parts[0].Trim(); break }
+  }
+  if (-not $expected) { Die "no checksum entry for $asset in SHA256SUMS" }
+  $actual = (Get-FileHash -Algorithm SHA256 -Path $zip).Hash
+  if ($actual -ine $expected) {
+    Die "checksum verification FAILED for $asset — refusing to install"
+  }
+
+  # --- install -------------------------------------------------------------
+  $unpack = Join-Path $tmp 'unpack'
+  Expand-Archive -Path $zip -DestinationPath $unpack -Force
+  $inner = Join-Path $unpack "sigil-$verN-$target"
+
+  $installDir = if ($env:SIGIL_INSTALL_DIR) { $env:SIGIL_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'Programs\sigil' }
+  New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+  foreach ($b in $binaries) {
+    $src = Join-Path $inner "$b.exe"
+    if (-not (Test-Path $src)) { Die "archive is missing expected binary: $b.exe" }
+    Copy-Item -Path $src -Destination (Join-Path $installDir "$b.exe") -Force
+  }
+
+  Say "installed into $installDir`: $($binaries -join ' ')"
+  Say "profile: $profileName — start the agent with 'sigil run' (sigil-mcp/sigil-hook need the running daemon)"
+
+  # --- PATH ----------------------------------------------------------------
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  if (($userPath -split ';') -notcontains $installDir) {
+    $newPath = if ([string]::IsNullOrEmpty($userPath)) { $installDir } else { $userPath.TrimEnd(';') + ';' + $installDir }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    Say "added $installDir to your user PATH (open a new terminal to pick it up)"
+  }
+  # Make 'sigil' resolvable in the current session too.
+  if (($env:Path -split ';') -notcontains $installDir) {
+    $env:Path = $env:Path.TrimEnd(';') + ';' + $installDir
+  }
+
+  Say "next: sigil doctor"
+} finally {
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -58,8 +58,10 @@ else
 fi
 
 # --- detect platform -------------------------------------------------------
-os="$(uname -s)"
-arch="$(uname -m)"
+# SIGIL_UNAME_S / SIGIL_UNAME_M let the tests drive platform detection without
+# spoofing uname; unset in normal use.
+os="${SIGIL_UNAME_S:-$(uname -s)}"
+arch="${SIGIL_UNAME_M:-$(uname -m)}"
 case "$os/$arch" in
   Linux/x86_64 | Linux/amd64)
     target="x86_64-unknown-linux-musl" ;;
@@ -68,10 +70,18 @@ case "$os/$arch" in
   Darwin/x86_64)
     err "Intel Macs aren't supported — build from source: https://github.com/$REPO#build-from-source" ;;
   Linux/aarch64 | Linux/arm64)
-    err "no prebuilt Linux aarch64 binary yet — build from source or open an issue" ;;
+    # Static musl ARM64 — runs on Graviton/Ampere and RHEL/Rocky 9 aarch64 (#171).
+    target="aarch64-unknown-linux-musl" ;;
   *)
     err "unsupported platform '$os/$arch' — see https://github.com/$REPO#installation" ;;
 esac
+
+# dry-run hook: print the resolved release target and exit before any network
+# I/O. Used by tests/install_profile_test.sh to verify platform->target mapping.
+if [ "${SIGIL_TARGET_DRYRUN:-}" = "1" ]; then
+  printf '%s\n' "$target"
+  exit 0
+fi
 
 # --- resolve version -------------------------------------------------------
 ver="${SIGIL_VERSION:-}"

--- a/tests/install_profile_test.ps1
+++ b/tests/install_profile_test.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+# install.ps1의 프로파일->binaries / 플랫폼->target 매핑을 dry-run으로 검증 (#172).
+# install_profile_test.sh의 PowerShell 짝. 네트워크 없이 매핑 로직만 확인한다.
+#   pwsh tests/install_profile_test.ps1
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$ps1 = Join-Path $root 'install.ps1'
+
+$fail = 0
+function Assert-Eq($desc, $expected, $actual) {
+  if ($expected -ne $actual) {
+    Write-Host "FAIL: $desc`n  want: $expected`n  got:  $actual"
+    $script:fail = 1
+  } else {
+    Write-Host "ok: $desc"
+  }
+}
+
+# profile -> binaries
+function Profile-Run($p) {
+  $env:SIGIL_PROFILE = $p
+  $env:SIGIL_PROFILE_DRYRUN = '1'
+  try { (& pwsh -NoProfile -File $ps1).Trim() } finally {
+    Remove-Item Env:SIGIL_PROFILE -ErrorAction SilentlyContinue
+    Remove-Item Env:SIGIL_PROFILE_DRYRUN -ErrorAction SilentlyContinue
+  }
+}
+Assert-Eq 'personal subset'    'sigil sigil-mcp sigil-hook' (Profile-Run 'personal')
+Assert-Eq 'fleet superset'     'sigil sigil-mcp sigil-hook sigil-sender sigil-server sigil-sign' (Profile-Run 'fleet')
+
+$env:SIGIL_PROFILE_DRYRUN = '1'
+$defaultBins = (& pwsh -NoProfile -File $ps1).Trim()
+Remove-Item Env:SIGIL_PROFILE_DRYRUN -ErrorAction SilentlyContinue
+Assert-Eq 'default is personal' 'sigil sigil-mcp sigil-hook' $defaultBins
+
+$env:SIGIL_PROFILE = 'bogus'; $env:SIGIL_PROFILE_DRYRUN = '1'
+& pwsh -NoProfile -File $ps1 *> $null
+if ($LASTEXITCODE -eq 0) { Write-Host 'FAIL: bogus profile should exit non-zero'; $fail = 1 }
+else { Write-Host 'ok: bogus profile rejected' }
+Remove-Item Env:SIGIL_PROFILE, Env:SIGIL_PROFILE_DRYRUN -ErrorAction SilentlyContinue
+
+# arch -> release target (#172: both Windows targets resolve)
+function Target-Run($arch) {
+  $env:SIGIL_ARCH_OVERRIDE = $arch
+  $env:SIGIL_TARGET_DRYRUN = '1'
+  try { (& pwsh -NoProfile -File $ps1).Trim() } finally {
+    Remove-Item Env:SIGIL_ARCH_OVERRIDE -ErrorAction SilentlyContinue
+    Remove-Item Env:SIGIL_TARGET_DRYRUN -ErrorAction SilentlyContinue
+  }
+}
+Assert-Eq 'x64 target'   'x86_64-pc-windows-msvc'  (Target-Run 'X64')
+Assert-Eq 'arm64 target' 'aarch64-pc-windows-msvc' (Target-Run 'Arm64')
+
+$env:SIGIL_ARCH_OVERRIDE = 'X86'; $env:SIGIL_TARGET_DRYRUN = '1'
+& pwsh -NoProfile -File $ps1 *> $null
+if ($LASTEXITCODE -eq 0) { Write-Host 'FAIL: x86 (32-bit) should exit non-zero'; $fail = 1 }
+else { Write-Host 'ok: 32-bit x86 rejected' }
+Remove-Item Env:SIGIL_ARCH_OVERRIDE, Env:SIGIL_TARGET_DRYRUN -ErrorAction SilentlyContinue
+
+exit $fail

--- a/tests/install_profile_test.sh
+++ b/tests/install_profile_test.sh
@@ -20,4 +20,15 @@ if SIGIL_PROFILE=bogus SIGIL_PROFILE_DRYRUN=1 sh "$SH" >/dev/null 2>&1; then
   echo "FAIL: bogus profile should exit non-zero"; fail=1
 else echo "ok: bogus profile rejected"; fi
 
+# platform -> release target mapping (#171: aarch64 Linux must resolve, not err).
+tgt() { SIGIL_UNAME_S="$1" SIGIL_UNAME_M="$2" SIGIL_TARGET_DRYRUN=1 sh "$SH" 2>/dev/null; }
+assert_eq "linux x86_64 target"  "x86_64-unknown-linux-musl"  "$(tgt Linux x86_64)"
+assert_eq "linux aarch64 target" "aarch64-unknown-linux-musl" "$(tgt Linux aarch64)"
+assert_eq "linux arm64 target"   "aarch64-unknown-linux-musl" "$(tgt Linux arm64)"
+assert_eq "macos arm64 target"   "aarch64-apple-darwin"       "$(tgt Darwin arm64)"
+
+if tgt Darwin x86_64 >/dev/null 2>&1; then
+  echo "FAIL: intel mac should exit non-zero"; fail=1
+else echo "ok: intel mac rejected"; fi
+
 exit $fail


### PR DESCRIPTION
Completes the script-installer story across macOS / Windows / Linux so the **personal** profile installs with one command everywhere — no native packages, no code-signing cost (`curl|sh` / `irm|iex` sidestep Gatekeeper/SmartScreen).

## Changes
- **`install.ps1` (new, Fixes #172)** — Windows counterpart to `install.sh`, at parity:
  - `irm https://raw.githubusercontent.com/Ju571nK/sigil/main/install.ps1 | iex`
  - `SIGIL_VERSION` / `SIGIL_INSTALL_DIR` / `SIGIL_PROFILE` (personal default / fleet)
  - arch detect: X64 → `x86_64-pc-windows-msvc`, Arm64 → `aarch64-pc-windows-msvc`
  - download `.zip` + `SHA256SUMS`, `Get-FileHash` verify (refuse on mismatch), `Expand-Archive`
  - install to `%LOCALAPPDATA%\Programs\sigil`, add to user PATH + current session
  - `SIGIL_PROFILE_DRYRUN` / `SIGIL_TARGET_DRYRUN` test hooks
- **`install.sh` (Fixes #171)** — stop rejecting Linux aarch64. `release.yml` has shipped `sigil-<ver>-aarch64-unknown-linux-musl.tar.gz` since the aarch64 matrix entry (present in v0.6.1); now mapped to that static musl target (Graviton/Ampere, RHEL/Rocky 9 aarch64). Added `SIGIL_UNAME_S/_M` + `SIGIL_TARGET_DRYRUN` for testability.
- **tests** — `install_profile_test.sh` gains platform→target cases; new `install_profile_test.ps1` parity test. README documents the Windows one-liner.

## Verification
- `shellcheck install.sh` clean
- `tests/install_profile_test.sh` green (profile + platform→target mapping, incl. aarch64)
- **Zero Rust changes** — cargo fmt/clippy/test unaffected
- ⏳ **Hardware verification pending VM power-on**: install.sh aarch64 on Rocky 9 aarch64 (.213), install.ps1 full flow on Windows ARM64 (.147). Both testable against the existing v0.6.1 release assets (no new release needed).

Fixes #171
Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)