### PR TITLE
chore(release): bump workspace version to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ### Added
 
+- **`sigil scan` — one-shot, daemon-free posture score** (#174). The fastest
+  personal read: it reads each installed agent's user-global config once
+  (`~/.claude`, `~/.codex`, `~/.cursor`, …) plus the current directory if it is a
+  project, scores them with the default rubric, and prints a headline (worst-scope
+  bucket + score) and a per-tool table — no daemon, no `state.db`, no policy.
+  `--json` emits the full report; the command always exits 0 (a read-out, not a
+  gate). Closes the gap behind the one-line installers ("install → score").
+- **One-line installer for all three OSes** (#172, #171). New `install.ps1` is the
+  Windows counterpart to `install.sh` (`irm …/install.ps1 | iex`): arch-detected
+  (x64 / ARM64), checksum-verified, installs the personal profile to
+  `%LOCALAPPDATA%\Programs\sigil` and adds it to PATH. `install.sh` now resolves
+  Linux **aarch64** (the musl tarball it had been wrongly rejecting), so the
+  one-liner works on Graviton/Ampere and RHEL/Rocky 9 aarch64. Script installs
+  avoid code-signing friction (Gatekeeper/SmartScreen) by design.
 - **OpenClaw / Hermes integration glue for `assess`** (#151). `sigil-mcp
   --print-config` now emits ready-to-paste blocks for `hermes` (a `config.yaml`
   `mcp_servers:` entry) and `openclaw` (a `~/.openclaw/openclaw.json` `mcpServers`
@@ -34,6 +48,19 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ### Fixed
 
+- **`sigil doctor` no longer warns about a control socket on a non-root install**
+  (#178). The check hardcoded `/var/run/sigil/control.sock` and expected it
+  root-owned, so a non-root personal user got a spurious `Permission denied`
+  warning (and a non-zero exit) about a socket the non-root daemon never binds.
+  Doctor now resolves the same XDG/tmp fallback path the daemon uses and expects
+  ownership by the invoking user.
+- **`install.sh` suggests how to install a missing tool** (#179). On a minimal
+  RHEL-family / container host without `tar` (or `curl`), the bare "missing
+  required tool" message now appends the host package manager's one-liner
+  (`sudo dnf install -y tar`, `sudo apt-get install -y …`, etc.).
+- **macOS install guide corrected** (#176). It claimed `install.sh` installs all
+  six binaries; the personal default is three. Added a 30-second personal
+  quickstart and framed the rest as the operator deployment.
 - **The local `rule-packs.yaml` watcher re-arms when the config dir is recreated
   at runtime** (#135). The dedicated hot-reload watcher previously gave up
   permanently if its config directory was absent at start, and a by-inode watch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.6.1"
+version = "0.6.2"
 
 [[package]]
 name = "sigil-sender"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **0.6.2** — the personal-UX completion arc on top of 0.6.1.

## Included since v0.6.1
- **`sigil scan`** — one-shot, daemon-free posture score (#174, #175)
- **One-line installers for all 3 OSes** — `install.ps1` (Windows) + Linux aarch64 in `install.sh` (#171, #172, #173)
- **doctor non-root control-socket check** + **install.sh missing-tool hints** (#178, #179, #180)
- **macOS install guide correction** (#176, #177)

## This PR
- `Cargo.toml` `version` 0.6.1 → 0.6.2 (+ `Cargo.lock`)
- `CHANGELOG.md` `[Unreleased]` updated with the above

## Verification
- ✅ `cargo fmt` + `clippy --all-targets -D warnings` + full `cargo test` (0 failures) at 0.6.2
- ✅ `version_flag` tests assert the new version
- ✅ End-to-end on **real hardware**: Rocky 9.7 aarch64 (install.sh + doctor + sigil scan) and Windows 11 ARM64 (install.ps1)

After merge, tag `v0.6.2` to trigger `release.yml` (5-target binaries + .deb/.rpm + SHA256SUMS + signed build manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)