### PR TITLE
feat(install): opt-in Claude Code allowlist for personal profile (#188)

### DIFF
--- a/docs/install-personal.md
+++ b/docs/install-personal.md
@@ -63,6 +63,29 @@ mkdir -p ~/.config/sigil
 
 For a packaged install the directory is `/etc/sigil` (created by the package).
 
+### Agent permission prompts (optional, opt-in)
+
+If you drive sigil from inside an AI coding agent (Claude Code), the agent
+improvises `sigil` commands with varying flags, so each distinct command string
+is a fresh approval and "don't ask again" never sticks — a first-run prompt
+storm. The **personal** `install.sh` / `install.ps1` therefore *offers* (opt-in,
+only when a terminal is present) to add a read-only allowlist to
+`~/.claude/settings.json`:
+
+```json
+{ "permissions": {
+    "allow": ["Bash(sigil:*)"],
+    "deny": ["Bash(sigil run:*)", "Bash(sigil-hook:*)"]
+} }
+```
+
+The broad `Bash(sigil:*)` allow stops the storm; the explicit **deny** keeps the
+privileged `sigil run` (daemon) and `sigil-hook` (enforce) from being silently
+granted to the agent — Claude Code evaluates deny before allow. Decline and the
+installer just prints the snippet; it never edits silently, and the fleet profile
+never offers it. (A posture tool editing agent config must be opt-in, read-only,
+and transparent.)
+
 ---
 
 ## Run the daemon

--- a/install.ps1
+++ b/install.ps1
@@ -49,6 +49,77 @@ if ($env:SIGIL_PROFILE_DRYRUN -eq '1') {
   exit 0
 }
 
+# --- #188: personal-profile Claude Code allowlist offer (mirrors install.sh) ---
+# Broad `Bash(sigil:*)` allow stops the per-command prompt storm; an explicit
+# deny keeps `sigil run` (daemon) and `sigil-hook` (enforce) from being silently
+# granted to the agent (Claude Code evaluates deny before allow).
+$SigilAllowRule = 'Bash(sigil:*)'
+$SigilDenyRules = @('Bash(sigil run:*)', 'Bash(sigil-hook:*)')
+
+function Get-ClaudeSettingsPath { Join-Path $env:USERPROFILE '.claude\settings.json' }
+
+function Show-AllowlistSnippet {
+  $s = Get-ClaudeSettingsPath
+  [Console]::Error.WriteLine(@"
+sigil-install: to stop your AI agent prompting on every sigil command, add this
+sigil-install: read-only allowlist to $s ('sigil run'/'sigil-hook' stay denied):
+
+  { "permissions": {
+      "allow": ["$SigilAllowRule"],
+      "deny": ["Bash(sigil run:*)", "Bash(sigil-hook:*)"]
+  } }
+"@)
+}
+
+# Idempotent, order-preserving merge into permissions.allow/deny via native JSON.
+function Merge-SigilAllowlist($path) {
+  $dir = Split-Path -Parent $path
+  if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+  $cfg = $null
+  if (Test-Path $path) {
+    $raw = Get-Content -Raw -Path $path -ErrorAction SilentlyContinue
+    if ($raw -and $raw.Trim()) { try { $cfg = $raw | ConvertFrom-Json } catch { $cfg = $null } }
+  }
+  if ($null -eq $cfg) { $cfg = [pscustomobject]@{} }
+  if (-not $cfg.PSObject.Properties['permissions'] -or $null -eq $cfg.permissions) {
+    $cfg | Add-Member -NotePropertyName permissions -NotePropertyValue ([pscustomobject]@{}) -Force
+  }
+  $perm = $cfg.permissions
+  if (-not $perm.PSObject.Properties['allow']) { $perm | Add-Member -NotePropertyName allow -NotePropertyValue @() }
+  if (-not $perm.PSObject.Properties['deny'])  { $perm | Add-Member -NotePropertyName deny  -NotePropertyValue @() }
+  $a = @($perm.allow); if ($a -notcontains $SigilAllowRule) { $a += $SigilAllowRule }; $perm.allow = $a
+  $dn = @($perm.deny); foreach ($r in $SigilDenyRules) { if ($dn -notcontains $r) { $dn += $r } }; $perm.deny = $dn
+  $json = $cfg | ConvertTo-Json -Depth 10
+  # PS 5.1 unwraps single-element arrays on serialize; force allow/deny to arrays.
+  $json = [regex]::Replace($json, '("(?:allow|deny)"\s*:\s*)("(?:[^"\\]|\\.)*")(\s*[,\r\n}])', '$1[$2]$3')
+  Set-Content -Path $path -Value $json -Encoding UTF8
+}
+
+function Invoke-AllowlistOffer {
+  if ($profileName -ne 'personal') { return }
+  $s = Get-ClaudeSettingsPath
+  if (-not [Environment]::UserInteractive) { Show-AllowlistSnippet; return }
+  [Console]::Error.Write("sigil-install: add a read-only sigil allowlist to $s so your AI agent doesn't prompt on every sigil command? ('sigil run'/'sigil-hook' stay denied) [y/N] ")
+  $ans = Read-Host
+  if ($ans -match '^(y|yes)$') {
+    try {
+      Merge-SigilAllowlist $s
+      Say "added read-only sigil allowlist to $s (allow Bash(sigil:*); deny sigil run + sigil-hook)"
+    } catch {
+      Say "could not edit $s; add the allowlist manually:"; Show-AllowlistSnippet
+    }
+  } else {
+    Say "skipped the allowlist; add it later if you want:"; Show-AllowlistSnippet
+  }
+}
+
+# dry-run hook: show what the offer would add (personal) without prompt/edit.
+if ($env:SIGIL_ALLOWLIST_DRYRUN -eq '1') {
+  if ($profileName -eq 'personal') { Show-AllowlistSnippet }
+  else { [Console]::Error.WriteLine("allowlist offer: skipped (profile=$profileName)") }
+  exit 0
+}
+
 # --- detect platform -------------------------------------------------------
 # SIGIL_ARCH_OVERRIDE lets the tests drive arch detection without spoofing the
 # OS; unset in normal use. Values match RuntimeInformation.OSArchitecture.
@@ -167,3 +238,6 @@ try {
 } finally {
   Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }
+
+# #188 — personal profile only: opt-in Claude Code allowlist (defined above).
+Invoke-AllowlistOffer

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,89 @@ if [ "${SIGIL_PROFILE_DRYRUN:-}" = "1" ]; then
   exit 0
 fi
 
+# --- #188: personal-profile Claude Code allowlist offer ---------------------
+# An AI agent (Claude Code) driving sigil improvises flagged commands, so each
+# distinct command string is a fresh approval and "don't ask again" never
+# sticks. Offer (opt-in) to add a read-only allowlist to ~/.claude/settings.json.
+# Broad `Bash(sigil:*)` allow kills the prompt storm; an explicit deny keeps the
+# privileged `sigil run` (daemon) and `sigil-hook` (enforce) from being silently
+# granted to the agent — Claude Code evaluates deny before allow, so deny wins.
+SIGIL_ALLOW_RULE='Bash(sigil:*)'
+
+claude_settings_path() { printf '%s/.claude/settings.json' "$HOME"; }
+
+print_allowlist_snippet() {
+  _s="$(claude_settings_path)"
+  cat >&2 <<EOF
+sigil-install: to stop your AI agent prompting on every sigil command, add this
+sigil-install: read-only allowlist to $_s ('sigil run'/'sigil-hook' stay denied):
+
+  { "permissions": {
+      "allow": ["$SIGIL_ALLOW_RULE"],
+      "deny": ["Bash(sigil run:*)", "Bash(sigil-hook:*)"]
+  } }
+
+sigil-install: with jq (creates the file if missing):
+  S="$_s"; mkdir -p "\$(dirname "\$S")"; [ -f "\$S" ] || echo '{}' > "\$S"; \\
+  jq '.permissions.allow=((.permissions.allow//[])+["$SIGIL_ALLOW_RULE"]-(.permissions.allow//[])) | .permissions.deny=((.permissions.deny//[])+["Bash(sigil run:*)","Bash(sigil-hook:*)"]-(.permissions.deny//[]))' "\$S" > "\$S.tmp" && mv "\$S.tmp" "\$S"
+EOF
+}
+
+# Idempotent, order-preserving merge into permissions.allow/deny via jq.
+merge_allowlist() {
+  _s="$1"
+  mkdir -p "$(dirname "$_s")" || return 1
+  _existing='{}'
+  [ -f "$_s" ] && _existing="$(cat "$_s")"
+  printf '%s' "$_existing" | jq \
+    --arg allow "$SIGIL_ALLOW_RULE" \
+    '.permissions = (.permissions // {})
+     | .permissions.allow = ((.permissions.allow // []) + ([$allow] - (.permissions.allow // [])))
+     | .permissions.deny  = ((.permissions.deny  // []) + (["Bash(sigil run:*)","Bash(sigil-hook:*)"] - (.permissions.deny // [])))' \
+    > "$_s.tmp.$$" 2>/dev/null && mv "$_s.tmp.$$" "$_s"
+}
+
+offer_claude_allowlist() {
+  [ "$PROFILE" = "personal" ] || return 0
+  _s="$(claude_settings_path)"
+  # Consent needs a real terminal. curl | sh has no stdin TTY, so read /dev/tty;
+  # if there's no controlling terminal (CI/cron), never edit — just print.
+  if ! { exec 3</dev/tty; } 2>/dev/null; then
+    print_allowlist_snippet
+    return 0
+  fi
+  printf 'sigil-install: add a read-only sigil allowlist to %s so your AI agent\n' "$_s" >&2
+  printf "sigil-install: doesn't prompt on every sigil command? ('sigil run'/'sigil-hook' stay denied) [y/N] " >&2
+  _ans=''
+  read -r _ans <&3 || _ans=''
+  exec 3<&- 2>/dev/null || true
+  case "$_ans" in
+    y | Y | yes | YES)
+      if ! command -v jq >/dev/null 2>&1; then
+        say "jq not found ($(pkg_hint jq)); add the allowlist manually:"
+        print_allowlist_snippet
+      elif merge_allowlist "$_s"; then
+        say "added read-only sigil allowlist to $_s (allow Bash(sigil:*); deny sigil run + sigil-hook)"
+      else
+        say "could not edit $_s; add the allowlist manually:"
+        print_allowlist_snippet
+      fi
+      ;;
+    *) say "skipped the allowlist; add it later if you want:" && print_allowlist_snippet ;;
+  esac
+}
+
+# dry-run hook: show what the allowlist offer would add (personal) without any
+# prompt/edit. Used by tests/install_profile_test.sh.
+if [ "${SIGIL_ALLOWLIST_DRYRUN:-}" = "1" ]; then
+  if [ "$PROFILE" = "personal" ]; then
+    print_allowlist_snippet
+  else
+    printf 'allowlist offer: skipped (profile=%s)\n' "$PROFILE" >&2
+  fi
+  exit 0
+fi
+
 # --- tooling ---------------------------------------------------------------
 # Minimal RHEL-family / container images often ship without `tar` (and even
 # `curl`); a bare "missing required tool" leaves the user guessing. Suggest the
@@ -175,3 +258,6 @@ case ":$PATH:" in
   *) say "note: add $INSTALL_DIR to your PATH to run 'sigil' directly" ;;
 esac
 say "next: sigil doctor"
+
+# #188 — personal profile only: opt-in Claude Code allowlist (defined above).
+offer_claude_allowlist

--- a/tests/install_profile_test.ps1
+++ b/tests/install_profile_test.ps1
@@ -85,4 +85,46 @@ if ($LASTEXITCODE -eq 0) { Write-Host 'FAIL: SIGIL_BASE_URL without SIGIL_VERSIO
 else { Write-Host 'ok: SIGIL_BASE_URL requires SIGIL_VERSION' }
 Remove-Item Env:SIGIL_ARCH_OVERRIDE, Env:SIGIL_BASE_URL, Env:SIGIL_URL_DRYRUN -ErrorAction SilentlyContinue
 
+# #188 — Claude allowlist offer (personal only), via SIGIL_ALLOWLIST_DRYRUN.
+function Allowlist-Snip($prof) {
+  $env:SIGIL_PROFILE = $prof; $env:SIGIL_ALLOWLIST_DRYRUN = '1'
+  try { (& pwsh -NoProfile -File $ps1 2>&1 | Out-String) } finally {
+    Remove-Item Env:SIGIL_PROFILE, Env:SIGIL_ALLOWLIST_DRYRUN -ErrorAction SilentlyContinue
+  }
+}
+$snip = Allowlist-Snip 'personal'
+if ($snip -match '"allow": \["Bash\(sigil:\*\)"\]' -and $snip -match 'Bash\(sigil run:\*\)' -and $snip -match 'Bash\(sigil-hook:\*\)') {
+  Write-Host 'ok: personal allowlist snippet (broad allow + deny run/hook)'
+} else { Write-Host 'FAIL: personal allowlist snippet missing expected rules'; Write-Host $snip; $fail = 1 }
+$fsnip = Allowlist-Snip 'fleet'
+if ($fsnip -match 'skipped \(profile=fleet\)') { Write-Host 'ok: fleet profile does not offer allowlist' }
+else { Write-Host 'FAIL: fleet should skip the allowlist offer'; $fail = 1 }
+
+# #188 — Merge-SigilAllowlist must be idempotent, order-preserving, non-clobbering.
+# Dot-source only the function block by extracting it is overkill; instead exercise
+# the same native-JSON merge logic the installer uses, asserting array output.
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $td | Out-Null
+$sj = Join-Path $td 'settings.json'
+'{"permissions":{"allow":["Bash(ls:*)"]},"keep":1}' | Set-Content -Path $sj -Encoding UTF8
+$merge = {
+  param($path)
+  $cfg = (Get-Content -Raw $path | ConvertFrom-Json)
+  if (-not $cfg.PSObject.Properties['permissions']) { $cfg | Add-Member -NotePropertyName permissions -NotePropertyValue ([pscustomobject]@{}) -Force }
+  $perm = $cfg.permissions
+  if (-not $perm.PSObject.Properties['allow']) { $perm | Add-Member -NotePropertyName allow -NotePropertyValue @() }
+  if (-not $perm.PSObject.Properties['deny'])  { $perm | Add-Member -NotePropertyName deny  -NotePropertyValue @() }
+  $a = @($perm.allow); if ($a -notcontains 'Bash(sigil:*)') { $a += 'Bash(sigil:*)' }; $perm.allow = $a
+  $dn = @($perm.deny); foreach ($r in @('Bash(sigil run:*)','Bash(sigil-hook:*)')) { if ($dn -notcontains $r) { $dn += $r } }; $perm.deny = $dn
+  $json = $cfg | ConvertTo-Json -Depth 10
+  $json = [regex]::Replace($json, '("(?:allow|deny)"\s*:\s*)("(?:[^"\\]|\\.)*")(\s*[,\r\n}])', '$1[$2]$3')
+  Set-Content -Path $path -Value $json -Encoding UTF8
+}
+& $merge $sj; & $merge $sj   # twice → idempotent
+$res = (Get-Content -Raw $sj | ConvertFrom-Json)
+if (@($res.permissions.allow).Count -eq 2 -and @($res.permissions.deny).Count -eq 2 -and $res.keep -eq 1 -and @($res.permissions.allow)[0] -eq 'Bash(ls:*)') {
+  Write-Host 'ok: native merge idempotent + preserves existing allow/keys'
+} else { Write-Host "FAIL: native merge (allow=$(@($res.permissions.allow).Count) deny=$(@($res.permissions.deny).Count))"; $fail = 1 }
+Remove-Item -Recurse -Force $td -ErrorAction SilentlyContinue
+
 exit $fail

--- a/tests/install_profile_test.sh
+++ b/tests/install_profile_test.sh
@@ -56,4 +56,32 @@ if SIGIL_UNAME_S=Linux SIGIL_UNAME_M=x86_64 \
   echo "FAIL: SIGIL_BASE_URL without SIGIL_VERSION should exit non-zero"; fail=1
 else echo "ok: SIGIL_BASE_URL requires SIGIL_VERSION"; fi
 
+# #188 — Claude allowlist offer (personal only), via SIGIL_ALLOWLIST_DRYRUN.
+snip="$(SIGIL_PROFILE=personal SIGIL_ALLOWLIST_DRYRUN=1 sh "$SH" 2>&1)"
+case "$snip" in
+  *'"allow": ["Bash(sigil:*)"]'*'Bash(sigil run:*)'*'Bash(sigil-hook:*)'*)
+    echo "ok: personal allowlist snippet (broad allow + deny run/hook)" ;;
+  *) echo "FAIL: personal allowlist snippet missing expected rules"; printf '%s\n' "$snip"; fail=1 ;;
+esac
+fleet_snip="$(SIGIL_PROFILE=fleet SIGIL_ALLOWLIST_DRYRUN=1 sh "$SH" 2>&1)"
+case "$fleet_snip" in
+  *"skipped (profile=fleet)"*) echo "ok: fleet profile does not offer allowlist" ;;
+  *) echo "FAIL: fleet should skip the allowlist offer"; fail=1 ;;
+esac
+
+# #188 — the jq merge must be idempotent + order-preserving + non-clobbering.
+if command -v jq >/dev/null 2>&1; then
+  jqd="$(mktemp -d)"; sj="$jqd/settings.json"
+  echo '{"permissions":{"allow":["Bash(ls:*)"]},"keep":1}' > "$sj"
+  JQM='.permissions = (.permissions // {}) | .permissions.allow = ((.permissions.allow // []) + (["Bash(sigil:*)"] - (.permissions.allow // []))) | .permissions.deny = ((.permissions.deny // []) + (["Bash(sigil run:*)","Bash(sigil-hook:*)"] - (.permissions.deny // [])))'
+  jq "$JQM" "$sj" > "$sj.t" && mv "$sj.t" "$sj"
+  jq "$JQM" "$sj" > "$sj.t" && mv "$sj.t" "$sj"   # twice → idempotent
+  a="$(jq '.permissions.allow|length' "$sj")"; d="$(jq '.permissions.deny|length' "$sj")"; k="$(jq -r '.keep' "$sj")"
+  first="$(jq -r '.permissions.allow[0]' "$sj")"
+  if [ "$a" = 2 ] && [ "$d" = 2 ] && [ "$k" = 1 ] && [ "$first" = "Bash(ls:*)" ]; then
+    echo "ok: jq merge idempotent + preserves existing allow/keys"
+  else echo "FAIL: jq merge (allow=$a deny=$d keep=$k first=$first)"; fail=1; fi
+  rm -rf "$jqd"
+else echo "ok: jq absent — merge test skipped"; fi
+
 exit $fail


### PR DESCRIPTION
Closes #188.

## Problem
Driving sigil from inside an AI agent (Claude Code) causes a per-command **permission-prompt storm**: the agent improvises flagged `sigil` commands (`sigil --policy x --state-db y doctor`), so each distinct string is a fresh approval and "don't ask again" (exact-match) never sticks.

## Fix — opt-in read-only allowlist (approach c)
Personal `install.sh` / `install.ps1` **offer** to add to `~/.claude/settings.json`:

    { "permissions": {
        "allow": ["Bash(sigil:*)"],
        "deny": ["Bash(sigil run:*)", "Bash(sigil-hook:*)"]
    } }

Broad `Bash(sigil:*)` allow kills the storm even for improvised flagged forms; the explicit **deny** keeps `sigil run` (daemon) + `sigil-hook` (enforce) from being silently granted (Claude Code evaluates deny before allow). A posture tool editing agent config must be opt-in, read-only-scoped, transparent.

- **Personal only** — fleet never offers.
- **Consent on a real terminal**: `/dev/tty` under `curl|sh`, `Read-Host` under `irm|iex`. No terminal => print snippet, never edit silently.
- **Safe merge**: jq (sh) / native JSON (ps1) — idempotent, order-preserving, non-clobbering; missing jq/file => print-only fallback (+ pkg hint).
- `SIGIL_ALLOWLIST_DRYRUN` test hook; `docs/install-personal.md` documents it.

## Verification
- `shellcheck install.sh` clean; `install_profile_test.sh` green — snippet content, fleet-skip, jq merge idempotency/no-clobber.
- **Real Windows PowerShell 5.1** (.147): personal dry-run snippet, fleet-skip, native-JSON merge incl. the single-element-array regex fix (PS 5.1 unwraps 1-element arrays on serialize) — confirmed `"allow": [...]` renders as an array.
- No Rust changes (install scripts + docs only); fleet install path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
