### PR TITLE
feat(scan): advisory remediation hints per finding (#188-followup A)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/mod.rs
+++ b/crates/sigil-agent/src/ai_guard/mod.rs
@@ -9,6 +9,7 @@ pub mod assess;
 pub mod command_scan;
 pub mod ext_script;
 pub mod parser;
+pub mod remediation;
 pub mod rubric;
 pub mod rule_pack;
 pub mod task;

--- a/crates/sigil-agent/src/ai_guard/remediation.rs
+++ b/crates/sigil-agent/src/ai_guard/remediation.rs
@@ -1,0 +1,85 @@
+//! #188-followup A — one-line, advisory remediation hints per AI-Guard reason.
+//! Turns a `sigil scan` score into action: each finding maps to a short "how to
+//! reduce it" line. Advisory only — Sigil measures, it does not block or
+//! auto-edit, so hints suggest, never act.
+//!
+//! `hint_for_reason` matches the `AiGuardReason` variant directly (not its wire
+//! `kind` string), so the exhaustive match makes a new reason variant fail to
+//! compile here until it has a hint — the same drift guard `rubric::kind_key`
+//! and `tool_cli_label` use. Hints are general per variant (one line), so a
+//! finding's distinguishing fields don't change the guidance.
+
+use sigil_core::event::AiGuardReason;
+
+/// Advisory one-liner for a finding. Always non-empty.
+pub fn hint_for_reason(reason: &AiGuardReason) -> &'static str {
+    use AiGuardReason::*;
+    match reason {
+        DestructiveInInlineCommand { .. } => {
+            "A hook runs a destructive shell command inline — review and remove it."
+        }
+        DestructiveInHookScript { .. } => {
+            "A hook script contains a destructive pattern — review the referenced script."
+        }
+        SandboxDisabled => {
+            "The sandbox is disabled — restore a non-bypass sandbox mode in the tool's config."
+        }
+        NoSandbox { .. } => {
+            "The agent runs with no sandbox boundary — enable the tool's sandbox or limit what it can run."
+        }
+        PermissionsAllowBroad { .. } => {
+            "A wildcard allow rule grants broad tool access — narrow it to specific commands."
+        }
+        ExternalScriptUnscanned { .. } => {
+            "A hook calls an external script Sigil can't read — review it, or keep hook scripts in the convention dir."
+        }
+        BroadMatcher { .. } => {
+            "A broad hook matcher catches most or all tool calls — scope it to specific tools."
+        }
+        PermissionsDenyEmpty => {
+            "The deny list is empty — add deny rules so permissions actually block something."
+        }
+        McpServerRemote { .. } => {
+            "A remote MCP server is configured — confirm you trust the endpoint and what it can see."
+        }
+        McpServerLocalCommand { .. } => {
+            "An MCP server auto-launches a local command — review or remove it, or run it sandboxed."
+        }
+        TrustedMcpServer { .. } => {
+            "An MCP server is marked trusted (skips per-tool confirmation) — remove the trust flag unless required."
+        }
+        AutoApprovalEnabled { .. } => {
+            "Auto-approval is on — turn it off so tool calls require confirmation."
+        }
+        McpServerSuspiciousLauncher { .. } => {
+            "An MCP server uses a suspicious launcher (shell exec or a transient/writable path) — pin it to a trusted binary."
+        }
+        ProjectMcpAutoEnabled { .. } => {
+            "Project MCP servers auto-launch on folder-trust — disable project-MCP autorun."
+        }
+        InstructionFileDirective { .. } => {
+            "An instruction file contains a flagged directive (fetch-pipe, destructive, obfuscated, or an override marker) — review it for prompt injection."
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hints_are_nonempty_and_specific() {
+        // A representative sample across the field-bearing and unit variants;
+        // the exhaustive match in hint_for_reason guarantees the rest compile.
+        let samples = [
+            AiGuardReason::SandboxDisabled,
+            AiGuardReason::PermissionsDenyEmpty,
+            AiGuardReason::AutoApprovalEnabled {
+                mode: "auto_edit".into(),
+            },
+        ];
+        for r in &samples {
+            assert!(!hint_for_reason(r).is_empty());
+        }
+    }
+}

--- a/crates/sigil-agent/src/scan_cli.rs
+++ b/crates/sigil-agent/src/scan_cli.rs
@@ -197,14 +197,19 @@ fn round1(x: f32) -> f64 {
     (x as f64 * 10.0).round() / 10.0
 }
 
+/// The serde `kind` tag of a single reason (e.g. "no_sandbox").
+fn reason_kind(reason: &AiGuardReason) -> String {
+    serde_json::to_value(reason)
+        .ok()
+        .and_then(|v| v.get("kind").and_then(|k| k.as_str()).map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 /// Distinct reason kinds (the serde `kind` tag) for a row, in first-seen order.
 fn reason_kinds(reasons: &[AiGuardReason]) -> Vec<String> {
     let mut seen: Vec<String> = Vec::new();
     for r in reasons {
-        let kind = serde_json::to_value(r)
-            .ok()
-            .and_then(|v| v.get("kind").and_then(|k| k.as_str()).map(str::to_string))
-            .unwrap_or_else(|| "unknown".to_string());
+        let kind = reason_kind(r);
         if !seen.contains(&kind) {
             seen.push(kind);
         }
@@ -317,6 +322,27 @@ fn render_human(report: &Report) -> String {
     }
 
     if !report.rows.is_empty() {
+        // How to reduce: the distinct finding kinds across all rows (rows are
+        // score-descending, so higher-impact fixes surface first), each with a
+        // one-line advisory hint. Advisory only — Sigil suggests, never edits.
+        // Keyed by the wire `kind` for the label; the hint comes from the reason
+        // variant (general per variant), so per-kind dedup is unambiguous.
+        let mut seen: Vec<(String, &'static str)> = Vec::new();
+        for r in &report.rows {
+            for reason in &r.reasons {
+                let kind = reason_kind(reason);
+                if kind != "unknown" && !seen.iter().any(|(k, _)| k == &kind) {
+                    seen.push((kind, crate::ai_guard::remediation::hint_for_reason(reason)));
+                }
+            }
+        }
+        if !seen.is_empty() {
+            let kcol = seen.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
+            let _ = writeln!(out, "\nHow to reduce");
+            for (kind, hint) in &seen {
+                let _ = writeln!(out, "  {kind:<kcol$}  {hint}");
+            }
+        }
         let _ = writeln!(out, "\nRun `sigil scan --json` for full detail.");
     }
     out
@@ -337,7 +363,20 @@ fn report_json(report: &Report) -> serde_json::Value {
             "scope": scope_str(&r.scope),
             "score": round1(r.score),
             "bucket": bucket_wire(r.bucket),
-            "reasons": r.reasons,
+            // Each reason is the serialized AiGuardReason with an advisory
+            // `hint` derived from the reason variant (#188-followup A).
+            "reasons": r.reasons.iter().map(|reason| {
+                let mut v = serde_json::to_value(reason).unwrap_or(serde_json::Value::Null);
+                if let Some(obj) = v.as_object_mut() {
+                    obj.insert(
+                        "hint".to_string(),
+                        serde_json::Value::String(
+                            crate::ai_guard::remediation::hint_for_reason(reason).to_string(),
+                        ),
+                    );
+                }
+                v
+            }).collect::<Vec<_>>(),
         })).collect::<Vec<_>>(),
         "not_configured": report.not_configured.iter()
             .map(|t| tool_cli_label(*t)).collect::<Vec<_>>(),

--- a/crates/sigil-agent/tests/scan.rs
+++ b/crates/sigil-agent/tests/scan.rs
@@ -113,3 +113,45 @@ fn human_output_has_headline_and_not_configured_footer() {
     assert!(out.contains("Sigil scan —"), "{out}");
     assert!(out.contains("tools not configured"), "{out}");
 }
+
+#[test]
+fn remediation_hint_in_json_and_human_for_a_finding() {
+    // #188-followup A — a local-command MCP finding must carry an advisory hint
+    // in --json (per reason) and surface in the human "How to reduce" section.
+    let home = tempdir().unwrap();
+    write(
+        &home.path().join(".cursor").join("mcp.json"),
+        r#"{"mcpServers":{"x":{"command":"npx","args":["-y","evil"]}}}"#,
+    );
+
+    let v = report_json_for(home.path(), None);
+    let cursor = v["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["tool"] == "cursor")
+        .expect("cursor row present");
+    let reason = cursor["reasons"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["kind"] == "mcp_server_local_command")
+        .expect("local-command reason present");
+    let hint = reason["hint"].as_str().expect("reason has a hint field");
+    assert!(
+        hint.contains("auto-launches a local command"),
+        "hint: {hint}"
+    );
+
+    let out = render_human_for(home.path(), None);
+    assert!(out.contains("How to reduce"), "{out}");
+    assert!(out.contains("auto-launches a local command"), "{out}");
+}
+
+#[test]
+fn no_how_to_reduce_section_when_clean() {
+    // Empty HOME ⇒ no rows ⇒ no "How to reduce" section.
+    let home = tempdir().unwrap();
+    let out = render_human_for(home.path(), None);
+    assert!(!out.contains("How to reduce"), "{out}");
+}


### PR DESCRIPTION
Personal-domain utility: turn `sigil scan` from "here's your score" into "here's what to do about it."

## What
Every finding now carries a one-line **advisory remediation hint**:

- **human**: a `How to reduce` section after the table lists the distinct finding kinds (highest-score rows first), each with its hint. Omitted when the scan is clean.
- **`--json`**: each reason gains a `hint` field.

```
How to reduce
  no_sandbox                The agent runs with no sandbox boundary — enable the tool's sandbox or limit what it can run.
  broad_matcher             A broad hook matcher catches most or all tool calls — scope it to specific tools.
  permissions_deny_empty    The deny list is empty — add deny rules so permissions actually block something.
  mcp_server_local_command  An MCP server auto-launches a local command — review or remove it, or run it sandboxed.
```

## How
`remediation::hint_for_reason(&AiGuardReason)` is an **exhaustive match on the reason variant** — a new variant fails to compile until it has a hint (same drift guard as `rubric::kind_key` / `tool_cli_label`). Matching the variant (not its wire `kind` string) also sidesteps the serde-tag vs `kind_key` split (e.g. `broad_matcher`), which a string-keyed map got wrong.

Hints are **general per variant** (one line). **Advisory only** — Sigil measures, it does not block or auto-edit, so hints suggest, never act (consistent with the project's stance). No `--fix`, no config editing.

## Verification
- `cargo fmt` + `clippy --all-targets -D warnings` clean; full `cargo test --workspace` 0 failures.
- New tests: scan integration (hint present in `--json` + human `How to reduce`; section absent when clean) + a remediation unit test. Smoke-checked against this machine's real config.

## Scope
`sigil scan` only (the daemon/`show risk` can reuse `hint_for_reason` later). No new parser, no daemon change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
