### PR TITLE
feat(ai-guard): dangerous-toggle OFF→ON drift detection (#147)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -743,20 +743,20 @@ mod tests {
     /// DANGEROUS_TOGGLE_KINDS and kind_key()).
     #[test]
     fn dangerous_toggle_kinds_match_kind_key_outputs() {
-        assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(
-            &AiGuardReason::AutoApprovalEnabled { mode: "m".into() }
-        )));
+        assert!(
+            DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::AutoApprovalEnabled {
+                mode: "m".into()
+            }))
+        );
         assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::SandboxDisabled)));
-        assert!(
-            DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::PermissionsAllowBroad {
-                rule: "r".into()
-            }))
-        );
-        assert!(
-            DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::ProjectMcpAutoEnabled {
+        assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(
+            &AiGuardReason::PermissionsAllowBroad { rule: "r".into() }
+        )));
+        assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(
+            &AiGuardReason::ProjectMcpAutoEnabled {
                 mechanism: "x".into()
-            }))
-        );
+            }
+        )));
     }
 
     /// #127 — the two shapes are independently tunable kind_keys.

--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -61,6 +61,23 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
     }
 }
 
+/// #147 — the dangerous self-escalation toggle kinds tracked for drift.
+pub const DANGEROUS_TOGGLE_KINDS: &[&str] = &[
+    "auto_approval_enabled",
+    "sandbox_disabled",
+    "permissions_allow_broad",
+    "project_mcp_auto_enabled",
+];
+
+/// The set of dangerous-toggle kind keys present in a reason set.
+pub fn dangerous_toggles(reasons: &[AiGuardReason]) -> std::collections::BTreeSet<&'static str> {
+    reasons
+        .iter()
+        .map(kind_key)
+        .filter(|k| DANGEROUS_TOGGLE_KINDS.contains(k))
+        .collect()
+}
+
 /// Phase 3b.5 — operator-tunable rubric. Holds the active weights and
 /// metadata about which entries came from operator overrides. Built once
 /// at boot and on each policy reload; consulted by the score() pipeline.
@@ -670,6 +687,76 @@ mod tests {
         });
         assert_eq!(score(&shell_destructive), 9.5);
         assert_eq!(bucket(score(&shell_destructive)), AiGuardBucket::Critical);
+    }
+
+    /// #147 — only the four dangerous-toggle kinds are returned, regardless of
+    /// other (non-dangerous) reasons present in the set.
+    #[test]
+    fn dangerous_toggles_returns_only_dangerous_kinds() {
+        let reasons = vec![
+            // dangerous
+            AiGuardReason::AutoApprovalEnabled {
+                mode: "auto_edit".into(),
+            },
+            AiGuardReason::SandboxDisabled,
+            AiGuardReason::PermissionsAllowBroad {
+                rule: "Bash:.*".into(),
+            },
+            AiGuardReason::ProjectMcpAutoEnabled {
+                mechanism: "enableAllProjectMcpServers".into(),
+            },
+            // non-dangerous noise
+            AiGuardReason::PermissionsDenyEmpty,
+            AiGuardReason::NoSandbox {
+                executor: "host_shell".into(),
+            },
+            AiGuardReason::TrustedMcpServer {
+                server_name: "x".into(),
+            },
+        ];
+        let got = dangerous_toggles(&reasons);
+        let expected: std::collections::BTreeSet<&'static str> = [
+            "auto_approval_enabled",
+            "sandbox_disabled",
+            "permissions_allow_broad",
+            "project_mcp_auto_enabled",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(got, expected);
+    }
+
+    /// #147 — a reason set with no dangerous toggles yields an empty set.
+    #[test]
+    fn dangerous_toggles_empty_when_none_present() {
+        let reasons = vec![
+            AiGuardReason::PermissionsDenyEmpty,
+            AiGuardReason::NoSandbox {
+                executor: "host_shell".into(),
+            },
+        ];
+        assert!(dangerous_toggles(&reasons).is_empty());
+    }
+
+    /// #147 — the four declared dangerous kinds match the kind_key() outputs of
+    /// their corresponding reason variants exactly (guards against drift between
+    /// DANGEROUS_TOGGLE_KINDS and kind_key()).
+    #[test]
+    fn dangerous_toggle_kinds_match_kind_key_outputs() {
+        assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(
+            &AiGuardReason::AutoApprovalEnabled { mode: "m".into() }
+        )));
+        assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::SandboxDisabled)));
+        assert!(
+            DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::PermissionsAllowBroad {
+                rule: "r".into()
+            }))
+        );
+        assert!(
+            DANGEROUS_TOGGLE_KINDS.contains(&kind_key(&AiGuardReason::ProjectMcpAutoEnabled {
+                mechanism: "x".into()
+            }))
+        );
     }
 
     /// #127 — the two shapes are independently tunable kind_keys.

--- a/crates/sigil-agent/src/ai_guard/task.rs
+++ b/crates/sigil-agent/src/ai_guard/task.rs
@@ -44,6 +44,9 @@ pub struct CachedAssessment {
     pub reasons_blake3: [u8; 32],
     pub reasons_count: usize,
     pub last_assessed_ts: OffsetDateTime,
+    /// #147 — the dangerous-toggle kinds present at this assessment. Compared
+    /// against the next assessment's set to detect OFF→ON transitions (drift).
+    pub dangerous_toggles: std::collections::BTreeSet<String>,
 }
 
 /// Bundle of shared dependencies the task needs at construction. Built once
@@ -181,6 +184,27 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
     // unchanged from the previous one. Boot (no prior state) is NOT a
     // reattestation even though it's force-emitted.
     let is_reattestation = force_emit && prev.is_some() && !changed;
+
+    // #147 — dangerous-toggle drift. A toggle is "dangerous" iff its reason
+    // kind is in DANGEROUS_TOGGLE_KINDS. We compare the current set against the
+    // previous cached set and emit a one-time event for each toggle that
+    // appeared (OFF→ON). The standing state still rides the normal
+    // AiGuardRiskAssessed reasons; this is an ADDITIONAL change event.
+    let new_toggles: std::collections::BTreeSet<String> = rubric::dangerous_toggles(&reasons)
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+    // Only fire when there is a PREVIOUS cached assessment for this key. The
+    // first/boot assessment merely establishes the baseline, so a daemon
+    // restart with a toggle already on never false-fires.
+    let appeared: Vec<String> = match prev.as_ref() {
+        Some(p) => new_toggles
+            .difference(&p.dangerous_toggles)
+            .cloned()
+            .collect(),
+        None => Vec::new(),
+    };
+
     ctx.state.write().insert(
         key.clone(),
         CachedAssessment {
@@ -189,8 +213,46 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
             reasons_blake3: reasons_hash,
             reasons_count: reasons.len(),
             last_assessed_ts: now,
+            dangerous_toggles: new_toggles,
         },
     );
+
+    // Emit one drift event per appeared toggle, via the same sink/channel and
+    // full-Event envelope as AiGuardRiskAssessed below.
+    for toggle in appeared {
+        let drift_event = Event {
+            schema_version: SCHEMA_VERSION,
+            event_id: uuid::Uuid::now_v7(),
+            ts: now,
+            host_id: ctx.host_id.clone(),
+            agent_version: AGENT_VERSION.to_string(),
+            severity: Severity::Warn,
+            source: SourceKind::Agent,
+            subject: Subject::Self_,
+            evidence: Evidence::AiGuardToggleDrift {
+                tool: key.0,
+                scope: key.1.clone(),
+                toggle,
+                rule_pack_id: key.2.clone(),
+                tool_label: parser.tool_label().map(|s| s.to_string()),
+            },
+            target_id: None,
+        };
+        if ctx
+            .event_tx
+            .send(CommittableEvent {
+                event: drift_event,
+                new_hash: None,
+                path_for_db: PathBuf::new(),
+                target_id: String::new(),
+            })
+            .await
+            .is_err()
+        {
+            tracing::debug!(tool = ?key.0, "ai_guard drift event_tx send failed (sink closed during shutdown?)");
+        }
+    }
+
     let event = Event {
         schema_version: SCHEMA_VERSION,
         event_id: uuid::Uuid::now_v7(),
@@ -295,6 +357,20 @@ mod tests {
         )
     }
 
+    /// Receive the next `AiGuardRiskAssessed` event, skipping any
+    /// `AiGuardToggleDrift` events emitted earlier in the same cycle (#147).
+    async fn recv_next_risk_assessed(
+        events: &mut mpsc::Receiver<CommittableEvent>,
+    ) -> CommittableEvent {
+        loop {
+            let ev = events.recv().await.expect("event");
+            if matches!(ev.event.evidence, Evidence::AiGuardToggleDrift { .. }) {
+                continue;
+            }
+            return ev;
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn boot_emits_initial_event_even_when_clean() {
         let (_tx, fc_rx) = broadcast::channel(8);
@@ -383,7 +459,9 @@ mod tests {
         let _boot = events.recv().await.expect("boot");
         tx.send(watched).unwrap();
         tokio::time::advance(Duration::from_millis(50)).await;
-        let ev = events.recv().await.expect("change event");
+        // SandboxDisabled is also a dangerous toggle, so an OFF→ON drift event
+        // precedes the risk event this cycle. Skip past it to the risk event.
+        let ev = recv_next_risk_assessed(&mut events).await;
         match ev.event.evidence {
             Evidence::AiGuardRiskAssessed {
                 is_reattestation, ..
@@ -489,7 +567,9 @@ mod tests {
         tokio::time::advance(Duration::from_millis(10)).await;
         let _boot = events.recv().await.expect("boot event");
         tokio::time::advance(Duration::from_millis(150)).await;
-        let ev = events.recv().await.expect("heartbeat event");
+        // SandboxDisabled (the changed reason) is also a dangerous toggle, so a
+        // drift event precedes the risk event this cycle. Skip to the risk one.
+        let ev = recv_next_risk_assessed(&mut events).await;
         match ev.event.evidence {
             Evidence::AiGuardRiskAssessed {
                 is_reattestation, ..
@@ -576,5 +656,241 @@ mod tests {
         assert!(s.contains_key(&(AiTool::Gemini, scope.clone(), Some("pack-a".to_string()))));
         assert!(s.contains_key(&(AiTool::Gemini, scope.clone(), Some("pack-b".to_string()))));
         assert_eq!(s.len(), 2);
+    }
+
+    // ---- #147 dangerous-toggle drift -------------------------------------
+
+    /// Build a parsers-less ctx + a shared event channel for driving a single
+    /// parser through `eval_and_maybe_emit` directly (mirrors
+    /// `emit_carries_tool_label_from_parser`). Returns (ctx, event receiver).
+    fn drift_ctx() -> (TaskCtx, mpsc::Receiver<CommittableEvent>) {
+        let (_fc_tx, fc_rx) = broadcast::channel(8);
+        let (event_tx, events) = mpsc::channel(32);
+        let ctx = TaskCtx {
+            parsers: Arc::new(RwLock::new(vec![])),
+            fc_rx,
+            event_tx,
+            state: Arc::new(RwLock::new(HashMap::new())),
+            heartbeat_interval: Duration::from_secs(24 * 3600),
+            home_dir: PathBuf::from("/tmp/test-home"),
+            host_id: "test-host".into(),
+            ext_scripts: crate::ai_guard::empty_ext_script_registry(),
+            rubric: crate::ai_guard::default_rubric_handle(),
+        };
+        (ctx, events)
+    }
+
+    /// Drain the channel and return only the `AiGuardToggleDrift` toggles, in
+    /// emission order. (Each `eval_and_maybe_emit` also emits an
+    /// `AiGuardRiskAssessed`; we ignore those here.)
+    fn drain_drift_toggles(events: &mut mpsc::Receiver<CommittableEvent>) -> Vec<String> {
+        let mut out = Vec::new();
+        while let Ok(ce) = events.try_recv() {
+            if let Evidence::AiGuardToggleDrift { toggle, .. } = ce.event.evidence {
+                out.push(toggle);
+            }
+        }
+        out
+    }
+
+    fn one_shot_parser(reasons: Vec<AiGuardReason>) -> ScriptedParser {
+        ScriptedParser {
+            tool: AiTool::Gemini,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
+            tool_label: None,
+            scripts: StdMutex::new(vec![reasons]),
+            watched: vec![],
+        }
+    }
+
+    /// Baseline: first assessment with a dangerous toggle already present must
+    /// NOT fire a drift event — boot establishes the baseline.
+    #[tokio::test]
+    async fn drift_baseline_does_not_fire() {
+        let (ctx, mut events) = drift_ctx();
+        let p = one_shot_parser(vec![AiGuardReason::AutoApprovalEnabled {
+            mode: "auto_edit".into(),
+        }]);
+        eval_and_maybe_emit(&p, &ctx, true).await;
+        assert!(
+            drain_drift_toggles(&mut events).is_empty(),
+            "boot assessment must not fire drift"
+        );
+        // Baseline was recorded.
+        let key = (AiTool::Gemini, AiGuardScope::UserGlobal, None);
+        assert!(ctx.state.read()[&key]
+            .dangerous_toggles
+            .contains("auto_approval_enabled"));
+    }
+
+    /// off→on: assess with toggle off, then flip it on → EXACTLY ONE drift
+    /// event for that toggle kind.
+    #[tokio::test]
+    async fn drift_off_to_on_fires_once() {
+        let (ctx, mut events) = drift_ctx();
+        // First (baseline): toggle off — a non-dangerous reason so the reason
+        // set is non-empty but carries no dangerous toggle.
+        let off = one_shot_parser(vec![AiGuardReason::PermissionsDenyEmpty]);
+        eval_and_maybe_emit(&off, &ctx, true).await;
+        assert!(drain_drift_toggles(&mut events).is_empty());
+
+        // Second: toggle on.
+        let on = one_shot_parser(vec![AiGuardReason::SandboxDisabled]);
+        eval_and_maybe_emit(&on, &ctx, false).await;
+        assert_eq!(
+            drain_drift_toggles(&mut events),
+            vec!["sandbox_disabled".to_string()]
+        );
+    }
+
+    /// already-on: toggle on across two assessments → no drift on the second.
+    #[tokio::test]
+    async fn drift_already_on_does_not_refire() {
+        let (ctx, mut events) = drift_ctx();
+        let on1 = one_shot_parser(vec![AiGuardReason::SandboxDisabled]);
+        eval_and_maybe_emit(&on1, &ctx, true).await; // baseline (no drift)
+        assert!(drain_drift_toggles(&mut events).is_empty());
+
+        // Same toggle present again — force_emit so an AiGuardRiskAssessed is
+        // produced, but the toggle was already in prev → no drift.
+        let on2 = one_shot_parser(vec![AiGuardReason::SandboxDisabled]);
+        eval_and_maybe_emit(&on2, &ctx, true).await;
+        assert!(
+            drain_drift_toggles(&mut events).is_empty(),
+            "an already-on toggle must not re-fire"
+        );
+    }
+
+    /// on→off: toggle removed → no drift (de-escalation is silent).
+    #[tokio::test]
+    async fn drift_on_to_off_does_not_fire() {
+        let (ctx, mut events) = drift_ctx();
+        let on = one_shot_parser(vec![AiGuardReason::SandboxDisabled]);
+        eval_and_maybe_emit(&on, &ctx, true).await; // baseline
+        let _ = drain_drift_toggles(&mut events);
+
+        let off = one_shot_parser(vec![AiGuardReason::PermissionsDenyEmpty]);
+        eval_and_maybe_emit(&off, &ctx, false).await;
+        assert!(
+            drain_drift_toggles(&mut events).is_empty(),
+            "on→off must not fire drift"
+        );
+        // Cache reflects the toggle is gone.
+        let key = (AiTool::Gemini, AiGuardScope::UserGlobal, None);
+        assert!(ctx.state.read()[&key].dangerous_toggles.is_empty());
+    }
+
+    /// on→off→on: the toggle re-appearing fires drift again (each on-transition).
+    #[tokio::test]
+    async fn drift_on_off_on_fires_again() {
+        let (ctx, mut events) = drift_ctx();
+        eval_and_maybe_emit(
+            &one_shot_parser(vec![AiGuardReason::SandboxDisabled]),
+            &ctx,
+            true,
+        )
+        .await; // baseline on
+        let _ = drain_drift_toggles(&mut events);
+        eval_and_maybe_emit(
+            &one_shot_parser(vec![AiGuardReason::PermissionsDenyEmpty]),
+            &ctx,
+            false,
+        )
+        .await; // off
+        let _ = drain_drift_toggles(&mut events);
+        eval_and_maybe_emit(
+            &one_shot_parser(vec![AiGuardReason::SandboxDisabled]),
+            &ctx,
+            false,
+        )
+        .await; // on again
+        assert_eq!(
+            drain_drift_toggles(&mut events),
+            vec!["sandbox_disabled".to_string()]
+        );
+    }
+
+    /// Multiple toggles appearing at once → one drift event per appeared toggle.
+    #[tokio::test]
+    async fn drift_multiple_toggles_one_event_each() {
+        let (ctx, mut events) = drift_ctx();
+        // Baseline: none.
+        eval_and_maybe_emit(
+            &one_shot_parser(vec![AiGuardReason::PermissionsDenyEmpty]),
+            &ctx,
+            true,
+        )
+        .await;
+        let _ = drain_drift_toggles(&mut events);
+
+        // Two dangerous toggles appear at once.
+        let both = one_shot_parser(vec![
+            AiGuardReason::SandboxDisabled,
+            AiGuardReason::AutoApprovalEnabled {
+                mode: "auto_edit".into(),
+            },
+        ]);
+        eval_and_maybe_emit(&both, &ctx, false).await;
+        let mut got = drain_drift_toggles(&mut events);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "auto_approval_enabled".to_string(),
+                "sandbox_disabled".to_string()
+            ]
+        );
+    }
+
+    /// Full-loop off→on via the file-change trigger: drift event flows through
+    /// `run()` exactly like the AiGuardRiskAssessed sibling.
+    #[tokio::test(start_paused = true)]
+    async fn drift_off_to_on_through_run_loop() {
+        let (tx, fc_rx) = broadcast::channel(8);
+        let watched = PathBuf::from("/tmp/test-home/.claude/settings.json");
+        let parser = ScriptedParser {
+            tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            pack_id: None,
+            tool_label: None,
+            scripts: StdMutex::new(vec![
+                vec![AiGuardReason::PermissionsDenyEmpty], // boot: toggle off
+                vec![AiGuardReason::SandboxDisabled],      // change: toggle on
+            ]),
+            watched: vec![watched.clone()],
+        };
+        let (ctx, mut events) = ctx_with(parser, fc_rx, Duration::from_secs(24 * 3600));
+        let h = tokio::spawn(run(ctx));
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(10)).await;
+        // Boot: AiGuardRiskAssessed only, no drift.
+        let boot = events.recv().await.expect("boot");
+        assert!(matches!(
+            boot.event.evidence,
+            Evidence::AiGuardRiskAssessed { .. }
+        ));
+
+        tx.send(watched).unwrap();
+        tokio::time::advance(Duration::from_millis(50)).await;
+
+        // The change cycle emits a drift event AND an AiGuardRiskAssessed.
+        // Collect both (order: drift is sent before the risk event).
+        let mut saw_drift = None;
+        let mut saw_risk = false;
+        for _ in 0..2 {
+            let ev = tokio::time::timeout(Duration::from_millis(100), events.recv())
+                .await
+                .expect("event available")
+                .expect("event");
+            match ev.event.evidence {
+                Evidence::AiGuardToggleDrift { toggle, .. } => saw_drift = Some(toggle),
+                Evidence::AiGuardRiskAssessed { .. } => saw_risk = true,
+                other => panic!("unexpected {other:?}"),
+            }
+        }
+        assert_eq!(saw_drift.as_deref(), Some("sandbox_disabled"));
+        assert!(saw_risk, "drift is IN ADDITION to AiGuardRiskAssessed");
+        h.abort();
     }
 }

--- a/crates/sigil-agent/src/ai_guard/task.rs
+++ b/crates/sigil-agent/src/ai_guard/task.rs
@@ -190,6 +190,19 @@ async fn eval_and_maybe_emit(parser: &dyn AiGuardParser, ctx: &TaskCtx, force_em
     // previous cached set and emit a one-time event for each toggle that
     // appeared (OFF→ON). The standing state still rides the normal
     // AiGuardRiskAssessed reasons; this is an ADDITIONAL change event.
+    //
+    // MVP limitations (codex-review, all P2, none a current bug):
+    //  1. Baseline is keyed by the full StateMap key (tool, scope, rule_pack_id),
+    //     so a toggle first seen under a *renamed* rule pack id is baselined (no
+    //     drift) — consistent with how every assessment is keyed. Built-in
+    //     toggles (rule_pack_id = None) are unaffected.
+    //  2. The prev-read / new-write below are not one atomic critical section.
+    //     Safe today because the eval loop is serialized per key; if parser eval
+    //     ever runs concurrently for the same key, fold read+compare+write into a
+    //     single `state.write()` to avoid a double-fire.
+    //  3. The cache advances before the drift send, so a send that fails during
+    //     shutdown drops that one alert (at-most-once). The standing reason still
+    //     re-establishes posture, so nothing about *state* is lost.
     let new_toggles: std::collections::BTreeSet<String> = rubric::dangerous_toggles(&reasons)
         .into_iter()
         .map(|s| s.to_string())

--- a/crates/sigil-agent/src/policy_reload_task.rs
+++ b/crates/sigil-agent/src/policy_reload_task.rs
@@ -928,6 +928,7 @@ mod tests {
                     reasons_blake3: [0u8; 32],
                     reasons_count: 1,
                     last_assessed_ts: time::OffsetDateTime::now_utc(),
+                    dangerous_toggles: std::collections::BTreeSet::new(),
                 },
             );
         }
@@ -1299,6 +1300,7 @@ mod tests {
                         reasons_blake3: [0u8; 32],
                         reasons_count: 1,
                         last_assessed_ts: time::OffsetDateTime::now_utc(),
+                        dangerous_toggles: std::collections::BTreeSet::new(),
                     },
                 );
             }

--- a/crates/sigil-agent/src/show.rs
+++ b/crates/sigil-agent/src/show.rs
@@ -506,6 +506,10 @@ fn evidence_summary(e: &sigil_core::event::Evidence) -> (&'static str, String) {
             "ai_guard_risk_assessed",
             format!("tool={tool:?} bucket={bucket:?}"),
         ),
+        Evidence::AiGuardToggleDrift { tool, toggle, .. } => (
+            "ai_guard_toggle_drift",
+            format!("{tool:?} {toggle} turned on (drift)"),
+        ),
         Evidence::HostMetaSnapshot { .. } => ("host_meta_snapshot", String::new()),
         Evidence::HookInvocation(_) => ("hook_invocation", String::new()),
         Evidence::HookDecision(d) => (

--- a/crates/sigil-agent/src/sink_task.rs
+++ b/crates/sigil-agent/src/sink_task.rs
@@ -67,6 +67,7 @@ fn evidence_kind_str(e: &sigil_core::event::Evidence) -> &'static str {
         ServerProtocolViolation { .. } => "server_protocol_violation",
         SenderLagCritical { .. } => "sender_lag_critical",
         AiGuardRiskAssessed { .. } => "ai_guard_risk_assessed",
+        AiGuardToggleDrift { .. } => "ai_guard_toggle_drift",
         HostMetaSnapshot { .. } => "host_meta_snapshot",
         HookInvocation(_) => "hook_invocation",
         HookDecision(_) => "hook_decision",

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -571,6 +571,19 @@ pub enum Evidence {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tool_label: Option<String>,
     },
+    /// #147 — a dangerous self-config toggle flipped OFF→ON between snapshots
+    /// (auto-approve / sandbox-off / broad-allow / project-MCP-autorun). One-time
+    /// change event; the standing state rides the normal AiGuardRiskAssessed reasons.
+    AiGuardToggleDrift {
+        tool: AiTool,
+        scope: AiGuardScope,
+        /// The dangerous-toggle kind that turned on, e.g. "auto_approval_enabled".
+        toggle: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rule_pack_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_label: Option<String>,
+    },
     /// Phase 3b.4-pre — periodic snapshot of host identity + network + OS
     /// metadata. Emitted by host_meta_snapshot_task on boot, every 24h, and
     /// whenever the snapshot's canonical hash differs from the last
@@ -922,6 +935,41 @@ mod tests {
         assert!(s.contains("\"executor\":\"host_shell\""));
         let back: Evidence = serde_json::from_str(&s).unwrap();
         assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn ai_guard_toggle_drift_serializes_with_kind_and_round_trips() {
+        let ev = Evidence::AiGuardToggleDrift {
+            tool: AiTool::ClaudeCode,
+            scope: AiGuardScope::UserGlobal,
+            toggle: "auto_approval_enabled".into(),
+            rule_pack_id: None,
+            tool_label: None,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"kind\":\"ai_guard_toggle_drift\""), "got: {s}");
+        assert!(s.contains("\"tool\":\"claude_code\""));
+        assert!(s.contains("\"toggle\":\"auto_approval_enabled\""));
+        // Optional fields omitted when None.
+        assert!(!s.contains("rule_pack_id"));
+        assert!(!s.contains("tool_label"));
+        let back: Evidence = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn ai_guard_toggle_drift_round_trips_optional_fields() {
+        let ev = Evidence::AiGuardToggleDrift {
+            tool: AiTool::Other,
+            scope: AiGuardScope::Project { path: "/r".into() },
+            toggle: "sandbox_disabled".into(),
+            rule_pack_id: Some("my-pack".into()),
+            tool_label: Some("acme-ai".into()),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains(r#""rule_pack_id":"my-pack""#));
+        assert!(s.contains(r#""tool_label":"acme-ai""#));
+        assert_eq!(ev, serde_json::from_str::<Evidence>(&s).unwrap());
     }
 
     #[test]

--- a/crates/sigil-server/src/fleet_index_update.rs
+++ b/crates/sigil-server/src/fleet_index_update.rs
@@ -13,7 +13,8 @@ fn is_alert_evidence(ev: &Evidence) -> bool {
         Evidence::AiGuardRiskAssessed {
             bucket: AiGuardBucket::High | AiGuardBucket::Critical,
             ..
-        } | Evidence::PolicySignatureInvalid { .. }
+        } | Evidence::AiGuardToggleDrift { .. }
+            | Evidence::PolicySignatureInvalid { .. }
             | Evidence::TlsFailure { .. }
             | Evidence::HostIdFingerprintDrift { .. }
             | Evidence::AgentDying { .. }
@@ -125,6 +126,7 @@ pub fn apply_event(host: &mut HostSummary, event: &Event) {
         // entire update. Listed explicitly so future variant additions raise
         // a non-exhaustive match warning until decided where to map them.
         Evidence::FileChange { .. }
+        | Evidence::AiGuardToggleDrift { .. }
         | Evidence::PermissionMissing { .. }
         | Evidence::AgentDying { .. }
         | Evidence::RateLimitExceeded { .. }
@@ -186,6 +188,13 @@ mod tests {
         for k in def["additional_kinds"].as_array().unwrap() {
             let kind = k.as_str().unwrap();
             let ev = match kind {
+                "ai_guard_toggle_drift" => Evidence::AiGuardToggleDrift {
+                    tool: AiTool::ClaudeCode,
+                    scope: AiGuardScope::UserGlobal,
+                    toggle: "auto_approval_enabled".into(),
+                    rule_pack_id: None,
+                    tool_label: None,
+                },
                 "policy_signature_invalid" => Evidence::PolicySignatureInvalid {
                     reason: PolicySignatureInvalidReason::SignatureInvalid,
                     signing_pubkey_id: "k".into(),

--- a/crates/sigil-server/src/routes/meta.rs
+++ b/crates/sigil-server/src/routes/meta.rs
@@ -14,6 +14,7 @@ pub(crate) fn alerts_definition_default() -> serde_json::Value {
         "evidence_kinds": ["ai_guard_risk_assessed"],
         "ai_guard_buckets": ["high", "critical"],
         "additional_kinds": [
+            "ai_guard_toggle_drift",
             "policy_signature_invalid", "tls_failure",
             "host_id_fingerprint_drift", "agent_dying", "sender_lag_critical"
         ]


### PR DESCRIPTION
Closes #147 (MVP). When a host's coding agent silently flips a **self-escalation toggle** on — auto-approve, sandbox-off, broad-allow, or project-MCP-autorun — Sigil emits a one-time security event. The CVE-2025-53773 pattern (`chat.tools.autoApprove: true`) and friends: once set, every later tool call self-approves.

## What it does
The daemon already caches the last AI-guard assessment per (tool, scope) and re-assesses on config change. This adds a **change** event on top of the standing posture:
- **Dangerous-toggle set** (`rubric::dangerous_toggles`): the four reason kinds `auto_approval_enabled`, `sandbox_disabled`, `permissions_allow_broad`, `project_mcp_auto_enabled`.
- **Drift** = the toggle kinds that **appeared** vs the previous cached snapshot. For each, emit `Evidence::AiGuardToggleDrift { tool, scope, toggle, … }` (Severity::Warn, classified as a fleet **alert**).
- **One-time + baseline-safe**: fires only when there's a previous assessment, so a daemon restart with a toggle already on never false-fires; the next assessment has it in the baseline so it doesn't re-fire; off→on→off→on re-arms.
- Works over reason **kinds**, so rule-pack-emitted dangerous toggles are covered automatically. No new parser, no rule-pack file, no `sigil scan` change (one-shot has no prior snapshot).

## Verification
- ✅ `cargo fmt` + `clippy --all-targets -D warnings` clean; `cargo test --workspace` **1337 passed / 0 failed**.
- ✅ Drift tests (7): off→on fires once, baseline doesn't fire, already-on doesn't re-fire, on→off doesn't fire, on→off→on re-arms, multiple toggles → one event each, full-run-loop integration; + `dangerous_toggles` unit tests incl. a guard that the kind list matches real `kind_key` outputs.
- ✅ **codex adversarial challenge** on the diff: 0 P1; confirmed no false-fire (restart / first / heartbeat / parser-error), no miss on unchanged-hash, no panic. The 3 P2s (rule-pack-key edge, future-parallel atomicity, shutdown at-most-once) are documented inline as MVP limitations — none is a current bug on the serialized loop.

## Out of scope (follow-ups)
VS Code/Copilot `chat.tools.autoApprove` parser, cross-restart drift persistence, cursor UI-only auto-run (not file-detectable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)