### PR TITLE
fix(doctor,install): non-root control-socket check + missing-tool hints

### DIFF
--- a/crates/sigil-agent/src/doctor.rs
+++ b/crates/sigil-agent/src/doctor.rs
@@ -294,10 +294,19 @@ pub fn run(policy_override: Option<PathBuf>, state_db_override: Option<PathBuf>)
     {
         let checks = [
             check_selinux(std::path::Path::new("/sys/fs/selinux/enforce")),
-            check_control_socket_perms(
-                std::path::Path::new("/var/run/sigil/control.sock"),
-                std::path::Path::new("/etc/group"),
-            ),
+            {
+                // Resolve the SAME socket path the daemon/CLI use: root →
+                // /var/run/sigil, non-root → the XDG/tmp fallback. Expect it to
+                // be owned by our euid (root for a root install). A non-root
+                // personal install therefore no longer warns about a root-owned
+                // socket at a path it never binds (#178).
+                let euid = unsafe { libc::geteuid() };
+                check_control_socket_perms(
+                    &crate::control::default_control_socket(),
+                    std::path::Path::new("/etc/group"),
+                    euid,
+                )
+            },
             check_systemd_unit(
                 std::path::Path::new("/run/systemd/system"),
                 std::path::Path::new("/usr/lib/systemd/system/sigil.service"),
@@ -553,6 +562,7 @@ fn check_selinux(enforce_path: &std::path::Path) -> CheckResult {
 fn check_control_socket_perms(
     socket_path: &std::path::Path,
     group_file: &std::path::Path,
+    expected_uid: u32,
 ) -> CheckResult {
     use std::os::unix::fs::MetadataExt;
     let meta = match std::fs::metadata(socket_path) {
@@ -577,12 +587,15 @@ fn check_control_socket_perms(
         meta.gid(),
         meta.mode() & 0o777,
         sigil_gid,
+        expected_uid,
     )
 }
 
-/// Pure classifier (testable without a real root-owned file). The socket must be
-/// root-owned and have no access bits for `other`; the `sigil` group, if present
-/// and matching, is reported but not required.
+/// Pure classifier (testable without a real owned file). The socket must be
+/// owned by `expected_uid` (root for a root install, the invoking user for a
+/// non-root personal install) and have no access bits for `other`. The
+/// root:sigil group hardening (epic #10) applies only to the root deployment,
+/// so the `sigil` group is reported but never required.
 #[cfg(target_os = "linux")]
 fn classify_socket_perms(
     path: &str,
@@ -590,10 +603,16 @@ fn classify_socket_perms(
     gid: u32,
     mode: u32,
     sigil_gid: Option<u32>,
+    expected_uid: u32,
 ) -> CheckResult {
-    if uid != 0 {
+    if uid != expected_uid {
+        let expected = if expected_uid == 0 {
+            "root (uid 0)".to_string()
+        } else {
+            format!("uid {expected_uid}")
+        };
         return CheckResult::warn(format!(
-            "control socket: owner uid={uid}, expected root (uid 0) at {path}"
+            "control socket: owner uid={uid}, expected {expected} at {path}"
         ));
     }
     if mode & 0o007 != 0 {
@@ -602,12 +621,17 @@ fn classify_socket_perms(
              (e.g. 0660) at {path}"
         ));
     }
-    let group = match sigil_gid {
-        Some(g) if g == gid => format!("root:sigil({g})"),
-        _ => format!("root:gid({gid})"),
+    let (owner, ownership) = if uid == 0 {
+        let group = match sigil_gid {
+            Some(g) if g == gid => format!("root:sigil({g})"),
+            _ => format!("root:gid({gid})"),
+        };
+        (group, "root-owned")
+    } else {
+        (format!("uid({uid}):gid({gid})"), "user-owned")
     };
     CheckResult::ok(format!(
-        "control socket: {group} mode {mode:o} (root-owned, not world-accessible)"
+        "control socket: {owner} mode {mode:o} ({ownership}, not world-accessible)"
     ))
 }
 
@@ -822,14 +846,14 @@ mod linux_tests {
         let p = dir.path().join("control.sock");
         let group_file = dir.path().join("group");
         std::fs::write(&group_file, "sigil:x:996:\n").unwrap();
-        let r = check_control_socket_perms(&p, &group_file);
+        let r = check_control_socket_perms(&p, &group_file, 0);
         assert_eq!(r.level, CheckLevel::Info);
         assert!(r.message.contains("not present"), "{:?}", r);
     }
 
     #[test]
     fn classify_socket_ok_root_0660_with_sigil_group() {
-        let r = classify_socket_perms("/run/sigil/control.sock", 0, 996, 0o660, Some(996));
+        let r = classify_socket_perms("/run/sigil/control.sock", 0, 996, 0o660, Some(996), 0);
         assert_eq!(r.level, CheckLevel::Ok);
         assert!(r.message.contains("root:sigil(996)"), "{r:?}");
     }
@@ -837,7 +861,7 @@ mod linux_tests {
     #[test]
     fn classify_socket_ok_root_0660_without_sigil_group() {
         // sigil group absent or gid mismatch → still OK (group is informational, epic #10).
-        let r = classify_socket_perms("/run/sigil/control.sock", 0, 0, 0o660, None);
+        let r = classify_socket_perms("/run/sigil/control.sock", 0, 0, 0o660, None, 0);
         assert_eq!(r.level, CheckLevel::Ok, "{r:?}");
         assert!(r.message.contains("root-owned"), "{r:?}");
     }
@@ -845,7 +869,7 @@ mod linux_tests {
     #[test]
     fn classify_socket_ok_root_0660_with_gid_mismatch() {
         // sigil group exists but the socket's gid differs → still Ok, labeled root:gid(N).
-        let r = classify_socket_perms("/run/sigil/control.sock", 0, 999, 0o660, Some(996));
+        let r = classify_socket_perms("/run/sigil/control.sock", 0, 999, 0o660, Some(996), 0);
         assert_eq!(r.level, CheckLevel::Ok, "{r:?}");
         assert!(r.message.contains("root:gid(999)"), "{r:?}");
         assert!(!r.message.contains("sigil"), "{r:?}");
@@ -854,22 +878,50 @@ mod linux_tests {
     #[test]
     fn classify_socket_ok_root_0600_is_not_world_accessible() {
         // 0600 (no group/other access) is stricter than 0660 → still Ok.
-        let r = classify_socket_perms("/run/sigil/control.sock", 0, 0, 0o600, None);
+        let r = classify_socket_perms("/run/sigil/control.sock", 0, 0, 0o600, None, 0);
         assert_eq!(r.level, CheckLevel::Ok, "{r:?}");
     }
 
     #[test]
     fn classify_socket_warns_when_world_accessible() {
-        let r = classify_socket_perms("/run/sigil/control.sock", 0, 0, 0o666, Some(996));
+        let r = classify_socket_perms("/run/sigil/control.sock", 0, 0, 0o666, Some(996), 0);
         assert_eq!(r.level, CheckLevel::Warn);
         assert!(r.message.contains("world-accessible"), "{r:?}");
     }
 
     #[test]
-    fn classify_socket_warns_when_not_root_owned() {
-        let r = classify_socket_perms("/run/sigil/control.sock", 1000, 1000, 0o660, Some(996));
+    fn classify_socket_warns_when_owner_differs_from_expected() {
+        // Root install expects uid 0; a non-root owner is a real warning.
+        let r = classify_socket_perms("/run/sigil/control.sock", 1000, 1000, 0o660, Some(996), 0);
         assert_eq!(r.level, CheckLevel::Warn);
         assert!(r.message.contains("uid=1000"), "{r:?}");
+        assert!(r.message.contains("expected root"), "{r:?}");
+    }
+
+    #[test]
+    fn classify_socket_ok_nonroot_user_owned() {
+        // #178 — non-root personal install: socket owned by the invoking user
+        // (expected_uid = 1000) is Ok, labeled user-owned (no root expectation).
+        let r = classify_socket_perms(
+            "/tmp/sigil-1000/control.sock",
+            1000,
+            1000,
+            0o600,
+            None,
+            1000,
+        );
+        assert_eq!(r.level, CheckLevel::Ok, "{r:?}");
+        assert!(r.message.contains("user-owned"), "{r:?}");
+        assert!(r.message.contains("uid(1000)"), "{r:?}");
+    }
+
+    #[test]
+    fn classify_socket_nonroot_warns_when_owner_mismatch() {
+        // #178 — non-root expects its own uid; a root-owned socket there is a
+        // genuine mismatch, reported as "expected uid 1000" (not "expected root").
+        let r = classify_socket_perms("/tmp/sigil-1000/control.sock", 0, 0, 0o600, None, 1000);
+        assert_eq!(r.level, CheckLevel::Warn);
+        assert!(r.message.contains("expected uid 1000"), "{r:?}");
     }
 
     #[test]

--- a/install.sh
+++ b/install.sh
@@ -37,16 +37,32 @@ if [ "${SIGIL_PROFILE_DRYRUN:-}" = "1" ]; then
 fi
 
 # --- tooling ---------------------------------------------------------------
-command -v uname >/dev/null 2>&1 || err "missing required tool: uname"
-command -v tar   >/dev/null 2>&1 || err "missing required tool: tar"
-command -v mktemp >/dev/null 2>&1 || err "missing required tool: mktemp"
+# Minimal RHEL-family / container images often ship without `tar` (and even
+# `curl`); a bare "missing required tool" leaves the user guessing. Suggest the
+# one-liner for the host's package manager (#179).
+pkg_hint() { # $1 = tool/package name
+  if   command -v dnf     >/dev/null 2>&1; then echo "install it: sudo dnf install -y $1"
+  elif command -v apt-get >/dev/null 2>&1; then echo "install it: sudo apt-get install -y $1"
+  elif command -v yum     >/dev/null 2>&1; then echo "install it: sudo yum install -y $1"
+  elif command -v apk     >/dev/null 2>&1; then echo "install it: sudo apk add $1"
+  elif command -v zypper  >/dev/null 2>&1; then echo "install it: sudo zypper install -y $1"
+  elif command -v pacman  >/dev/null 2>&1; then echo "install it: sudo pacman -S $1"
+  elif command -v brew    >/dev/null 2>&1; then echo "install it: brew install $1"
+  else echo "install $1 with your package manager"; fi
+}
+need() { # $1 = command, $2 = package providing it (defaults to $1)
+  command -v "$1" >/dev/null 2>&1 || err "missing required tool: $1 — $(pkg_hint "${2:-$1}")"
+}
+need uname coreutils
+need tar tar
+need mktemp coreutils
 
 if command -v curl >/dev/null 2>&1; then
   dl() { curl --proto '=https' --tlsv1.2 -fsSL "$1"; }
 elif command -v wget >/dev/null 2>&1; then
   dl() { wget -qO- "$1"; }
 else
-  err "need curl or wget"
+  err "need curl or wget — $(pkg_hint curl)"
 fi
 
 if command -v sha256sum >/dev/null 2>&1; then
@@ -54,7 +70,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   sha_check() { shasum -a 256 -c "$1"; }
 else
-  err "need sha256sum or shasum to verify the download"
+  err "need sha256sum or shasum to verify the download — $(pkg_hint coreutils)"
 fi
 
 # --- detect platform -------------------------------------------------------


### PR DESCRIPTION
Two papercuts found during real-hardware verification on Rocky 9.7 aarch64.

## #178 — doctor non-root control-socket
`sigil doctor` hardcoded `/var/run/sigil/control.sock` and expected it **root-owned**. A non-root personal install therefore warned:
```
[WARN] control socket: stat failed at /var/run/sigil/control.sock: Permission denied
```
…about a socket the non-root daemon never binds (it uses the XDG/tmp fallback per `default_control_socket()`), spuriously pushing doctor's exit to 1.

**Fix:** resolve the same path the runtime/CLI use, and expect ownership by the invoking euid (root for a root install, the user otherwise). `classify_socket_perms` gains an `expected_uid` and a user-owned OK path.

**Verified on real aarch64 Rocky** — before: `[WARN] … Permission denied`; after: `[INFO] control socket: not present at /run/user/1001/sigil/control.sock`.

## #179 — install.sh missing-tool hint
A missing tool printed a bare `missing required tool: tar`. Minimal RHEL-family / container images often lack `tar` (sometimes `curl`). Added `pkg_hint` (dnf/apt/yum/apk/zypper/pacman/brew detection) appended to every missing-tool error, e.g. `missing required tool: tar — install it: sudo dnf install -y tar`.

## Verification
- ✅ `cargo fmt` + `clippy --all-targets -D warnings`
- ✅ full mac `cargo test` (0 failures)
- ✅ **real aarch64 Rocky 9.7**: doctor module `cargo test` (35 ok incl. new non-root cases) + built binary `sigil doctor` confirms the WARN→INFO change
- ✅ `shellcheck install.sh` clean + `install_profile_test.sh` green

Fixes #178
Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)