### PR TITLE
chore(release): bump workspace version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ also appear under [GitHub Releases](https://github.com/Ju571nK/sigil/releases).
 
 ### Added
 
+- **Dangerous-toggle drift detection** (#147). When a coding agent's config
+  silently flips a self-escalation toggle on — auto-approve, sandbox-off,
+  broad-allow, or project-MCP-autorun — the daemon emits a one-time
+  `AiGuardToggleDrift` security event (the CVE-2025-53773 `chat.tools.autoApprove`
+  class). Fires only on the OFF→ON transition vs the previous hashed snapshot
+  (baseline-safe across restarts; re-arms on off→on→off→on); classified as a
+  fleet alert. Works over reason kinds, so rule-pack-emitted toggles are covered.
+- **`sigil-server` enrollment endpoint (B-mint)** (#184). `POST /v1/enroll` signs
+  a host CSR into a per-host mTLS client cert using an operator-provided
+  intermediate CA (root stays offline), gated by a single-use, TTL, per-host
+  token (`sigil-server enroll-token`). Fixed client-cert profile + post-sign
+  inspection, allowlist auto-add, signed enrollment audit; enrollment refuses to
+  run without mTLS + a restrictive allowlist. Lets a PMS bootstrap host identity
+  without hand-running openssl per host. Hardware-verified on Rocky 9 aarch64.
+- **`sigil-server` signed-artifact serving** (#182). `GET /v1/artifacts[/<file>]`
+  serves the release binaries (tarballs/zips, `.deb`/`.rpm`, `SHA256SUMS`,
+  build-manifest) read-only from an operator-populated `artifacts_dir`, so an
+  air-gapped fleet/PMS can pull from the server instead of GitHub. Bearer-gated,
+  path-traversal-hardened; `install.sh`/`install.ps1` gained `SIGIL_BASE_URL` +
+  `SIGIL_BASE_TOKEN` to fetch from it.
 - **`sigil scan` — one-shot, daemon-free posture score** (#174). The fastest
   personal read: it reads each installed agent's user-global config once
   (`~/.claude`, `~/.codex`, `~/.cursor`, …) plus the current directory if it is a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-agent"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-hook"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-mcp"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -3145,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "sigil-rules-basic"
-version = "0.6.2"
+version = "0.7.0"
 
 [[package]]
 name = "sigil-sender"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-server"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-signer"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-spool"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sigil-core", "crates/sigil-agent", "crates/sigil-spool", "cra
 resolver = "2"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.78"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **0.7.0** on top of 0.6.2.

## Included since v0.6.2
- **Dangerous-toggle drift detection** (#147, PR #186) — one-time `AiGuardToggleDrift` event on a self-escalation toggle flipping OFF→ON.
- **B-mint enrollment endpoint** (#184, PR #185) — `POST /v1/enroll` mints per-host mTLS client certs from an intermediate CA; hardware-verified on Rocky 9 aarch64.
- **Signed-artifact serving** (#182, PR #183) — `GET /v1/artifacts` + installer `SIGIL_BASE_URL`/`SIGIL_BASE_TOKEN`.

## This PR
- `Cargo.toml` `version` 0.6.2 → 0.7.0 (+ `Cargo.lock`)
- `CHANGELOG.md` `[Unreleased]` updated

## Verification
- ✅ `cargo fmt` + `clippy --all-targets -D warnings` + full `cargo test --workspace` (0 failures) at 0.7.0
- ✅ Version bump breaks no version-coupled snapshots (no hardcoded version; `version_flag` tests use `env!()`)

After merge, tag `v0.7.0` → `release.yml` builds the 5-target binaries + .deb/.rpm + SHA256SUMS + signed build manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)