### PR TITLE
feat(ai-guard): flag autonomous/unattended Claude Code config (#191 Phase 1)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -25,6 +25,9 @@ impl AiGuardParser for ClaudeCodeParser {
             home_dir.join(".claude").join("settings.local.json"),
             home_dir.join(".claude").join("hooks"),
             home_dir.join(".claude").join("CLAUDE.md"),
+            // #191 — watch the scheduled-tasks dir so the daemon re-assesses
+            // when an unattended task appears/changes (OFF->ON drift).
+            home_dir.join(".claude").join("scheduled-tasks"),
         ]
     }
 
@@ -56,7 +59,13 @@ impl AiGuardParser for ClaudeCodeParser {
         let local = super::read_json_optional(&local_path)?;
 
         // Missing primary file with no overlay → operator hasn't enabled tool.
-        if base.is_none() && local.is_none() && !claude.join("CLAUDE.md").is_file() {
+        // #191 — a `scheduled-tasks/` dir alone is still evidence of use, so it
+        // must not be short-circuited by this "tool not enabled" guard.
+        if base.is_none()
+            && local.is_none()
+            && !claude.join("CLAUDE.md").is_file()
+            && !claude.join("scheduled-tasks").is_dir()
+        {
             return Ok(Vec::new());
         }
 
@@ -66,6 +75,10 @@ impl AiGuardParser for ClaudeCodeParser {
         let mut out = Vec::new();
         emit_hook_reasons(&merged, &hooks_dir, &mut out)?;
         emit_permission_reasons(&merged, &mut out);
+        // #191 signal 1 — `permissions.defaultMode` auto-approval posture.
+        emit_default_mode_reason(&merged, &mut out);
+        // #191 signal 2 — unattended recurring Claude Code scheduled tasks.
+        emit_scheduled_task_reasons(&claude, &mut out);
         emit_mcp_reasons(&merged, &mut out);
         // #145 (codex C8) — a user-global `enableAllProjectMcpServers: true`
         // blanket-approves project MCP servers across EVERY repo. No single
@@ -304,6 +317,81 @@ pub(crate) fn emit_permission_reasons(settings: &Value, out: &mut Vec<AiGuardRea
                 }
             }
         }
+    }
+}
+
+/// #191 signal 1 — `permissions.defaultMode` in `~/.claude/settings.json` sets
+/// the standing auto-approval posture. `"auto"`, `"bypassPermissions"`, and
+/// `"acceptEdits"` all approve tool calls without a human prompt, so each is an
+/// auto-approval posture reusing the existing `AutoApprovalEnabled` reason
+/// (which already flows into scan / #147 drift / remediation hints / rubric).
+/// `"dontAsk"` is deliberately excluded: it only runs PRE-APPROVED tools, so it
+/// is not a blanket auto-approval. `mode` carries the raw config value verbatim.
+pub(crate) fn emit_default_mode_reason(settings: &Value, out: &mut Vec<AiGuardReason>) {
+    let Some(mode) = settings
+        .get("permissions")
+        .and_then(|p| p.get("defaultMode"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    if matches!(mode, "auto" | "bypassPermissions" | "acceptEdits") {
+        out.push(AiGuardReason::AutoApprovalEnabled {
+            mode: mode.to_string(),
+        });
+    }
+}
+
+/// Max number of `UnattendedScheduledTask` reasons emitted per assessment, to
+/// bound output; tasks beyond this are logged and ignored.
+const MAX_SCHEDULED_TASK_REASONS: usize = 20;
+
+/// #191 signal 2 — an unattended, recurring Claude Code task is configured when
+/// `<home>/.claude/scheduled-tasks/<name>/SKILL.md` exists. This is the
+/// readable, persistent equivalent of an autonomous loop/goal. Emits one
+/// `UnattendedScheduledTask { name }` per task subdir that carries a `SKILL.md`
+/// (`name` = the subdir name), capped at `MAX_SCHEDULED_TASK_REASONS`.
+///
+/// `claude_dir` is the parser's configured `<home>/.claude` (temp home in
+/// tests) — never a hardcoded `~`.
+pub(crate) fn emit_scheduled_task_reasons(claude_dir: &Path, out: &mut Vec<AiGuardReason>) {
+    let sched_dir = claude_dir.join("scheduled-tasks");
+    let entries = match std::fs::read_dir(&sched_dir) {
+        Ok(e) => e,
+        // Absent dir (the common case) or unreadable → no findings.
+        Err(_) => return,
+    };
+    // Sort task names for deterministic emission order across platforms.
+    let mut names: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_md = path.join("SKILL.md");
+        // Phase 2 (#191): analyze SKILL.md content via InstructionFileDirective
+        // (prompts that read files / pipe to shell / run repeated destructive
+        // shell). For now, presence of the file is the signal; `skill_md` is
+        // the path Phase 2 will feed to content analysis.
+        if !skill_md.is_file() {
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            names.push(name.to_string());
+        }
+    }
+    names.sort();
+    let total = names.len();
+    for name in names.into_iter().take(MAX_SCHEDULED_TASK_REASONS) {
+        out.push(AiGuardReason::UnattendedScheduledTask { name });
+    }
+    if total > MAX_SCHEDULED_TASK_REASONS {
+        tracing::warn!(
+            dir = %sched_dir.display(),
+            total,
+            cap = MAX_SCHEDULED_TASK_REASONS,
+            "claude scheduled-tasks: capping UnattendedScheduledTask reasons"
+        );
     }
 }
 
@@ -1338,6 +1426,182 @@ mod tests {
                 .any(|r| matches!(r, AiGuardReason::InstructionFileDirective { .. })),
             "got {out:?}"
         );
+    }
+
+    // ---- #191 signal 1: permissions.defaultMode auto-approval ----
+
+    fn default_mode_reasons(mode_json: &str) -> Vec<AiGuardReason> {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            &format!(r#"{{"permissions": {{"defaultMode": {mode_json}}}}}"#),
+        );
+        ClaudeCodeParser.assess(dir.path()).unwrap()
+    }
+
+    #[test]
+    fn default_mode_bypass_permissions_emits_auto_approval_with_raw_mode() {
+        let reasons = default_mode_reasons(r#""bypassPermissions""#);
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::AutoApprovalEnabled { mode } if mode == "bypassPermissions"
+            )),
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn default_mode_auto_and_accept_edits_emit_auto_approval() {
+        for m in ["auto", "acceptEdits"] {
+            let reasons = default_mode_reasons(&format!("\"{m}\""));
+            assert!(
+                reasons.iter().any(|r| matches!(
+                    r,
+                    AiGuardReason::AutoApprovalEnabled { mode } if mode == m
+                )),
+                "mode {m}: got {reasons:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_mode_dont_ask_does_not_emit_auto_approval() {
+        // "dontAsk" only runs pre-approved tools — not a blanket auto-approval.
+        let reasons = default_mode_reasons(r#""dontAsk""#);
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })),
+            "dontAsk must not emit auto-approval; got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn absent_default_mode_does_not_emit_auto_approval() {
+        let dir = tempdir().unwrap();
+        write_settings(dir.path(), r#"{"permissions": {"allow": ["Read"]}}"#);
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    // ---- #191 signal 2: unattended scheduled tasks ----
+
+    #[test]
+    fn scheduled_task_with_skill_md_emits_one_unattended_reason() {
+        let dir = tempdir().unwrap();
+        write_file(
+            &dir.path().join(".claude"),
+            "scheduled-tasks/mytask/SKILL.md",
+            "# do stuff\n",
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        let names: Vec<&str> = reasons
+            .iter()
+            .filter_map(|r| match r {
+                AiGuardReason::UnattendedScheduledTask { name } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["mytask"], "got {reasons:?}");
+    }
+
+    #[test]
+    fn scheduled_tasks_absent_dir_emits_none() {
+        let dir = tempdir().unwrap();
+        write_settings(dir.path(), r#"{"permissions": {"deny": ["Bash"]}}"#);
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::UnattendedScheduledTask { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn scheduled_tasks_subdir_without_skill_md_emits_none() {
+        let dir = tempdir().unwrap();
+        // An empty task subdir (no SKILL.md) is not an unattended task.
+        std::fs::create_dir_all(
+            dir.path()
+                .join(".claude")
+                .join("scheduled-tasks")
+                .join("empty"),
+        )
+        .unwrap();
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::UnattendedScheduledTask { .. })),
+            "empty scheduled-tasks subdir must emit nothing; got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn scheduled_tasks_alone_are_not_short_circuited_by_missing_settings() {
+        // A `scheduled-tasks/` dir with no settings.json / CLAUDE.md must still
+        // be assessed (the "tool not enabled" guard must not swallow it).
+        let dir = tempdir().unwrap();
+        write_file(
+            &dir.path().join(".claude"),
+            "scheduled-tasks/loop/SKILL.md",
+            "# loop\n",
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::UnattendedScheduledTask { name } if name == "loop"
+            )),
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn scheduled_tasks_multiple_are_all_emitted() {
+        let dir = tempdir().unwrap();
+        for t in ["alpha", "beta", "gamma"] {
+            write_file(
+                &dir.path().join(".claude"),
+                &format!("scheduled-tasks/{t}/SKILL.md"),
+                "# x\n",
+            );
+        }
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        let mut names: Vec<&str> = reasons
+            .iter()
+            .filter_map(|r| match r {
+                AiGuardReason::UnattendedScheduledTask { name } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["alpha", "beta", "gamma"], "got {reasons:?}");
+    }
+
+    #[test]
+    fn scheduled_tasks_capped_at_20() {
+        let dir = tempdir().unwrap();
+        for i in 0..25 {
+            write_file(
+                &dir.path().join(".claude"),
+                &format!("scheduled-tasks/task{i:02}/SKILL.md"),
+                "# x\n",
+            );
+        }
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        let n = reasons
+            .iter()
+            .filter(|r| matches!(r, AiGuardReason::UnattendedScheduledTask { .. }))
+            .count();
+        assert_eq!(n, 20, "must cap at 20; got {n}");
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -59,12 +59,13 @@ impl AiGuardParser for ClaudeCodeParser {
         let local = super::read_json_optional(&local_path)?;
 
         // Missing primary file with no overlay → operator hasn't enabled tool.
-        // #191 — a `scheduled-tasks/` dir alone is still evidence of use, so it
-        // must not be short-circuited by this "tool not enabled" guard.
+        // #191 — a real unattended task (a `scheduled-tasks/<name>/SKILL.md`) is
+        // still evidence of use, so it must not be short-circuited here. An empty
+        // `scheduled-tasks/` dir is NOT evidence and stays short-circuited.
         if base.is_none()
             && local.is_none()
             && !claude.join("CLAUDE.md").is_file()
-            && !claude.join("scheduled-tasks").is_dir()
+            && !has_scheduled_task(&claude)
         {
             return Ok(Vec::new());
         }
@@ -354,6 +355,24 @@ const MAX_SCHEDULED_TASK_REASONS: usize = 20;
 ///
 /// `claude_dir` is the parser's configured `<home>/.claude` (temp home in
 /// tests) — never a hardcoded `~`.
+/// True iff `<claude_dir>/scheduled-tasks/<name>/SKILL.md` exists for at least
+/// one task. Short-circuits on the first hit — the actual signal is a `SKILL.md`,
+/// not a bare (possibly empty) `scheduled-tasks/` dir, so the "tool enabled"
+/// guard uses this rather than `.is_dir()`.
+pub(crate) fn has_scheduled_task(claude_dir: &Path) -> bool {
+    let sched_dir = claude_dir.join("scheduled-tasks");
+    let Ok(entries) = std::fs::read_dir(&sched_dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.join("SKILL.md").is_file() {
+            return true;
+        }
+    }
+    false
+}
+
 pub(crate) fn emit_scheduled_task_reasons(claude_dir: &Path, out: &mut Vec<AiGuardReason>) {
     let sched_dir = claude_dir.join("scheduled-tasks");
     let entries = match std::fs::read_dir(&sched_dir) {
@@ -1562,6 +1581,25 @@ mod tests {
             )),
             "got {reasons:?}"
         );
+    }
+
+    #[test]
+    fn empty_scheduled_tasks_dir_is_short_circuited() {
+        // #191 (codex) — a bare `scheduled-tasks/` dir with no `<name>/SKILL.md`
+        // is NOT evidence of use: with no settings/CLAUDE.md the parser must
+        // still short-circuit to no findings (not treat Claude Code as enabled).
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude").join("scheduled-tasks")).unwrap();
+        // Also a subdir without a SKILL.md — still not a real task.
+        std::fs::create_dir_all(
+            dir.path()
+                .join(".claude")
+                .join("scheduled-tasks")
+                .join("empty"),
+        )
+        .unwrap();
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(reasons.is_empty(), "expected no findings, got {reasons:?}");
     }
 
     #[test]

--- a/crates/sigil-agent/src/ai_guard/remediation.rs
+++ b/crates/sigil-agent/src/ai_guard/remediation.rs
@@ -60,6 +60,9 @@ pub fn hint_for_reason(reason: &AiGuardReason) -> &'static str {
         InstructionFileDirective { .. } => {
             "An instruction file contains a flagged directive (fetch-pipe, destructive, obfuscated, or an override marker) — review it for prompt injection."
         }
+        UnattendedScheduledTask { .. } => {
+            "An unattended scheduled task runs Claude Code on a recurring basis — review its prompt and permissions, or remove it if unexpected."
+        }
     }
 }
 

--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -58,6 +58,7 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
             directive_kind: InstructionDirectiveKind::OverrideMarker,
             ..
         } => "instruction_override_marker",
+        AiGuardReason::UnattendedScheduledTask { .. } => "unattended_scheduled_task",
     }
 }
 
@@ -67,6 +68,9 @@ pub const DANGEROUS_TOGGLE_KINDS: &[&str] = &[
     "sandbox_disabled",
     "permissions_allow_broad",
     "project_mcp_auto_enabled",
+    // #191 — a newly-appeared unattended scheduled task is an OFF→ON drift:
+    // it means an autonomous loop/goal is now running without a human present.
+    "unattended_scheduled_task",
 ];
 
 /// The set of dangerous-toggle kind keys present in a reason set.
@@ -84,7 +88,7 @@ pub fn dangerous_toggles(reasons: &[AiGuardReason]) -> std::collections::BTreeSe
 #[derive(Debug, Clone)]
 pub struct Rubric {
     /// kind_key → weight. Keys are static strings owned by the rubric
-    /// module (returned by `kind_key()`). Defaults populate all 20 known
+    /// module (returned by `kind_key()`). Defaults populate all 21 known
     /// kinds; with_overrides() may replace values but never adds keys.
     pub weights: HashMap<&'static str, f32>,
     /// Subset of `weights` whose value came from an operator override
@@ -99,7 +103,7 @@ pub struct Rubric {
 impl Rubric {
     /// Build the canonical hardcoded weights — single source of truth for
     /// defaults. Must match the historical `weight_for()` match arms for
-    /// all 20 kinds.
+    /// all 21 kinds.
     pub fn defaults() -> Self {
         let mut w: HashMap<&'static str, f32> = HashMap::new();
         w.insert("destructive_in_inline_command", 4.0);
@@ -122,6 +126,9 @@ impl Rubric {
         w.insert("instruction_override_marker", 2.0);
         w.insert("trusted_mcp_server", 1.5);
         w.insert("auto_approval_enabled", 2.0);
+        // #191 — an unattended recurring task is serious (autonomous loop
+        // without guardrails) but not max.
+        w.insert("unattended_scheduled_task", 2.5);
         Rubric {
             weights: w,
             overridden: HashSet::new(),
@@ -459,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn rubric_defaults_all_20_kinds_present() {
+    fn rubric_defaults_all_21_kinds_present() {
         let r = Rubric::defaults();
         assert_eq!(r.weights.get("destructive_in_inline_command"), Some(&4.0));
         assert_eq!(r.weights.get("destructive_in_hook_script"), Some(&4.0));
@@ -481,7 +488,8 @@ mod tests {
         assert_eq!(r.weights.get("instruction_destructive"), Some(&3.0));
         assert_eq!(r.weights.get("instruction_obfuscation"), Some(&2.5));
         assert_eq!(r.weights.get("instruction_override_marker"), Some(&2.0));
-        assert_eq!(r.weights.len(), 20);
+        assert_eq!(r.weights.get("unattended_scheduled_task"), Some(&2.5));
+        assert_eq!(r.weights.len(), 21);
     }
 
     #[test]
@@ -757,6 +765,32 @@ mod tests {
                 mechanism: "x".into()
             }
         )));
+        assert!(DANGEROUS_TOGGLE_KINDS.contains(&kind_key(
+            &AiGuardReason::UnattendedScheduledTask { name: "x".into() }
+        )));
+    }
+
+    /// #191 — an unattended scheduled task weighs 2.5.
+    #[test]
+    fn unattended_scheduled_task_weighs_2_5() {
+        let r = vec![AiGuardReason::UnattendedScheduledTask {
+            name: "mytask".into(),
+        }];
+        assert_eq!(score(&r), 2.5);
+    }
+
+    /// #191 — the drift set includes the new unattended-scheduled-task kind so
+    /// a newly-appeared task is caught as OFF→ON drift (#147).
+    #[test]
+    fn unattended_scheduled_task_is_a_dangerous_toggle() {
+        let reasons = vec![AiGuardReason::UnattendedScheduledTask {
+            name: "mytask".into(),
+        }];
+        let got = dangerous_toggles(&reasons);
+        assert!(
+            got.contains("unattended_scheduled_task"),
+            "expected unattended_scheduled_task in drift set, got {got:?}"
+        );
     }
 
     /// #127 — the two shapes are independently tunable kind_keys.

--- a/crates/sigil-agent/tests/scan.rs
+++ b/crates/sigil-agent/tests/scan.rs
@@ -149,6 +149,35 @@ fn remediation_hint_in_json_and_human_for_a_finding() {
 }
 
 #[test]
+fn claude_default_mode_bypass_shows_auto_approval_in_scan_and_hint() {
+    // #191 signal 1 — a user-global `permissions.defaultMode: "bypassPermissions"`
+    // reuses the AutoApprovalEnabled reason, so it must surface in the scan JSON
+    // reasons AND the human "How to reduce" section must carry the auto-approval hint.
+    let home = tempdir().unwrap();
+    write(
+        &home.path().join(".claude").join("settings.json"),
+        r#"{"permissions":{"defaultMode":"bypassPermissions"}}"#,
+    );
+
+    let v = report_json_for(home.path(), None);
+    let claude = v["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["tool"] == "claude-code")
+        .expect("claude-code row present");
+    assert!(
+        kinds(&claude["reasons"]).contains(&"auto_approval_enabled".to_string()),
+        "claude reasons: {:?}",
+        claude["reasons"]
+    );
+
+    let out = render_human_for(home.path(), None);
+    assert!(out.contains("How to reduce"), "{out}");
+    assert!(out.contains("Auto-approval is on"), "{out}");
+}
+
+#[test]
 fn no_how_to_reduce_section_when_clean() {
     // Empty HOME ⇒ no rows ⇒ no "How to reduce" section.
     let home = tempdir().unwrap();

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -242,6 +242,11 @@ pub enum AiGuardReason {
         directive_kind: InstructionDirectiveKind,
         snippet: String,
     },
+    /// #191 — an unattended, recurring Claude Code scheduled task is configured
+    /// (`~/.claude/scheduled-tasks/<name>/SKILL.md` exists). The readable,
+    /// persistent equivalent of a loop/goal running without a human in the
+    /// loop. POSTURE only; `name` is the task subdir name.
+    UnattendedScheduledTask { name: String },
 }
 
 /// #146 — category of instruction-file directive. Stable wire strings


### PR DESCRIPTION
Phase 1 of #191. Loop/goal-style features run repeated work unattended; if the agent runs without guardrails, the blast radius grows — it should at least be **measured**. This flags the *readable* autonomous-Claude-Code signals (verified against current docs).

## Two signals (user-global Claude Code parser)
1. **`permissions.defaultMode`** in `~/.claude/settings.json` ∈ {`auto`, `bypassPermissions`, `acceptEdits`} → reuses `AiGuardReason::AutoApprovalEnabled { mode }` (raw value), so it flows into `sigil scan`, #147 toggle-drift, remediation hints, and the rubric weight with **no new wiring**. `dontAsk` is excluded (runs only pre-approved tools).
2. **`~/.claude/scheduled-tasks/<name>/SKILL.md`** exists → new `AiGuardReason::UnattendedScheduledTask { name }` (weight 2.5) — the readable, persistent equivalent of a loop. One per task subdir, sorted, capped at 20.

## Honest limits (not statically detectable)
Active `/loop` (session in-memory, restored on `--resume`), `/goal` conditions, cloud `/schedule` routines — no on-disk trace, so out of scope (like Cursor's UI-only YOLO). Verified via Claude Code docs.

## Live proof
A temp HOME with `defaultMode: bypassPermissions` + one scheduled task scores **HIGH 5.5** with findings `permissions_deny_empty, auto_approval_enabled, unattended_scheduled_task` and all three remediation hints in "How to reduce".

## Verification
- `cargo fmt` + `clippy --all-targets -D warnings` clean; full `cargo test --workspace` 0 failures.
- New reason wired via compiler-forced exhaustive matches (kind_key, hint_for_reason) + rubric weight + #147 dangerous-toggle drift set.
- **codex adversarial review**: 0 P1. The one real P2 (an empty `scheduled-tasks/` dir slipping past the tool-enabled guard) is fixed — the guard now requires a real `SKILL.md` (`has_scheduled_task`, short-circuiting) + regression test. The cap's >20-tasks truncation is logged (unrealistic for heavyweight Desktop tasks).

## Phase 2 (follow-up, seam left in place)
Analyze the SKILL.md **content** — prompts that read files / pipe to a shell / run repeated destructive shell — by reusing the `InstructionFileDirective` machinery. Seam comment marks the `skill_md` path. #191 stays open for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
