### PR TITLE
feat(server): mTLS peer-cert identity — enroll issuer binding + opt-in events cert↔host_id match (#194)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +872,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2069,10 +2122,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2240,6 +2312,15 @@ checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2784,6 +2865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,11 +3291,13 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -4449,6 +4541,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ data-encoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2"
+# #194 — peer-cert plumbing: names axum-server's TlsStream type (no default
+# features so the crypto backend stays the workspace rustls/ring choice).
+tokio-rustls = { version = "0.26", default-features = false }
+# #194 — pure-Rust X.509 parsing (CN + SAN DNS) of TLS-verified peer certs.
+x509-parser = "0.18"
 http = "1"
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio"] }
 tower = "0.5"

--- a/crates/sigil-server/Cargo.toml
+++ b/crates/sigil-server/Cargo.toml
@@ -32,6 +32,10 @@ axum = { workspace = true, features = ["query"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
+# #194 — peer-cert identity plumbing (custom Accept + per-request Extension).
+tokio-rustls = { workspace = true }
+tower = { workspace = true }
+x509-parser = { workspace = true }
 blake3 = { workspace = true }
 parking_lot = { workspace = true }
 ed25519-dalek = { workspace = true }
@@ -44,7 +48,6 @@ tempfile = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
-tower = { workspace = true }
 http = { workspace = true }
 reqwest = { workspace = true }
 

--- a/crates/sigil-server/src/app.rs
+++ b/crates/sigil-server/src/app.rs
@@ -50,6 +50,10 @@ pub struct AppState {
     /// #184 — enrollment state (intermediate CA + tokens + mint mutex). `None` ⇒
     /// every `/v1/enroll*` route 404s (feature off).
     pub enroll: Option<crate::enroll::EnrollState>,
+    /// #194.2 — when true, `POST /v1/events` requires the TLS client cert to
+    /// match the envelope host_id (CN == host_id or host_id ∈ SAN DNS). Boot
+    /// validation guarantees mTLS is on whenever this is set.
+    pub events_require_cert_host_match: bool,
 }
 
 pub type SharedState = Arc<AppState>;

--- a/crates/sigil-server/src/config.rs
+++ b/crates/sigil-server/src/config.rs
@@ -72,6 +72,12 @@ pub struct ServerConfig {
     /// enrollment stays off (404) when this is unset.
     #[serde(default)]
     pub host_allowlist_path: Option<PathBuf>,
+    /// #194.2 — when true, `POST /v1/events` additionally requires the TLS
+    /// client cert to match the envelope `host_id` (subject CN == host_id, or
+    /// host_id ∈ SAN DNS). Requires mTLS: the server refuses to start if this
+    /// is set without the full TLS triple. Default false (pre-#194 behavior).
+    #[serde(default)]
+    pub events_require_cert_host_match: bool,
     /// Path to the persisted per-host high-water-sequence map (for dedup
     /// across restarts). Defaults to `<events_out_dir>/.high-water.json`.
     #[serde(default)]
@@ -87,10 +93,28 @@ impl ServerConfig {
             path: path.to_path_buf(),
             source,
         })?;
-        serde_yaml::from_slice(&bytes).map_err(|source| ConfigError::Parse {
+        let cfg: Self = serde_yaml::from_slice(&bytes).map_err(|source| ConfigError::Parse {
             path: path.to_path_buf(),
             source,
-        })
+        })?;
+        cfg.validate(path)?;
+        Ok(cfg)
+    }
+
+    /// Cross-field boot validation. #194.2: `events_require_cert_host_match`
+    /// is meaningless over plain HTTP (there is no client cert to match), so
+    /// setting it without the full mTLS triple is a refuse-to-start error —
+    /// never a silently-ignored gate.
+    fn validate(&self, path: &Path) -> Result<(), ConfigError> {
+        if self.events_require_cert_host_match && !self.mtls_enabled() {
+            return Err(ConfigError::Invalid {
+                path: path.to_path_buf(),
+                reason: "events_require_cert_host_match requires mTLS \
+                         (tls_cert_path + tls_key_path + client_ca_path)"
+                    .to_string(),
+            });
+        }
+        Ok(())
     }
 
     /// Effective high-water path: explicit, or `<events_out_dir>/.high-water.json`.
@@ -118,6 +142,8 @@ pub enum ConfigError {
         path: PathBuf,
         source: serde_yaml::Error,
     },
+    #[error("invalid config {path}: {reason}")]
+    Invalid { path: PathBuf, reason: String },
 }
 
 #[cfg(test)]
@@ -194,6 +220,69 @@ policy_bundle_path: "/d/signed-policy.json"
 "#;
         let cfg: ServerConfig = serde_yaml::from_str(yaml_absent).unwrap();
         assert_eq!(cfg.enroll_issuer_fingerprints, None);
+    }
+
+    /// #194.2 — events_require_cert_host_match parses; default false.
+    #[test]
+    fn parses_events_require_cert_host_match() {
+        let yaml = r#"
+bind: "127.0.0.1:8443"
+tls_cert_path: "/e/server.crt"
+tls_key_path: "/e/server.key"
+client_ca_path: "/e/client-ca.pem"
+events_out_dir: "/d/events"
+policy_bundle_path: "/d/signed-policy.json"
+events_require_cert_host_match: true
+"#;
+        let cfg: ServerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.events_require_cert_host_match);
+
+        let yaml_absent = r#"
+bind: "127.0.0.1:8443"
+events_out_dir: "/d/events"
+policy_bundle_path: "/d/signed-policy.json"
+"#;
+        let cfg: ServerConfig = serde_yaml::from_str(yaml_absent).unwrap();
+        assert!(!cfg.events_require_cert_host_match, "default is false");
+    }
+
+    /// #194.2 — the flag without mTLS is a refuse-to-start config error; with
+    /// the full mTLS triple the same config loads.
+    #[test]
+    fn cert_host_match_without_mtls_refuses_to_load() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("server.yaml");
+        std::fs::write(
+            &p,
+            r#"
+bind: "127.0.0.1:8443"
+events_out_dir: "/d/events"
+policy_bundle_path: "/d/signed-policy.json"
+events_require_cert_host_match: true
+"#,
+        )
+        .unwrap();
+        let err = ServerConfig::load(&p).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Invalid { .. }),
+            "flag without mTLS must refuse to start, got: {err}"
+        );
+
+        std::fs::write(
+            &p,
+            r#"
+bind: "127.0.0.1:8443"
+tls_cert_path: "/e/server.crt"
+tls_key_path: "/e/server.key"
+client_ca_path: "/e/client-ca.pem"
+events_out_dir: "/d/events"
+policy_bundle_path: "/d/signed-policy.json"
+events_require_cert_host_match: true
+"#,
+        )
+        .unwrap();
+        let cfg = ServerConfig::load(&p).unwrap();
+        assert!(cfg.events_require_cert_host_match && cfg.mtls_enabled());
     }
 
     #[test]

--- a/crates/sigil-server/src/config.rs
+++ b/crates/sigil-server/src/config.rs
@@ -57,6 +57,12 @@ pub struct ServerConfig {
     /// Absent ⇒ enrollment off.
     #[serde(default)]
     pub enroll_tokens_path: Option<PathBuf>,
+    /// #194.1 — optional allowlist of TLS client-cert fingerprints (blake3 hex
+    /// of the leaf cert DER) permitted to call `POST /v1/enroll` (the
+    /// PMS/issuer box). Absent ⇒ any mTLS fleet member may redeem an enroll
+    /// token (pre-#194 behavior). Present-but-empty ⇒ deny-all.
+    #[serde(default)]
+    pub enroll_issuer_fingerprints: Option<Vec<String>>,
     /// #184 — issued client-cert validity in days (default 30; short by design,
     /// re-enroll replaces revocation in the MVP).
     #[serde(default)]
@@ -162,6 +168,32 @@ host_allowlist_path: "/d/hosts.json"
         let cfg = ServerConfig::load(&p).unwrap();
         assert!(cfg.mtls_enabled());
         assert!(cfg.host_allowlist_path.is_some());
+    }
+
+    /// #194.1 — enroll_issuer_fingerprints parses; absent stays None.
+    #[test]
+    fn parses_enroll_issuer_fingerprints() {
+        let yaml = r#"
+bind: "127.0.0.1:8443"
+events_out_dir: "/d/events"
+policy_bundle_path: "/d/signed-policy.json"
+enroll_issuer_fingerprints:
+  - "aabb01"
+  - "ccdd02"
+"#;
+        let cfg: ServerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            cfg.enroll_issuer_fingerprints,
+            Some(vec!["aabb01".to_string(), "ccdd02".to_string()])
+        );
+
+        let yaml_absent = r#"
+bind: "127.0.0.1:8443"
+events_out_dir: "/d/events"
+policy_bundle_path: "/d/signed-policy.json"
+"#;
+        let cfg: ServerConfig = serde_yaml::from_str(yaml_absent).unwrap();
+        assert_eq!(cfg.enroll_issuer_fingerprints, None);
     }
 
     #[test]

--- a/crates/sigil-server/src/enroll/audit.rs
+++ b/crates/sigil-server/src/enroll/audit.rs
@@ -33,9 +33,9 @@ pub struct EnrollmentAuditRecord {
     pub serial: String,
     /// not_after of the issued cert, rfc3339 (empty when denied).
     pub not_after: String,
-    /// Caller (peer) cert fingerprint, if extractable. Empty otherwise.
-    // TODO(#184): caller cert fingerprint — needs peer-cert plumbing from the
-    // axum-server rustls connection; deferred (see report). Left empty for now.
+    /// Caller (TLS peer) cert fingerprint — blake3 hex of the leaf DER, as
+    /// plumbed by `tls_accept::PeerCertAcceptor` (#194). Empty when the
+    /// request carried no peer identity (plain-HTTP dev mode).
     pub caller_fingerprint: String,
     pub prev_hash: String,
 }
@@ -96,6 +96,7 @@ pub fn append(
     cert_fingerprint: &str,
     serial: &str,
     not_after: &str,
+    caller_fingerprint: &str,
     ts: &str,
 ) -> Result<SignedEnrollmentRecord, AuditAppendError> {
     let (seq, prev_hash) = resume_chain(path);
@@ -110,7 +111,7 @@ pub fn append(
         cert_fingerprint: cert_fingerprint.to_string(),
         serial: serial.to_string(),
         not_after: not_after.to_string(),
-        caller_fingerprint: String::new(),
+        caller_fingerprint: caller_fingerprint.to_string(),
         prev_hash,
     };
     let canonical =
@@ -180,6 +181,7 @@ mod tests {
             "certfp",
             "0a",
             "2026-07-01T00:00:00Z",
+            "callerfp",
             "2026-06-23T00:00:00Z",
         )
         .unwrap();
@@ -193,11 +195,14 @@ mod tests {
             "",
             "",
             "",
+            "",
             "2026-06-23T00:01:00Z",
         )
         .unwrap();
         assert_eq!(a.record.seq, 0);
         assert_eq!(a.record.prev_hash, GENESIS_PREV_HASH);
+        assert_eq!(a.record.caller_fingerprint, "callerfp");
+        assert_eq!(b.record.caller_fingerprint, "");
         assert_eq!(b.record.seq, 1);
         assert_eq!(b.record.prev_hash, a.hash, "chain link");
         assert!(verify_line(&a, &k));

--- a/crates/sigil-server/src/enroll/mod.rs
+++ b/crates/sigil-server/src/enroll/mod.rs
@@ -129,14 +129,33 @@ impl EnrollState {
             return None;
         }
         // #194.1 — normalize issuer fingerprints to lowercase hex once, at
-        // boot. `Some([])` is kept as-is: deny-all, so an operator typo (an
-        // empty list in the config) surfaces immediately rather than silently
-        // disabling the gate.
-        let issuer_fingerprints = issuer_fingerprints.map(|list| {
-            list.iter()
-                .map(|f| f.trim().to_ascii_lowercase())
-                .collect::<Vec<_>>()
-        });
+        // boot, and VALIDATE them (codex review): a blake3 fingerprint is
+        // exactly 64 hex chars, so a typo'd entry can never match anything —
+        // it would silently lock the operator out. Malformed entries disable
+        // enrollment loudly instead. Duplicates are removed. `Some([])` is
+        // kept as-is: deny-all, so an empty list in the config surfaces
+        // immediately rather than silently disabling the gate.
+        let issuer_fingerprints = match issuer_fingerprints {
+            None => None,
+            Some(list) => {
+                let mut norm: Vec<String> = Vec::with_capacity(list.len());
+                for raw in &list {
+                    let f = raw.trim().to_ascii_lowercase();
+                    if f.len() != 64 || !f.bytes().all(|b| b.is_ascii_hexdigit()) {
+                        tracing::error!(
+                            entry = %raw,
+                            "enroll: enroll_issuer_fingerprints entry is not 64 hex chars \
+                             (blake3 of the client cert DER); enrollment disabled"
+                        );
+                        return None;
+                    }
+                    if !norm.contains(&f) {
+                        norm.push(f);
+                    }
+                }
+                Some(norm)
+            }
+        };
         match issuer_fingerprints.as_deref() {
             Some([]) => tracing::warn!(
                 "enroll: enroll_issuer_fingerprints is EMPTY — every /v1/enroll caller will be denied"
@@ -398,16 +417,28 @@ mod tests {
                 issuers,
             )
         };
-        let s = load(Some(vec!["  ABCDEF0123  ".to_string()])).unwrap();
+        let hexfp = "AB".repeat(32); // 64 hex chars, uppercase
+        let s = load(Some(vec![format!("  {hexfp}  "), hexfp.to_lowercase()])).unwrap();
         assert_eq!(
             s.issuer_fingerprints,
-            Some(vec!["abcdef0123".to_string()]),
-            "trimmed + lowercased"
+            Some(vec!["ab".repeat(32)]),
+            "trimmed + lowercased + deduped"
         );
         let s = load(Some(vec![])).unwrap();
         assert_eq!(s.issuer_fingerprints, Some(vec![]), "empty kept = deny-all");
         let s = load(None).unwrap();
         assert_eq!(s.issuer_fingerprints, None, "absent stays permissive");
+        // codex review — malformed entries (wrong length / non-hex) can never
+        // match a blake3 fingerprint; they disable enrollment loudly instead
+        // of silently locking the operator out.
+        assert!(
+            load(Some(vec!["abcdef0123".to_string()])).is_none(),
+            "short entry rejected"
+        );
+        assert!(
+            load(Some(vec!["zz".repeat(32)])).is_none(),
+            "non-hex entry rejected"
+        );
     }
 
     /// A non-CA (CA:FALSE) cert must be rejected.

--- a/crates/sigil-server/src/enroll/mod.rs
+++ b/crates/sigil-server/src/enroll/mod.rs
@@ -36,8 +36,12 @@ pub struct EnrollState {
     /// Absolute path to the openssl binary, resolved once at boot.
     pub openssl_path: PathBuf,
     pub cert_days: u32,
+    /// #194.1 — optional allowlist of caller (TLS client-cert) fingerprints
+    /// permitted to enroll, normalized to lowercase hex at load. `None` ⇒ any
+    /// mTLS fleet member may redeem a token; `Some([])` ⇒ deny-all.
+    pub issuer_fingerprints: Option<Vec<String>>,
     /// Serializes the whole mint critical section:
-    /// CN-check → reserve(token) → sign → allowlist → audit.
+    /// issuer-check → CN-check → reserve(token) → sign → allowlist → audit.
     pub mint: Mutex<()>,
 }
 
@@ -56,6 +60,7 @@ impl EnrollState {
         mtls_enabled: bool,
         cert_days: Option<u32>,
         audit_path: PathBuf,
+        issuer_fingerprints: Option<Vec<String>>,
     ) -> Option<EnrollState> {
         // fix A: never expose token-only cert minting over cleartext HTTP.
         if !mtls_enabled {
@@ -123,6 +128,25 @@ impl EnrollState {
             tracing::error!("enroll: CA key does not match CA cert; enrollment disabled");
             return None;
         }
+        // #194.1 — normalize issuer fingerprints to lowercase hex once, at
+        // boot. `Some([])` is kept as-is: deny-all, so an operator typo (an
+        // empty list in the config) surfaces immediately rather than silently
+        // disabling the gate.
+        let issuer_fingerprints = issuer_fingerprints.map(|list| {
+            list.iter()
+                .map(|f| f.trim().to_ascii_lowercase())
+                .collect::<Vec<_>>()
+        });
+        match issuer_fingerprints.as_deref() {
+            Some([]) => tracing::warn!(
+                "enroll: enroll_issuer_fingerprints is EMPTY — every /v1/enroll caller will be denied"
+            ),
+            Some(list) => tracing::info!(
+                entries = list.len(),
+                "enroll: issuer cert-fingerprint binding enabled (#194.1)"
+            ),
+            None => {}
+        }
         tracing::info!(
             cert = %cert.display(),
             "enroll: enabled (intermediate CA validated)"
@@ -134,6 +158,7 @@ impl EnrollState {
             audit_path,
             openssl_path: openssl,
             cert_days: cert_days.unwrap_or(DEFAULT_CERT_DAYS),
+            issuer_fingerprints,
             mint: Mutex::new(()),
         })
     }
@@ -218,6 +243,7 @@ mod tests {
             true, // mtls on
             None,
             PathBuf::from("/tmp/a.jsonl"),
+            None,
         );
         assert!(s.is_none());
     }
@@ -233,6 +259,7 @@ mod tests {
             true, // mtls on
             None,
             PathBuf::from("/tmp/a.jsonl"),
+            None,
         );
         assert!(s.is_none());
     }
@@ -250,6 +277,7 @@ mod tests {
             false, // mtls OFF ⇒ must refuse
             None,
             d.path().join("a.jsonl"),
+            None,
         );
         assert!(s.is_none(), "no mTLS ⇒ enrollment must be disabled");
     }
@@ -273,6 +301,7 @@ mod tests {
             false, // mtls OFF
             Some(30),
             d.path().join("a.jsonl"),
+            None,
         );
         assert!(s.is_none(), "valid CA still disabled when mTLS is off");
     }
@@ -296,6 +325,7 @@ mod tests {
             true, // mtls on
             Some(30),
             d.path().join("a.jsonl"),
+            None,
         );
         assert!(
             s.is_none(),
@@ -315,6 +345,7 @@ mod tests {
             true,
             None,
             d.path().join("a.jsonl"),
+            None,
         );
         assert!(s.is_none());
     }
@@ -338,9 +369,45 @@ mod tests {
             true,
             Some(30),
             d.path().join("a.jsonl"),
+            None,
         );
         assert!(s.is_some(), "valid CA should enable enrollment");
         assert_eq!(s.unwrap().cert_days, 30);
+    }
+
+    /// #194.1 — issuer fingerprints are normalized (trim + lowercase) at load;
+    /// absent stays `None`; an empty list is preserved (deny-all).
+    #[test]
+    fn load_normalizes_issuer_fingerprints() {
+        let Some(openssl) = sign::resolve_openssl() else {
+            return;
+        };
+        let d = tempfile::tempdir().unwrap();
+        let (cert, key) = make_ca(&openssl, d.path());
+        let al = write_allowlist(d.path());
+        let toks = d.path().join("t.json");
+        let load = |issuers: Option<Vec<String>>| {
+            EnrollState::load(
+                Some(&cert),
+                Some(&key),
+                Some(&toks),
+                Some(&al),
+                true,
+                Some(30),
+                d.path().join("a.jsonl"),
+                issuers,
+            )
+        };
+        let s = load(Some(vec!["  ABCDEF0123  ".to_string()])).unwrap();
+        assert_eq!(
+            s.issuer_fingerprints,
+            Some(vec!["abcdef0123".to_string()]),
+            "trimmed + lowercased"
+        );
+        let s = load(Some(vec![])).unwrap();
+        assert_eq!(s.issuer_fingerprints, Some(vec![]), "empty kept = deny-all");
+        let s = load(None).unwrap();
+        assert_eq!(s.issuer_fingerprints, None, "absent stays permissive");
     }
 
     /// A non-CA (CA:FALSE) cert must be rejected.
@@ -360,6 +427,7 @@ mod tests {
             true,
             None,
             d.path().join("a.jsonl"),
+            None,
         );
         assert!(s.is_none(), "CA:FALSE cert must disable enrollment");
     }

--- a/crates/sigil-server/src/events_route.rs
+++ b/crates/sigil-server/src/events_route.rs
@@ -7,9 +7,11 @@
 use crate::allowlist;
 use crate::app::SharedState;
 use crate::persist::{append_events, PersistEvent};
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use crate::tls_accept::PeerIdentity;
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Extension, Json};
 use serde_json::{json, Value as JsonValue};
 use sigil_core::event::{Event, SCHEMA_VERSION};
+use std::sync::Arc;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -66,8 +68,37 @@ fn validate(payload: &JsonValue, envelope_host_id: &str) -> Result<(), &'static 
 
 pub async fn post_events(
     State(state): State<SharedState>,
+    // #194 — injected per-connection by `tls_accept::PeerCertAcceptor`.
+    // Absent over plain HTTP (dev mode) or if rustls reported no peer cert.
+    peer: Option<Extension<Arc<PeerIdentity>>>,
     Json(req): Json<EventsRequest>,
 ) -> impl IntoResponse {
+    // #194.2 — cert↔host_id binding, checked BEFORE the allowlist so a
+    // mismatched cert can never even probe allowlist membership. The response
+    // is byte-identical to the allowlist rejection (no oracle distinguishing
+    // "not allowlisted" from "wrong cert"); the fingerprint is logged for
+    // operators. Boot validation guarantees mTLS is on when this flag is set.
+    if state.events_require_cert_host_match {
+        let peer = peer.as_ref().map(|Extension(p)| p);
+        let matches = peer.is_some_and(|p| {
+            p.cn.as_deref() == Some(req.envelope.host_id.as_str())
+                || p.san_dns.iter().any(|d| d == &req.envelope.host_id)
+        });
+        if !matches {
+            tracing::warn!(
+                host_id = %req.envelope.host_id,
+                peer_fingerprint = peer.map(|p| p.fingerprint.as_str()).unwrap_or(""),
+                peer_cn = peer.and_then(|p| p.cn.as_deref()).unwrap_or(""),
+                "events: client cert does not match envelope host_id; rejecting"
+            );
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "host_unknown", "host_id": req.envelope.host_id})),
+            )
+                .into_response();
+        }
+    }
+
     if !allowlist::permits(&state.allowlist.read(), &req.envelope.host_id) {
         return (
             StatusCode::NOT_FOUND,

--- a/crates/sigil-server/src/events_route.rs
+++ b/crates/sigil-server/src/events_route.rs
@@ -78,11 +78,19 @@ pub async fn post_events(
     // is byte-identical to the allowlist rejection (no oracle distinguishing
     // "not allowlisted" from "wrong cert"); the fingerprint is logged for
     // operators. Boot validation guarantees mTLS is on when this flag is set.
+    // Matching is ASCII-case-insensitive (codex review): DNS names are
+    // case-insensitive and UUID host_ids appear in both hex cases in the wild;
+    // hex case carries no identity, so folding removes false rejects without
+    // weakening the binding. (Known limit, deliberate: this gate runs after
+    // axum's Json extraction, so a malformed body still 400s before the 404 —
+    // a parser-level oracle only, not a token/allowlist oracle.)
     if state.events_require_cert_host_match {
         let peer = peer.as_ref().map(|Extension(p)| p);
+        let host_id = req.envelope.host_id.as_str();
         let matches = peer.is_some_and(|p| {
-            p.cn.as_deref() == Some(req.envelope.host_id.as_str())
-                || p.san_dns.iter().any(|d| d == &req.envelope.host_id)
+            p.cn.as_deref()
+                .is_some_and(|cn| cn.eq_ignore_ascii_case(host_id))
+                || p.san_dns.iter().any(|d| d.eq_ignore_ascii_case(host_id))
         });
         if !matches {
             tracing::warn!(

--- a/crates/sigil-server/src/lib.rs
+++ b/crates/sigil-server/src/lib.rs
@@ -31,3 +31,4 @@ pub mod persist;
 pub mod policy_route;
 pub mod routes;
 pub mod rule_packs_route;
+pub mod tls_accept;

--- a/crates/sigil-server/src/main.rs
+++ b/crates/sigil-server/src/main.rs
@@ -263,7 +263,11 @@ async fn run(cfg: ServerConfig) -> Result<()> {
     if cfg.mtls_enabled() {
         let tls = build_mtls(&cfg)?;
         tracing::info!(bind = %cfg.bind, "starting sigil-server (mTLS)");
-        axum_server::bind_rustls(cfg.bind, tls)
+        // #194 — PeerCertAcceptor wraps axum-server's rustls acceptor (same
+        // handshake + timeout) and exposes the verified client cert to
+        // handlers as an `Extension<Arc<PeerIdentity>>` on every request.
+        axum_server::bind(cfg.bind)
+            .acceptor(sigil_server::tls_accept::PeerCertAcceptor::new(tls))
             .serve(app.into_make_service())
             .await
             .context("axum_server serve (mTLS)")?;

--- a/crates/sigil-server/src/main.rs
+++ b/crates/sigil-server/src/main.rs
@@ -136,6 +136,7 @@ fn build_state(cfg: &ServerConfig) -> Result<SharedState> {
         cfg.mtls_enabled(),
         cfg.enroll_cert_days,
         enroll_audit_path,
+        cfg.enroll_issuer_fingerprints.clone(),
     );
     if enroll.is_some() {
         tracing::info!("enrollment endpoint enabled (POST /v1/enroll)");

--- a/crates/sigil-server/src/main.rs
+++ b/crates/sigil-server/src/main.rs
@@ -158,6 +158,10 @@ fn build_state(cfg: &ServerConfig) -> Result<SharedState> {
         audit_head: Mutex::new(None),
         allowlist_path: cfg.host_allowlist_path.clone(),
         enroll,
+        // #194.2 — ServerConfig::load refused to start if this is set
+        // without mTLS, so `true` here implies the mTLS listener (and thus
+        // PeerIdentity injection) is active.
+        events_require_cert_host_match: cfg.events_require_cert_host_match,
     }))
 }
 

--- a/crates/sigil-server/src/routes/enroll.rs
+++ b/crates/sigil-server/src/routes/enroll.rs
@@ -8,6 +8,9 @@
 //! COMMIT ORDER (codex-hardened, prevents double-mint):
 //!   lock mint Mutex
 //!   → recompute now/ts (a token that expired while queued is rejected) (fix G)
+//!   → issuer gate (#194.1): when `enroll_issuer_fingerprints` is configured,
+//!     the TLS caller's cert fingerprint must be on the list — checked BEFORE
+//!     any CSR parsing or token access
 //!   → validate (UUID host_id, CSR size/PEM, CSR CN == host_id)
 //!   → RESERVE the token (durably stamp used_at + write) BEFORE signing
 //!   → sign (openssl, fixed profile, random serial, post-sign inspection)
@@ -20,20 +23,22 @@
 //! a host allowlisted without an issuance record (both still ⇒ 500 + no cert).
 //!
 //! External error generalization: every token failure (expired/used/mismatch/
-//! not-found) returns a single `403 {"error":{"code":"enrollment_denied"}}`.
-//! The specific reason is logged + audited internally. 404 (off) and 400
-//! (malformed) stay distinct.
+//! not-found) AND every issuer-gate failure returns the single generic
+//! `403 {"error":{"code":"enrollment_denied"}}`. The specific reason is logged
+//! + audited internally. 404 (off) and 400 (malformed) stay distinct.
 
 use crate::app::SharedState;
 use crate::enroll::audit;
 use crate::enroll::sign::{self, SignError};
 use crate::enroll::tokens::{RedeemErr, TokenStore};
+use crate::tls_accept::PeerIdentity;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{Extension, Json};
 use serde::Deserialize;
 use serde_json::json;
+use std::sync::Arc;
 
 #[derive(Debug, Deserialize)]
 pub struct EnrollReq {
@@ -42,7 +47,20 @@ pub struct EnrollReq {
     pub csr_pem: String,
 }
 
-pub async fn post_enroll(State(st): State<SharedState>, Json(req): Json<EnrollReq>) -> Response {
+pub async fn post_enroll(
+    State(st): State<SharedState>,
+    // #194 — injected per-connection by `tls_accept::PeerCertAcceptor`.
+    // Absent over plain HTTP (dev mode) or if rustls reported no peer cert.
+    peer: Option<Extension<Arc<PeerIdentity>>>,
+    Json(req): Json<EnrollReq>,
+) -> Response {
+    let peer = peer.map(|Extension(p)| p);
+    // Real caller fingerprint for ALL audit outcomes ("" when absent). #194
+    let caller_fp = peer
+        .as_ref()
+        .map(|p| p.fingerprint.clone())
+        .unwrap_or_default();
+
     // Feature off ⇒ 404 (indistinguishable from "route absent").
     let Some(en) = st.enroll.as_ref() else {
         return err(
@@ -82,6 +100,34 @@ pub async fn post_enroll(State(st): State<SharedState>, Json(req): Json<EnrollRe
         .format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_default();
 
+    // 0. #194.1 — issuer gate. When configured, the TLS caller must present a
+    //    client cert whose fingerprint is on the operator's issuer list.
+    //    Runs BEFORE any CSR parsing (openssl on attacker input) or token
+    //    access; answered with the same generic 403 as token failures so an
+    //    unauthorized caller learns nothing (no oracle).
+    if let Some(allowed) = en.issuer_fingerprints.as_deref() {
+        let permitted = peer
+            .as_ref()
+            .is_some_and(|p| allowed.iter().any(|f| f == &p.fingerprint));
+        if !permitted {
+            tracing::warn!(
+                host_id = %req.host_id,
+                caller_fingerprint = %caller_fp,
+                "enroll: caller cert not in enroll_issuer_fingerprints"
+            );
+            record_denied(
+                &st,
+                en,
+                &req.host_id,
+                "issuer_not_allowed",
+                &csr_fp,
+                &caller_fp,
+                &ts,
+            );
+            return enrollment_denied();
+        }
+    }
+
     // 1. CSR sanity: parse + verify the CSR, extract CN, require CN == host_id.
     let cn = match sign::csr_cn(&en.openssl_path, &req.csr_pem) {
         Ok(c) => c,
@@ -99,14 +145,22 @@ pub async fn post_enroll(State(st): State<SharedState>, Json(req): Json<EnrollRe
     };
     if cn != req.host_id {
         // CN mismatch is a token-scope denial → generic enrollment_denied.
-        record_denied(&st, en, &req.host_id, "cn_mismatch", &csr_fp, &ts);
+        record_denied(
+            &st,
+            en,
+            &req.host_id,
+            "cn_mismatch",
+            &csr_fp,
+            &caller_fp,
+            &ts,
+        );
         return enrollment_denied();
     }
 
     // 2. Pre-check the token (cheap, gives the specific internal reason).
     if let Err(e) = TokenStore::check(&en.tokens_path, &req.token, &req.host_id, now) {
         let reason = denial_reason(&e);
-        record_denied(&st, en, &req.host_id, reason, &csr_fp, &ts);
+        record_denied(&st, en, &req.host_id, reason, &csr_fp, &caller_fp, &ts);
         // I/O errors are a server fault (500); everything else is a denial.
         if let RedeemErr::Io(msg) = &e {
             tracing::error!(error = %msg, "enroll: token store read failed");
@@ -123,7 +177,7 @@ pub async fn post_enroll(State(st): State<SharedState>, Json(req): Json<EnrollRe
     //    point the token is spent; any failure ⇒ 500 + no cert (safe re-issue).
     if let Err(e) = TokenStore::mark_used(&en.tokens_path, &req.token, &req.host_id, now) {
         let reason = denial_reason(&e);
-        record_denied(&st, en, &req.host_id, reason, &csr_fp, &ts);
+        record_denied(&st, en, &req.host_id, reason, &csr_fp, &caller_fp, &ts);
         if matches!(e, RedeemErr::Io(_)) {
             tracing::error!(error = %e, "enroll: token reserve write failed");
             return err(
@@ -148,7 +202,15 @@ pub async fn post_enroll(State(st): State<SharedState>, Json(req): Json<EnrollRe
         Ok(c) => c,
         Err(e) => {
             tracing::error!(error = %e, host_id = %req.host_id, "enroll: signing failed (token already spent)");
-            record_denied(&st, en, &req.host_id, "sign_failed", &csr_fp, &ts);
+            record_denied(
+                &st,
+                en,
+                &req.host_id,
+                "sign_failed",
+                &csr_fp,
+                &caller_fp,
+                &ts,
+            );
             return err(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "sign_failed",
@@ -180,6 +242,7 @@ pub async fn post_enroll(State(st): State<SharedState>, Json(req): Json<EnrollRe
         &cert_fp,
         &serial,
         &not_after,
+        &caller_fp,
         &ts,
     ) {
         tracing::error!(error = %e, "enroll: audit append failed (token already spent)");
@@ -243,6 +306,7 @@ fn record_denied(
     host_id: &str,
     reason: &str,
     csr_fp: &str,
+    caller_fp: &str,
     ts: &str,
 ) {
     let Some(key) = st.audit_key.as_ref() else {
@@ -259,6 +323,7 @@ fn record_denied(
         "",
         "",
         "",
+        caller_fp,
         ts,
     ) {
         tracing::error!(error = %e, host_id, reason, "enroll: failed to audit denial");

--- a/crates/sigil-server/src/tls_accept.rs
+++ b/crates/sigil-server/src/tls_accept.rs
@@ -1,0 +1,306 @@
+//! #194 — peer-certificate identity plumbing for the mTLS listener.
+//!
+//! rustls verifies the client certificate chain during the TLS handshake
+//! (`WebPkiClientVerifier`), but axum handlers never see WHO connected. This
+//! module closes that gap:
+//!
+//! - [`PeerIdentity`] — leaf-cert fingerprint (blake3 of the DER) + subject CN
+//!   + SAN DNS names, extracted once per connection after the handshake.
+//! - [`PeerCertAcceptor`] — an [`axum_server::accept::Accept`] implementation
+//!   that wraps axum-server's own `RustlsAcceptor` (same handshake, same
+//!   timeout), then reads `peer_certificates()` off the resulting
+//!   `tokio_rustls::server::TlsStream` and wraps the connection's service in
+//!   [`InjectPeerIdentity`], which inserts `Arc<PeerIdentity>` into the
+//!   extensions of every request on that connection.
+//!
+//! Handlers read it via `Option<Extension<Arc<PeerIdentity>>>`, so the plain
+//! HTTP (no-mTLS dev) path — where the extension is simply absent — keeps
+//! working unchanged.
+//!
+//! Security notes:
+//! - The fingerprint is computed over the raw DER exactly as presented (and as
+//!   verified by rustls); it needs no parsing and is therefore always set.
+//! - CN/SAN parsing uses the pure-Rust `x509-parser` crate, which returns
+//!   `Result` on malformed input (nom-based total parser — no panics on
+//!   attacker-controlled bytes). Parse failure ⇒ `cn: None`, `san_dns: []`,
+//!   fingerprint still set. In practice the leaf has already passed webpki
+//!   chain verification before we ever parse it here.
+//! - If rustls reports no peer certificate (defensive; `WebPkiClientVerifier`
+//!   rejects anonymous clients during the handshake), NO extension is injected
+//!   — handlers see `None`, never a forged identity.
+
+use axum_server::accept::Accept;
+use axum_server::tls_rustls::{RustlsAcceptor, RustlsConfig};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_rustls::server::TlsStream;
+
+/// Identity of the TLS peer (client) on one connection, extracted from the
+/// leaf certificate rustls verified during the handshake.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PeerIdentity {
+    /// blake3 hex (lowercase) of the leaf certificate DER bytes.
+    pub fingerprint: String,
+    /// Subject CN, if the certificate parses and carries one.
+    pub cn: Option<String>,
+    /// SAN DNS entries, if the certificate parses and carries any.
+    pub san_dns: Vec<String>,
+}
+
+impl PeerIdentity {
+    /// Build an identity from leaf-cert DER bytes. The fingerprint is always
+    /// set (no parsing needed); CN/SAN fall back to `None`/empty when the
+    /// certificate does not parse. Never panics on malformed input.
+    pub fn from_der(der: &[u8]) -> Self {
+        let fingerprint = blake3::hash(der).to_hex().to_string();
+        let (cn, san_dns) = parse_cn_san(der).unwrap_or((None, Vec::new()));
+        PeerIdentity {
+            fingerprint,
+            cn,
+            san_dns,
+        }
+    }
+}
+
+/// Parse subject CN + SAN DNS names out of certificate DER. `None` when the
+/// certificate itself does not parse; a malformed/absent SAN extension alone
+/// degrades to an empty list (the CN is still returned).
+fn parse_cn_san(der: &[u8]) -> Option<(Option<String>, Vec<String>)> {
+    let (_, cert) = x509_parser::parse_x509_certificate(der).ok()?;
+    let cn = cert
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|attr| attr.as_str().ok())
+        .map(str::to_owned);
+    let san_dns = cert
+        .subject_alternative_name()
+        .ok()
+        .flatten()
+        .map(|ext| {
+            ext.value
+                .general_names
+                .iter()
+                .filter_map(|gn| match gn {
+                    x509_parser::extensions::GeneralName::DNSName(d) => Some((*d).to_string()),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Some((cn, san_dns))
+}
+
+/// [`Accept`] implementation: run axum-server's rustls handshake, then expose
+/// the verified peer identity to every request on the connection.
+#[derive(Clone)]
+pub struct PeerCertAcceptor {
+    inner: RustlsAcceptor,
+}
+
+impl PeerCertAcceptor {
+    pub fn new(config: RustlsConfig) -> Self {
+        PeerCertAcceptor {
+            inner: RustlsAcceptor::new(config),
+        }
+    }
+}
+
+impl<I, S> Accept<I, S> for PeerCertAcceptor
+where
+    I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: Send + 'static,
+{
+    type Stream = TlsStream<I>;
+    type Service = InjectPeerIdentity<S>;
+    type Future = Pin<Box<dyn Future<Output = io::Result<(Self::Stream, Self::Service)>> + Send>>;
+
+    fn accept(&self, stream: I, service: S) -> Self::Future {
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            // Same handshake (and handshake timeout) as axum-server's own
+            // rustls path — we only add identity extraction afterwards.
+            let (stream, service) = inner.accept(stream, service).await?;
+            let identity = stream
+                .get_ref()
+                .1
+                .peer_certificates()
+                .and_then(|certs| certs.first())
+                .map(|leaf| Arc::new(PeerIdentity::from_der(leaf.as_ref())));
+            Ok((
+                stream,
+                InjectPeerIdentity {
+                    inner: service,
+                    identity,
+                },
+            ))
+        })
+    }
+}
+
+/// Per-connection service wrapper that inserts `Arc<PeerIdentity>` into each
+/// request's extensions. When the identity is absent (defensive: rustls
+/// reported no peer cert), nothing is injected.
+#[derive(Clone)]
+pub struct InjectPeerIdentity<S> {
+    inner: S,
+    identity: Option<Arc<PeerIdentity>>,
+}
+
+impl<S, B> tower::Service<axum::http::Request<B>> for InjectPeerIdentity<S>
+where
+    S: tower::Service<axum::http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: axum::http::Request<B>) -> Self::Future {
+        if let Some(identity) = &self.identity {
+            req.extensions_mut().insert(identity.clone());
+        }
+        self.inner.call(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn openssl() -> PathBuf {
+        crate::enroll::sign::resolve_openssl().expect("openssl must be installed")
+    }
+
+    fn run(args: &[&std::ffi::OsStr]) {
+        let o = Command::new(openssl()).args(args).output().unwrap();
+        assert!(
+            o.status.success(),
+            "openssl {args:?}: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+    }
+
+    /// Generate a self-signed cert (EC P-256, fast) with the given CN and
+    /// optional SAN, and return its DER bytes.
+    fn make_cert_der(dir: &Path, cn: &str, san: Option<&str>) -> Vec<u8> {
+        let key = dir.join("k.pem");
+        let crt = dir.join("c.pem");
+        run(&[
+            "genpkey".as_ref(),
+            "-algorithm".as_ref(),
+            "EC".as_ref(),
+            "-pkeyopt".as_ref(),
+            "ec_paramgen_curve:P-256".as_ref(),
+            "-out".as_ref(),
+            key.as_os_str(),
+        ]);
+        let subj = format!("/CN={cn}");
+        let mut args: Vec<&std::ffi::OsStr> = vec![
+            "req".as_ref(),
+            "-x509".as_ref(),
+            "-new".as_ref(),
+            "-key".as_ref(),
+            key.as_os_str(),
+            "-days".as_ref(),
+            "1".as_ref(),
+            "-subj".as_ref(),
+            subj.as_ref(),
+        ];
+        let san_ext = san.map(|s| format!("subjectAltName=DNS:{s}"));
+        if let Some(ext) = san_ext.as_deref() {
+            args.push("-addext".as_ref());
+            args.push(ext.as_ref());
+        }
+        args.push("-out".as_ref());
+        args.push(crt.as_os_str());
+        run(&args);
+        // PEM → DER via rustls-pemfile (same decoder the server uses).
+        let pem = std::fs::read(&crt).unwrap();
+        let mut rd = std::io::BufReader::new(&pem[..]);
+        let certs: Vec<_> = rustls_pemfile::certs(&mut rd)
+            .collect::<Result<_, _>>()
+            .unwrap();
+        certs[0].as_ref().to_vec()
+    }
+
+    const HOST: &str = "018f9c1a-0000-7000-8000-0000000000aa";
+
+    #[test]
+    fn identity_from_cert_with_cn_and_san() {
+        let d = tempfile::tempdir().unwrap();
+        let der = make_cert_der(d.path(), HOST, Some(HOST));
+        let id = PeerIdentity::from_der(&der);
+        assert_eq!(id.fingerprint, blake3::hash(&der).to_hex().to_string());
+        assert_eq!(id.cn.as_deref(), Some(HOST));
+        assert_eq!(id.san_dns, vec![HOST.to_string()]);
+    }
+
+    #[test]
+    fn identity_from_cert_without_san() {
+        let d = tempfile::tempdir().unwrap();
+        let der = make_cert_der(d.path(), "no-san-host", None);
+        let id = PeerIdentity::from_der(&der);
+        assert_eq!(id.cn.as_deref(), Some("no-san-host"));
+        assert!(id.san_dns.is_empty());
+    }
+
+    /// Garbage DER: fingerprint is still set (it needs no parsing); CN/SAN
+    /// degrade to None/empty. Must not panic.
+    #[test]
+    fn identity_from_garbage_der_keeps_fingerprint() {
+        let garbage = b"definitely not a certificate";
+        let id = PeerIdentity::from_der(garbage);
+        assert_eq!(
+            id.fingerprint,
+            blake3::hash(garbage).to_hex().to_string(),
+            "fingerprint must be blake3 of the raw bytes"
+        );
+        assert_eq!(id.cn, None);
+        assert!(id.san_dns.is_empty());
+    }
+
+    /// The service wrapper injects `Arc<PeerIdentity>` into request extensions
+    /// when an identity is present, and injects NOTHING when it is absent.
+    #[tokio::test]
+    async fn inject_service_adds_extension_only_when_identity_present() {
+        use axum::http::Request;
+        use tower::{Service, ServiceExt};
+
+        // Echo service that reports whether the extension was present.
+        let probe = tower::service_fn(|req: Request<axum::body::Body>| async move {
+            let present = req.extensions().get::<Arc<PeerIdentity>>().is_some();
+            Ok::<_, std::convert::Infallible>(axum::http::Response::new(present.to_string()))
+        });
+
+        let identity = Arc::new(PeerIdentity {
+            fingerprint: "ff".into(),
+            cn: Some("c".into()),
+            san_dns: vec![],
+        });
+        let mut with_id = InjectPeerIdentity {
+            inner: probe,
+            identity: Some(identity),
+        };
+        let req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        let resp = with_id.ready().await.unwrap().call(req).await.unwrap();
+        assert_eq!(resp.into_body(), "true");
+
+        let mut without_id = InjectPeerIdentity {
+            inner: probe,
+            identity: None,
+        };
+        let req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        let resp = without_id.ready().await.unwrap().call(req).await.unwrap();
+        assert_eq!(resp.into_body(), "false");
+    }
+}

--- a/crates/sigil-server/tests/artifacts.rs
+++ b/crates/sigil-server/tests/artifacts.rs
@@ -33,6 +33,7 @@ fn state(scratch: &Path, artifacts_dir: Option<PathBuf>, token: Option<&str>) ->
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     })
 }
 

--- a/crates/sigil-server/tests/audit.rs
+++ b/crates/sigil-server/tests/audit.rs
@@ -37,6 +37,7 @@ async fn meta_reports_audit_head_when_signing_enabled() {
         })),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
 
     let app = build_router(state);
@@ -86,6 +87,7 @@ async fn meta_reports_null_audit_head_when_disabled() {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
 
     let app = build_router(state);

--- a/crates/sigil-server/tests/auth_e2e.rs
+++ b/crates/sigil-server/tests/auth_e2e.rs
@@ -26,6 +26,7 @@ fn state(dir: &std::path::Path, token: ReadToken) -> Arc<AppState> {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     })
 }
 

--- a/crates/sigil-server/tests/boot_rebuild_e2e.rs
+++ b/crates/sigil-server/tests/boot_rebuild_e2e.rs
@@ -69,6 +69,7 @@ async fn boot_rebuild_populates_fleet_hosts() {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
     let app = build_router(state);
     let req = Request::builder()

--- a/crates/sigil-server/tests/enroll.rs
+++ b/crates/sigil-server/tests/enroll.rs
@@ -178,6 +178,7 @@ fn state_with_issuers(
         audit_head: Mutex::new(None),
         allowlist_path: Some(allowlist_path),
         enroll,
+        events_require_cert_host_match: false,
     })
 }
 

--- a/crates/sigil-server/tests/enroll.rs
+++ b/crates/sigil-server/tests/enroll.rs
@@ -15,6 +15,7 @@ use sigil_server::enroll::tokens::TokenStore;
 use sigil_server::enroll::EnrollState;
 use sigil_server::fleet_index::FleetIndex;
 use sigil_server::persist::HighWater;
+use sigil_server::tls_accept::PeerIdentity;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -131,6 +132,15 @@ fn cert_text(dir: &Path, leaf_pem: &str) -> String {
 /// (empty) allowlist file is written so EnrollState::load's fix-B gate passes,
 /// and the in-memory allowlist starts as the same restrictive `Some(set)`.
 fn state(scratch: &Path, with_enroll: bool) -> Arc<AppState> {
+    state_with_issuers(scratch, with_enroll, None)
+}
+
+/// Same as `state`, with an optional #194.1 issuer-fingerprint allowlist.
+fn state_with_issuers(
+    scratch: &Path,
+    with_enroll: bool,
+    issuer_fingerprints: Option<Vec<String>>,
+) -> Arc<AppState> {
     let tokens_path = scratch.join("tokens.json");
     let allowlist_path = scratch.join("hosts.json");
     // restrictive (empty) on-disk allowlist — required when enrollment is on.
@@ -146,6 +156,7 @@ fn state(scratch: &Path, with_enroll: bool) -> Arc<AppState> {
             true, // mtls on (fix A) — tests drive the handler directly
             Some(30),
             scratch.join("enrollment-audit.jsonl"),
+            issuer_fingerprints,
         )
     } else {
         None
@@ -176,18 +187,34 @@ async fn post_enroll(
     host_id: &str,
     csr_pem: &str,
 ) -> (StatusCode, serde_json::Value) {
+    post_enroll_as(app, token, host_id, csr_pem, None).await
+}
+
+/// Like `post_enroll`, but optionally injects a `PeerIdentity` request
+/// extension — exactly what `PeerCertAcceptor` does on a live mTLS connection.
+async fn post_enroll_as(
+    app: &axum::Router,
+    token: &str,
+    host_id: &str,
+    csr_pem: &str,
+    peer: Option<Arc<PeerIdentity>>,
+) -> (StatusCode, serde_json::Value) {
     let body = serde_json::json!({
         "token": token,
         "host_id": host_id,
         "csr_pem": csr_pem,
     });
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/enroll")
+        .header("content-type", "application/json");
+    if let Some(peer) = peer {
+        builder = builder.extension(peer);
+    }
     let resp = app
         .clone()
         .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/enroll")
-                .header("content-type", "application/json")
+            builder
                 .body(Body::from(serde_json::to_vec(&body).unwrap()))
                 .unwrap(),
         )
@@ -199,6 +226,15 @@ async fn post_enroll(
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
     (status, json)
+}
+
+/// A synthetic caller identity, as the acceptor would build from the leaf DER.
+fn peer_with_fingerprint(fp: &str) -> Arc<PeerIdentity> {
+    Arc::new(PeerIdentity {
+        fingerprint: fp.to_string(),
+        cn: Some("issuer-box".to_string()),
+        san_dns: vec![],
+    })
 }
 
 const HOST: &str = "018f9c1a-0000-7000-8000-000000000001";
@@ -419,4 +455,165 @@ async fn audit_failure_does_not_grant_allowlist() {
         !permits(&st_for_check.allowlist.read(), HOST),
         "host must NOT be permitted in-memory when audit failed"
     );
+}
+
+// --- #194.1 — caller (issuer) cert binding -----------------------------------
+
+/// Read the enrollment audit JSONL as parsed JSON values.
+fn audit_lines(path: &Path) -> Vec<serde_json::Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+const ISSUER_FP: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+#[tokio::test]
+async fn issuer_list_with_matching_peer_is_allowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state_with_issuers(dir.path(), true, Some(vec![ISSUER_FP.to_string()]));
+    let en = st.enroll.as_ref().unwrap();
+    let (tokens_path, audit_path) = (en.tokens_path.clone(), en.audit_path.clone());
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let peer = peer_with_fingerprint(ISSUER_FP);
+    let (status, body) = post_enroll_as(&app, &token, HOST, &csr, Some(peer)).await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+
+    // The issued audit record carries the caller's fingerprint.
+    let lines = audit_lines(&audit_path);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0]["decision"], "issued");
+    assert_eq!(lines[0]["caller_fingerprint"], ISSUER_FP);
+}
+
+#[tokio::test]
+async fn issuer_list_with_wrong_fingerprint_is_denied_403_generic() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state_with_issuers(dir.path(), true, Some(vec![ISSUER_FP.to_string()]));
+    let en = st.enroll.as_ref().unwrap();
+    let (tokens_path, audit_path) = (en.tokens_path.clone(), en.audit_path.clone());
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let wrong = peer_with_fingerprint(&"b".repeat(64));
+    let (status, body) = post_enroll_as(&app, &token, HOST, &csr, Some(wrong)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    // SAME body as every token failure — no oracle for "wrong caller".
+    assert_eq!(
+        body,
+        serde_json::json!({"error": {"code": "enrollment_denied", "message": "enrollment denied"}})
+    );
+
+    // Denial is audited with the internal reason + caller fingerprint.
+    let lines = audit_lines(&audit_path);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0]["decision"], "denied");
+    assert_eq!(lines[0]["reason"], "issuer_not_allowed");
+    assert_eq!(lines[0]["caller_fingerprint"], "b".repeat(64));
+
+    // The gate runs BEFORE the token is touched: the same token still works
+    // for an authorized caller.
+    let ok_peer = peer_with_fingerprint(ISSUER_FP);
+    let (status, body) = post_enroll_as(&app, &token, HOST, &csr, Some(ok_peer)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "token must not be spent, body={body}"
+    );
+}
+
+#[tokio::test]
+async fn issuer_list_with_no_peer_identity_is_denied_403() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state_with_issuers(dir.path(), true, Some(vec![ISSUER_FP.to_string()]));
+    let tokens_path = st.enroll.as_ref().unwrap().tokens_path.clone();
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let (status, body) = post_enroll_as(&app, &token, HOST, &csr, None).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["error"]["code"], "enrollment_denied");
+}
+
+/// Uppercase config entries are normalized: a lowercase-hex caller still matches.
+#[tokio::test]
+async fn issuer_list_entries_are_normalized_to_lowercase() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state_with_issuers(dir.path(), true, Some(vec![ISSUER_FP.to_ascii_uppercase()]));
+    let tokens_path = st.enroll.as_ref().unwrap().tokens_path.clone();
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let peer = peer_with_fingerprint(ISSUER_FP);
+    let (status, body) = post_enroll_as(&app, &token, HOST, &csr, Some(peer)).await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+}
+
+/// An EMPTY issuer list is deny-all (operator error surfaces fast).
+#[tokio::test]
+async fn issuer_list_empty_denies_all() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state_with_issuers(dir.path(), true, Some(vec![]));
+    let tokens_path = st.enroll.as_ref().unwrap().tokens_path.clone();
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let peer = peer_with_fingerprint(ISSUER_FP);
+    let (status, _) = post_enroll_as(&app, &token, HOST, &csr, Some(peer)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+/// List unset ⇒ pre-#194 behavior: a peer identity may be present or absent;
+/// either way enrollment succeeds and the audit carries the real caller
+/// fingerprint ("" when absent — covered by the other happy-path test).
+#[tokio::test]
+async fn no_issuer_list_still_records_caller_fingerprint_when_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state(dir.path(), true);
+    let en = st.enroll.as_ref().unwrap();
+    let (tokens_path, audit_path) = (en.tokens_path.clone(), en.audit_path.clone());
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let peer = peer_with_fingerprint(ISSUER_FP);
+    let (status, body) = post_enroll_as(&app, &token, HOST, &csr, Some(peer)).await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    let lines = audit_lines(&audit_path);
+    assert_eq!(lines[0]["caller_fingerprint"], ISSUER_FP);
+}
+
+/// Absent peer + no issuer list: the audit caller_fingerprint is "" (empty),
+/// never fabricated.
+#[tokio::test]
+async fn absent_peer_audits_empty_caller_fingerprint() {
+    let dir = tempfile::tempdir().unwrap();
+    let st = state(dir.path(), true);
+    let en = st.enroll.as_ref().unwrap();
+    let (tokens_path, audit_path) = (en.tokens_path.clone(), en.audit_path.clone());
+    let now = OffsetDateTime::now_utc();
+    let token = TokenStore::issue(&tokens_path, HOST, now + Duration::hours(1), now).unwrap();
+    let csr = make_csr(dir.path(), HOST);
+    let app = build_router(st);
+
+    let (status, _) = post_enroll(&app, &token, HOST, &csr).await;
+    assert_eq!(status, StatusCode::OK);
+    let lines = audit_lines(&audit_path);
+    assert_eq!(lines[0]["caller_fingerprint"], "");
 }

--- a/crates/sigil-server/tests/events_cert_binding.rs
+++ b/crates/sigil-server/tests/events_cert_binding.rs
@@ -1,8 +1,8 @@
 //! #194.2 — `POST /v1/events` cert↔host_id binding, driven in-process via
 //! `tower::ServiceExt::oneshot` with a `PeerIdentity` request extension —
 //! exactly what `tls_accept::PeerCertAcceptor` injects on a live mTLS
-//! connection. (The acceptor itself is covered by unit tests; a live-TLS
-//! round trip is a hardware e2e item.)
+//! connection. (The acceptor itself is covered by unit tests and by the
+//! live-TLS round trip in `tests/mtls_acceptor_e2e.rs`.)
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};

--- a/crates/sigil-server/tests/events_cert_binding.rs
+++ b/crates/sigil-server/tests/events_cert_binding.rs
@@ -1,0 +1,176 @@
+//! #194.2 — `POST /v1/events` cert↔host_id binding, driven in-process via
+//! `tower::ServiceExt::oneshot` with a `PeerIdentity` request extension —
+//! exactly what `tls_accept::PeerCertAcceptor` injects on a live mTLS
+//! connection. (The acceptor itself is covered by unit tests; a live-TLS
+//! round trip is a hardware e2e item.)
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sigil_server::app::{build_router, AppState};
+use sigil_server::auth::ReadToken;
+use sigil_server::fleet_index::FleetIndex;
+use sigil_server::persist::HighWater;
+use sigil_server::tls_accept::PeerIdentity;
+use std::sync::{Arc, Mutex};
+
+/// AppState with NO allowlist (permit-all) so only the #194.2 cert gate is
+/// under test — a cert-mismatch rejection therefore proves the gate fires
+/// BEFORE (independently of) the allowlist.
+fn state(dir: &std::path::Path, require_match: bool) -> Arc<AppState> {
+    Arc::new(AppState {
+        events_out_dir: dir.to_path_buf(),
+        policy_bundle_path: dir.join("signed-policy.json"),
+        rule_packs_bundle_path: None,
+        artifacts_dir: None,
+        high_water_path: dir.join(".high-water.json"),
+        allowlist: parking_lot::RwLock::new(None),
+        high_water: Mutex::new(HighWater::default()),
+        fleet_index: FleetIndex::new(),
+        read_token: ReadToken(None),
+        license_state: sigil_core::license::status::LicenseState::Free,
+        active_window_days: 7,
+        audit_key: None,
+        audit_head: Mutex::new(None),
+        allowlist_path: None,
+        enroll: None,
+        events_require_cert_host_match: require_match,
+    })
+}
+
+fn sample_event_json(host_id: &str, event_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": 1,
+        "event_id": event_id,
+        "ts": "2026-07-01T00:00:00Z",
+        "host_id": host_id,
+        "agent_version": "0.1.0",
+        "severity": "warn",
+        "source": {"kind": "agent"},
+        "subject": {"kind": "self"},
+        "evidence": {"kind": "host_id_conflict", "observed_status": 200},
+        "target_id": null
+    })
+}
+
+fn events_request(host_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "envelope": {"host_id": host_id, "schema_version": 1},
+        "events": [{
+            "event_id": EVENT_ID,
+            "sequence": 1,
+            "payload": sample_event_json(host_id, EVENT_ID),
+        }],
+    })
+}
+
+async fn post_events_as(
+    app: &axum::Router,
+    body: &serde_json::Value,
+    peer: Option<Arc<PeerIdentity>>,
+) -> (StatusCode, serde_json::Value) {
+    use tower::ServiceExt;
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/events")
+        .header("content-type", "application/json");
+    if let Some(peer) = peer {
+        builder = builder.extension(peer);
+    }
+    let resp = app
+        .clone()
+        .oneshot(
+            builder
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+const HOST: &str = "018f9c1a-0000-7000-8000-0000000000c1";
+const EVENT_ID: &str = "00000000-0000-0000-0000-00000000000a";
+
+fn peer(cn: Option<&str>, san: &[&str]) -> Arc<PeerIdentity> {
+    Arc::new(PeerIdentity {
+        fingerprint: "f".repeat(64),
+        cn: cn.map(str::to_string),
+        san_dns: san.iter().map(|s| s.to_string()).collect(),
+    })
+}
+
+#[tokio::test]
+async fn flag_on_cn_match_is_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state(dir.path(), true));
+    let (status, body) =
+        post_events_as(&app, &events_request(HOST), Some(peer(Some(HOST), &[]))).await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["accepted"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn flag_on_san_only_match_is_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state(dir.path(), true));
+    // CN differs; SAN DNS carries the host_id (B-mint certs carry both, but
+    // either alone must satisfy the gate).
+    let (status, body) = post_events_as(
+        &app,
+        &events_request(HOST),
+        Some(peer(Some("something-else"), &[HOST])),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+}
+
+#[tokio::test]
+async fn flag_on_cn_mismatch_is_404_host_unknown() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state(dir.path(), true));
+    let (status, body) = post_events_as(
+        &app,
+        &events_request(HOST),
+        Some(peer(Some("other-host"), &["other-host"])),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    // SAME shape as the allowlist rejection — no oracle distinguishing the two.
+    assert_eq!(body["error"], "host_unknown");
+    assert_eq!(body["host_id"], HOST);
+}
+
+#[tokio::test]
+async fn flag_on_missing_peer_identity_is_404_host_unknown() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state(dir.path(), true));
+    let (status, body) = post_events_as(&app, &events_request(HOST), None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "host_unknown");
+}
+
+#[tokio::test]
+async fn flag_off_behavior_unchanged_no_peer_needed() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state(dir.path(), false));
+    let (status, body) = post_events_as(&app, &events_request(HOST), None).await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+}
+
+#[tokio::test]
+async fn flag_off_mismatched_peer_is_still_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = build_router(state(dir.path(), false));
+    let (status, body) = post_events_as(
+        &app,
+        &events_request(HOST),
+        Some(peer(Some("other-host"), &[])),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+}

--- a/crates/sigil-server/tests/events_pagination_e2e.rs
+++ b/crates/sigil-server/tests/events_pagination_e2e.rs
@@ -53,6 +53,7 @@ async fn events_pagination_walks_in_pages() {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
     let app = build_router(state);
 

--- a/crates/sigil-server/tests/host_meta_in_detail_e2e.rs
+++ b/crates/sigil-server/tests/host_meta_in_detail_e2e.rs
@@ -64,6 +64,7 @@ async fn ingested_host_meta_appears_in_detail_block() {
         audit_head: std::sync::Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
     let app = build_router(state);
     let req = Request::builder()

--- a/crates/sigil-server/tests/http_routes.rs
+++ b/crates/sigil-server/tests/http_routes.rs
@@ -36,6 +36,7 @@ fn state_in_with_rule_packs(
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     })
 }
 

--- a/crates/sigil-server/tests/license.rs
+++ b/crates/sigil-server/tests/license.rs
@@ -44,6 +44,7 @@ async fn meta_reports_over_limit_for_free_tier_above_200_active_hosts() {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
 
     let app = build_router(state);
@@ -111,6 +112,7 @@ async fn meta_reports_ok_for_valid_license_under_its_limit() {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
 
     let app = build_router(state);
@@ -179,6 +181,7 @@ async fn meta_reports_expired_falls_back_to_free_tier() {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     });
 
     let app = build_router(state);

--- a/crates/sigil-server/tests/mtls_acceptor_e2e.rs
+++ b/crates/sigil-server/tests/mtls_acceptor_e2e.rs
@@ -1,0 +1,264 @@
+//! #194 — live-TLS e2e for `tls_accept::PeerCertAcceptor`: a REAL rustls
+//! handshake (WebPkiClientVerifier), a REAL client cert, and the
+//! `events_require_cert_host_match` gate — proving the acceptor extracts the
+//! peer identity from the wire and injects it into requests, end to end.
+//!
+//! Uses openssl (on PATH in CI) for the test PKI and reqwest (rustls) as the
+//! mTLS client. Binds 127.0.0.1:0.
+
+use sigil_server::app::{build_router, AppState};
+use sigil_server::auth::ReadToken;
+use sigil_server::fleet_index::FleetIndex;
+use sigil_server::persist::HighWater;
+use sigil_server::tls_accept::PeerCertAcceptor;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+fn openssl() -> PathBuf {
+    sigil_server::enroll::sign::resolve_openssl().expect("openssl must be installed")
+}
+
+fn run(args: &[&std::ffi::OsStr]) {
+    let o = Command::new(openssl()).args(args).output().unwrap();
+    assert!(
+        o.status.success(),
+        "openssl {args:?}: {}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+}
+
+/// Self-signed CA (RSA 2048 — same profile as the enroll tests; parses with
+/// ring across openssl/LibreSSL PKCS#8 output variants) used for BOTH the server cert and client certs.
+fn make_ca(dir: &Path) -> (PathBuf, PathBuf) {
+    let key = dir.join("ca.key");
+    let crt = dir.join("ca.crt");
+    run(&[
+        "genpkey".as_ref(),
+        "-algorithm".as_ref(),
+        "RSA".as_ref(),
+        "-pkeyopt".as_ref(),
+        "rsa_keygen_bits:2048".as_ref(),
+        "-out".as_ref(),
+        key.as_os_str(),
+    ]);
+    run(&[
+        "req".as_ref(),
+        "-x509".as_ref(),
+        "-new".as_ref(),
+        "-key".as_ref(),
+        key.as_os_str(),
+        "-days".as_ref(),
+        "1".as_ref(),
+        "-subj".as_ref(),
+        "/CN=test-e2e-ca".as_ref(),
+        "-addext".as_ref(),
+        "basicConstraints=critical,CA:TRUE".as_ref(),
+        "-out".as_ref(),
+        crt.as_os_str(),
+    ]);
+    (crt, key)
+}
+
+/// CA-signed leaf: key + cert paths. `ext` is an openssl x509 v3 ext block.
+fn make_leaf(dir: &Path, name: &str, cn: &str, ext: &str) -> (PathBuf, PathBuf) {
+    let key = dir.join(format!("{name}.key"));
+    let csr = dir.join(format!("{name}.csr"));
+    let crt = dir.join(format!("{name}.crt"));
+    let extf = dir.join(format!("{name}.ext"));
+    std::fs::write(&extf, ext).unwrap();
+    run(&[
+        "genpkey".as_ref(),
+        "-algorithm".as_ref(),
+        "RSA".as_ref(),
+        "-pkeyopt".as_ref(),
+        "rsa_keygen_bits:2048".as_ref(),
+        "-out".as_ref(),
+        key.as_os_str(),
+    ]);
+    let subj = format!("/CN={cn}");
+    run(&[
+        "req".as_ref(),
+        "-new".as_ref(),
+        "-key".as_ref(),
+        key.as_os_str(),
+        "-subj".as_ref(),
+        subj.as_ref(),
+        "-out".as_ref(),
+        csr.as_os_str(),
+    ]);
+    run(&[
+        "x509".as_ref(),
+        "-req".as_ref(),
+        "-in".as_ref(),
+        csr.as_os_str(),
+        "-CA".as_ref(),
+        dir.join("ca.crt").as_os_str(),
+        "-CAkey".as_ref(),
+        dir.join("ca.key").as_os_str(),
+        "-CAcreateserial".as_ref(),
+        "-days".as_ref(),
+        "1".as_ref(),
+        "-extfile".as_ref(),
+        extf.as_os_str(),
+        "-out".as_ref(),
+        crt.as_os_str(),
+    ]);
+    (crt, key)
+}
+
+fn state(dir: &Path, require_match: bool) -> Arc<AppState> {
+    Arc::new(AppState {
+        events_out_dir: dir.to_path_buf(),
+        policy_bundle_path: dir.join("signed-policy.json"),
+        rule_packs_bundle_path: None,
+        artifacts_dir: None,
+        high_water_path: dir.join(".high-water.json"),
+        allowlist: parking_lot::RwLock::new(None), // permit-all: only #194.2 gates
+        high_water: Mutex::new(HighWater::default()),
+        fleet_index: FleetIndex::new(),
+        read_token: ReadToken(None),
+        license_state: sigil_core::license::status::LicenseState::Free,
+        active_window_days: 7,
+        audit_key: None,
+        audit_head: Mutex::new(None),
+        allowlist_path: None,
+        enroll: None,
+        events_require_cert_host_match: require_match,
+    })
+}
+
+/// rustls ServerConfig mirroring main.rs `build_mtls` (WebPkiClientVerifier).
+fn tls_config(server_crt: &Path, server_key: &Path, ca: &Path) -> rustls::ServerConfig {
+    let certs: Vec<_> = rustls_pemfile::certs(&mut std::io::BufReader::new(
+        &std::fs::read(server_crt).unwrap()[..],
+    ))
+    .collect::<Result<_, _>>()
+    .unwrap();
+    let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(
+        &std::fs::read(server_key).unwrap()[..],
+    ))
+    .unwrap()
+    .unwrap();
+    let ca_certs: Vec<_> = rustls_pemfile::certs(&mut std::io::BufReader::new(
+        &std::fs::read(ca).unwrap()[..],
+    ))
+    .collect::<Result<_, _>>()
+    .unwrap();
+    let mut roots = rustls::RootCertStore::empty();
+    for c in ca_certs {
+        roots.add(c).unwrap();
+    }
+    let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(roots))
+        .build()
+        .unwrap();
+    rustls::ServerConfig::builder()
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .unwrap()
+}
+
+fn events_body(host_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "envelope": {"host_id": host_id, "schema_version": 1},
+        "events": [{
+            "event_id": "00000000-0000-0000-0000-00000000000a",
+            "sequence": 1,
+            "payload": {
+                "schema_version": 1,
+                "event_id": "00000000-0000-0000-0000-00000000000a",
+                "ts": "2026-07-01T00:00:00Z",
+                "host_id": host_id,
+                "agent_version": "0.1.0",
+                "severity": "warn",
+                "source": {"kind": "agent"},
+                "subject": {"kind": "self"},
+                "evidence": {"kind": "host_id_conflict", "observed_status": 200},
+                "target_id": null
+            },
+        }],
+    })
+}
+
+/// mTLS reqwest client presenting `crt`+`key`, trusting the test CA.
+fn client(ca: &Path, crt: &Path, key: &Path) -> reqwest::Client {
+    let mut identity_pem = std::fs::read(key).unwrap();
+    identity_pem.extend_from_slice(&std::fs::read(crt).unwrap());
+    reqwest::Client::builder()
+        .use_rustls_tls()
+        .add_root_certificate(reqwest::Certificate::from_pem(&std::fs::read(ca).unwrap()).unwrap())
+        .identity(reqwest::Identity::from_pem(&identity_pem).unwrap())
+        .build()
+        .unwrap()
+}
+
+const HOST: &str = "018f9c1a-0000-7000-8000-0000000000e1";
+
+#[tokio::test]
+async fn live_mtls_cert_host_binding_end_to_end() {
+    // rustls 0.23 needs a process default provider (same as main.rs).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let dir = tempfile::tempdir().unwrap();
+    make_ca(dir.path());
+    let (srv_crt, srv_key) = make_leaf(
+        dir.path(),
+        "server",
+        "localhost",
+        "subjectAltName=IP:127.0.0.1\nextendedKeyUsage=serverAuth\nbasicConstraints=CA:FALSE\n",
+    );
+    // Agent cert: CN == host_id and SAN DNS:host_id (B-mint profile).
+    let good_ext = format!(
+        "subjectAltName=DNS:{HOST}\nextendedKeyUsage=clientAuth\nbasicConstraints=CA:FALSE\n"
+    );
+    let (good_crt, good_key) = make_leaf(dir.path(), "agent-good", HOST, &good_ext);
+    // Valid fleet cert (chains to the CA!) but for a DIFFERENT host.
+    let (other_crt, other_key) = make_leaf(
+        dir.path(),
+        "agent-other",
+        "018f9c1a-0000-7000-8000-0000000000ff",
+        "subjectAltName=DNS:018f9c1a-0000-7000-8000-0000000000ff\nextendedKeyUsage=clientAuth\nbasicConstraints=CA:FALSE\n",
+    );
+
+    let ca = dir.path().join("ca.crt");
+    let tls = axum_server::tls_rustls::RustlsConfig::from_config(Arc::new(tls_config(
+        &srv_crt, &srv_key, &ca,
+    )));
+    let app = build_router(state(dir.path(), true));
+    let handle = axum_server::Handle::new();
+    let server_handle = handle.clone();
+    tokio::spawn(async move {
+        axum_server::bind("127.0.0.1:0".parse().unwrap())
+            .handle(server_handle)
+            .acceptor(PeerCertAcceptor::new(tls))
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+    let addr = handle.listening().await.expect("server must bind");
+    let url = format!("https://127.0.0.1:{}/v1/events", addr.port());
+
+    // Matching cert (CN + SAN == host_id) over a REAL handshake ⇒ accepted.
+    let resp = client(&ca, &good_crt, &good_key)
+        .post(&url)
+        .json(&events_body(HOST))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "matching cert must be accepted");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["accepted"].as_array().unwrap().len(), 1);
+
+    // Valid fleet cert for ANOTHER host claiming this host_id ⇒ 404, no oracle.
+    let resp = client(&ca, &other_crt, &other_key)
+        .post(&url)
+        .json(&events_body(HOST))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404, "cross-host cert must be rejected");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"], "host_unknown");
+
+    handle.shutdown();
+}

--- a/crates/sigil-server/tests/read_api_e2e.rs
+++ b/crates/sigil-server/tests/read_api_e2e.rs
@@ -26,6 +26,7 @@ fn state_with_token(dir: &std::path::Path, token: &str) -> Arc<AppState> {
         audit_head: Mutex::new(None),
         allowlist_path: None,
         enroll: None,
+        events_require_cert_host_match: false,
     })
 }
 


### PR DESCRIPTION
Closes #194 (B-mint #184 follow-up). The rustls layer verified WHO connected but handlers never saw it — `caller_fingerprint` in the enrollment audit was an empty TODO, any enrolled cert could redeem a leaked enroll token, and any enrolled cert could impersonate any allowlisted host_id on `/v1/events`.

## Foundation — peer-cert plumbing (`tls_accept.rs`)
`PeerCertAcceptor` wraps axum-server's own `RustlsAcceptor` (same handshake, same timeout): after the handshake it reads the verified leaf from `peer_certificates()`, derives `PeerIdentity { fingerprint: blake3(DER), cn, san_dns }` (CN/SAN via pure-Rust `x509-parser` — total parser, no panics on attacker bytes; no per-connection openssl), and wraps the connection's service so every request carries `Extension<Arc<PeerIdentity>>`. No peer cert ⇒ nothing injected — handlers can never see a forged identity, and the plain-HTTP dev path is untouched.

## 1. `/v1/enroll` issuer binding
New config `enroll_issuer_fingerprints: ["<64-hex blake3>", …]`. When set, the caller's client-cert fingerprint must be listed — checked inside the mint lock, **before any CSR parsing or token access** (an unauthorized caller can't feed openssl input, probe token state, or spend the token), answered with the byte-identical generic 403. Entries are boot-validated (exactly 64 hex, deduped; malformed ⇒ enrollment disabled loudly, not a silent lockout). The enrollment audit now records `caller_fingerprint` for **all** outcomes (resolves the #184 TODO).

## 2. `/v1/events` cert↔host_id match (opt-in)
New config `events_require_cert_host_match: true`: the peer cert's CN or a SAN DNS entry must equal `envelope.host_id` (ASCII-case-insensitive — DNS semantics; UUID hex case carries no identity). Checked **before** the allowlist; rejection is byte-identical to the allowlist 404 (no oracle), fingerprint logged for operators. Default **off** for compatibility with manually-deployed certs; B-mint-issued certs (CN=SAN=host_id) work immediately. Boot refuses the flag without mTLS.

## Verification (layered)
- Implementation reviewed line-by-line; **codex adversarial review: 0 P1**. Non-findings confirmed: extension smuggling not viable, keep-alive keeps per-connection identity, `peer_certificates()[0]` is the leaf (rustls 0.23), no renegotiation cert swap, no panics. 2 of 3 P2s fixed (case-insensitive match; boot validation of fingerprints); the third (gates run after axum's `Json` extraction — parser-level oracle only, not a token/allowlist oracle) documented in-code as a known limit.
- `cargo fmt` + `clippy --all-targets -D warnings` clean; `cargo test --workspace` 0 failures. New tests: acceptor unit (CN/SAN/fingerprint, garbage DER), enroll oneshot (listed 200 / unlisted generic 403 + token **not** spent / audit fp), events oneshot (CN match / SAN match / mismatch 404 same-shape / flag off unchanged), config (parse + boot refusal), **live-TLS e2e** (real WebPkiClientVerifier handshake in-repo).
- **Hardware e2e on Rocky 9 aarch64** (real openssl PKI, real connections): bootstrap enroll records a 64-hex `caller_fingerprint`; unlisted cert → 403 with token left unspent, listed cert then succeeds; hostA's cert accepted for its own host_id and rejected (404 `host_unknown`, allowlist-identical shape) when claiming another allowlisted host; denial audited as `issuer_not_allowed` with the caller fingerprint.

## Deps
`x509-parser 0.18` (pure Rust), `tokio-rustls` (types only, default-features off), `tower` promoted from dev-dep.

## Follow-ups (not in scope)
Revocation (CRL), rate limiting, `config/server.example.yaml` docs pass for the #184+#194 keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
