### PR TITLE
docs(server): document enroll + peer-cert + artifacts keys in example config

### DIFF
--- a/config/server.example.yaml
+++ b/config/server.example.yaml
@@ -25,3 +25,47 @@ policy_bundle_path: "/var/lib/sigil-server/signed-policy.json"
 # Optional — per-host event-id high-water file (at-least-once dedup). If
 # unset, the server uses <events_out_dir>/.high-water.json.
 # high_water_path: "/var/lib/sigil-server/high_water.json"
+
+# Optional — signed rule-pack bundle served at GET /v1/rule-packs. Produced by
+# `sigil-sign` like the policy bundle. Absent ⇒ that route returns 404.
+# rule_packs_bundle_path: "/var/lib/sigil-server/signed-rule-packs.json"
+
+# Optional (#182) — directory of operator-populated, signed agent release
+# artifacts (tarballs/zips, .deb/.rpm, SHA256SUMS, build-manifest.json), served
+# read-only at GET /v1/artifacts[/ <file>] so an air-gapped fleet/PMS can pull
+# clients from the server instead of GitHub. Bearer-gated, path-traversal-hardened.
+# Absent ⇒ /v1/artifacts* returns 404 (feature off).
+# artifacts_dir: "/var/lib/sigil-server/artifacts"
+
+# --- Automated enrollment / B-mint (#184) --------------------------------------
+# POST /v1/enroll signs a per-host CSR into a short-lived mTLS client cert using
+# an operator-provided INTERMEDIATE CA (keep the root offline). Requires mTLS
+# above AND a restrictive host_allowlist_path — the server refuses to enable
+# enrollment otherwise. Mint a single-use token with:
+#   sigil-server enroll-token --config server.yaml --host-id <uuid> [--ttl 1h]
+#
+# enroll_ca_cert_path: "/etc/sigil/enroll-intermediate.crt"   # CA:TRUE, PEM
+# enroll_ca_key_path:  "/etc/sigil/enroll-intermediate.key"   # 0600, matches cert
+# enroll_tokens_path:  "/var/lib/sigil-server/enroll-tokens.json"
+# enroll_cert_days: 30                                          # issued-cert TTL (default 30)
+
+# Optional (#194.1) — bind /v1/enroll to specific caller certs. Each entry is the
+# blake3 hex (64 lowercase chars) of a permitted client cert's DER — typically
+# the PMS/issuer box. When set, a caller whose client cert is not listed is
+# denied (generic 403) even with a valid token, so a leaked token is useless
+# without the issuer cert. Malformed entries disable enrollment at boot.
+# enroll_issuer_fingerprints:
+#   - "0000000000000000000000000000000000000000000000000000000000000000"
+
+# Optional (#194.2) — require the TLS client cert to match the event's host_id
+# (subject CN, or a SAN DNS entry, == envelope.host_id; ASCII-case-insensitive)
+# on POST /v1/events. Blocks an enrolled host from impersonating another in the
+# body. Requires mTLS (the server refuses to start otherwise). Default false —
+# leave off if your client certs' CN is not the host_id. B-mint-issued certs
+# (CN = SAN = host_id) satisfy it immediately.
+# events_require_cert_host_match: true
+
+# Optional — commercial license bundle. Absent ⇒ free tier.
+# license:
+#   path: "/etc/sigil/license.bundle"
+#   active_window_days: 30

--- a/crates/sigil-server/src/config.rs
+++ b/crates/sigil-server/src/config.rs
@@ -151,6 +151,52 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    /// The shipped `config/server.example.yaml` must stay in sync with the
+    /// `ServerConfig` schema: uncomment every documented setting and it must
+    /// still deserialize (guards against a typo'd or renamed key in the docs).
+    #[test]
+    fn example_config_matches_schema() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../config/server.example.yaml"
+        );
+        let raw = std::fs::read_to_string(path).expect("read example yaml");
+        let mut out = String::new();
+        for line in raw.lines() {
+            let t = line.trim_start();
+            // Uncomment lines that document a setting (`# key:`, `#   - item`,
+            // nested `# path:` / `# active_window_days:`); drop prose comments.
+            let is_setting = t
+                .strip_prefix('#')
+                .map(|r| {
+                    let r = r.trim_start();
+                    r.starts_with("- ")
+                        || r.split_once(':').is_some_and(|(k, _)| {
+                            !k.is_empty() && k.chars().all(|c| c.is_ascii_lowercase() || c == '_')
+                        })
+                })
+                .unwrap_or(false);
+            if let Some(stripped) = line.strip_prefix("# ").or_else(|| line.strip_prefix('#')) {
+                if is_setting {
+                    out.push_str(stripped);
+                    out.push('\n');
+                }
+                // else: prose comment — skip
+            } else {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        let cfg: ServerConfig = serde_yaml::from_str(&out).unwrap_or_else(|e| {
+            panic!("example yaml (all keys uncommented) must parse: {e}\n---\n{out}")
+        });
+        // Spot-check the #184/#194 keys are present and typed as expected.
+        assert!(cfg.enroll_ca_cert_path.is_some());
+        assert!(cfg.enroll_issuer_fingerprints.is_some());
+        assert!(cfg.events_require_cert_host_match);
+        assert!(cfg.artifacts_dir.is_some());
+    }
+
     #[test]
     fn loads_minimal_config() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
`config/server.example.yaml` had drifted — it documented only the pre-enrollment keys, missing everything shipped since #182.

## Added (commented, accurate to the boot-validation rules)
- `rule_packs_bundle_path`, `artifacts_dir` (#182 read-only artifact serving)
- **Enrollment / B-mint** (#184): `enroll_ca_cert_path`/`enroll_ca_key_path`/`enroll_tokens_path`/`enroll_cert_days`, with the `enroll-token` CLI and the mTLS-+-restrictive-allowlist requirement noted
- **Peer-cert bindings** (#194): `enroll_issuer_fingerprints` (blake3 hex of the caller cert) and `events_require_cert_host_match` (requires mTLS; refuses to start otherwise; default off for CN≠host_id certs)
- `license` block

## Guardrail
New test `example_config_matches_schema` reads the shipped file, uncomments every documented setting, and deserializes it into `ServerConfig` — so a renamed/typo'd key in the docs fails CI instead of silently misleading operators. Verified the #184/#194 keys parse to the right types.

No code behavior change; docs + one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)