### PR TITLE
feat(ai-guard): refresh Claude Code and Codex config surfaces (#199, #200)

### DIFF
--- a/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/claude_code.rs
@@ -28,6 +28,8 @@ impl AiGuardParser for ClaudeCodeParser {
             // #191 — watch the scheduled-tasks dir so the daemon re-assesses
             // when an unattended task appears/changes (OFF->ON drift).
             home_dir.join(".claude").join("scheduled-tasks"),
+            // #199 — the other unattended-prompt file, same drift reason.
+            home_dir.join(".claude").join("loop.md"),
         ]
     }
 
@@ -66,10 +68,17 @@ impl AiGuardParser for ClaudeCodeParser {
             && local.is_none()
             && !claude.join("CLAUDE.md").is_file()
             && !has_scheduled_task(&claude)
+            // #199 — a `loop.md` is the same kind of evidence: an unattended
+            // prompt exists, so the tool is in use even with no settings file.
+            && !claude.join("loop.md").is_file()
         {
             return Ok(Vec::new());
         }
 
+        // #199 — keep the unmerged base: the auto-mode classifier does not
+        // read the `settings.local.json` overlay, so scoring the merged view
+        // would attribute rules to a control that never sees them.
+        let base_settings = base.clone().unwrap_or(Value::Object(Default::default()));
         let merged = merge_overlay(base.unwrap_or(Value::Object(Default::default())), local);
 
         let hooks_dir = claude.join("hooks");
@@ -78,8 +87,12 @@ impl AiGuardParser for ClaudeCodeParser {
         emit_permission_reasons(&merged, &mut out);
         // #191 signal 1 — `permissions.defaultMode` auto-approval posture.
         emit_default_mode_reason(&merged, &mut out);
+        // #199 — the classifier's own safety rules, when auto mode is in use.
+        emit_auto_mode_reasons(&base_settings, &mut out);
         // #191 signal 2 — unattended recurring Claude Code scheduled tasks.
         emit_scheduled_task_reasons(&claude, &mut out);
+        // #199 — the other unattended-prompt surface, enumerated alongside.
+        emit_loop_prompt_reason(&claude, "user", &mut out);
         emit_mcp_reasons(&merged, &mut out);
         // #145 (codex C8) — a user-global `enableAllProjectMcpServers: true`
         // blanket-approves project MCP servers across EVERY repo. No single
@@ -150,14 +163,117 @@ pub(crate) fn emit_hook_reasons(
                 continue;
             };
             for h in inner {
-                let Some(cmd) = h.get("command").and_then(Value::as_str) else {
-                    continue;
-                };
-                classify_command(cmd, event_name, hooks_dir, out)?;
+                // #199 — a hook is no longer necessarily a shell command.
+                // `http` POSTs the tool call to a URL, and `prompt` / `agent` /
+                // `mcp_tool` run inside the agent. Only `command` carries a
+                // `command` string, so keying off that field alone made every
+                // other type invisible.
+                match h.get("type").and_then(Value::as_str) {
+                    Some("http") => emit_http_hook_reason(h, event_name, out),
+                    // An `mcp_tool` hook hands the tool call to a configured
+                    // MCP server — a different trust domain from the agent,
+                    // and possibly a remote one.
+                    Some("mcp_tool") => emit_mcp_tool_hook_reason(h, event_name, out),
+                    // Absent `type` means the historical shape, which is a
+                    // command hook.
+                    Some("command") | None => {
+                        if let Some(cmd) = h.get("command").and_then(Value::as_str) {
+                            classify_command(cmd, event_name, hooks_dir, out)?;
+                        }
+                    }
+                    // `prompt` and `agent` hand the payload to the model the
+                    // user is already talking to, so nothing crosses a trust
+                    // boundary that was not already crossed, and they run no
+                    // host command. They still counted toward `NoSandbox`
+                    // above; there is nothing further to classify.
+                    Some(_) => {}
+                }
             }
         }
     }
     Ok(())
+}
+
+/// #199 — an `http` hook forwards the whole tool-call payload to a URL. On
+/// `PreToolUse` that is every intercepted call and its arguments leaving the
+/// machine. Evidence records the destination host, not the full URL: a URL can
+/// carry a token or a path that identifies the user.
+fn emit_http_hook_reason(hook: &Value, event_name: &str, out: &mut Vec<AiGuardReason>) {
+    let Some(url) = hook.get("url").and_then(Value::as_str) else {
+        return;
+    };
+    // A loopback hook is a local validator: the payload never leaves the
+    // machine, which is the whole claim this finding makes. Reporting one
+    // would describe an exposure the operator does not have.
+    if destination_is_loopback(url) {
+        return;
+    }
+    out.push(AiGuardReason::HookForwardsToolCalls {
+        hook_event: event_name.to_string(),
+        destination: url_host_for_evidence(url),
+    });
+}
+
+/// #199 — an `mcp_tool` hook routes the tool call to a configured MCP server.
+/// Unlike `prompt`/`agent`, that server is a separate trust domain and may be
+/// remote, so the payload can leave the machine.
+fn emit_mcp_tool_hook_reason(hook: &Value, event_name: &str, out: &mut Vec<AiGuardReason>) {
+    let server = hook
+        .get("server")
+        .or_else(|| hook.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("unnamed");
+    out.push(AiGuardReason::HookForwardsToolCalls {
+        hook_event: event_name.to_string(),
+        destination: truncate_for_snippet(&format!("mcp:{server}")),
+    });
+}
+
+/// Does this URL point back at the same machine? Host-form only — resolving
+/// names is not this parser's job, so a name that merely resolves to loopback
+/// is still reported.
+fn destination_is_loopback(url: &str) -> bool {
+    let Some((_, rest)) = url.split_once("://") else {
+        return false;
+    };
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    // Strip a port, and the brackets around an IPv6 literal.
+    let host = match host.strip_prefix('[') {
+        Some(v6) => v6.split(']').next().unwrap_or(v6),
+        None => host.split(':').next().unwrap_or(host),
+    };
+    let host = host.trim().to_ascii_lowercase();
+    host == "localhost"
+        || host == "::1"
+        || host
+            .parse::<std::net::Ipv4Addr>()
+            .is_ok_and(|a| a.is_loopback())
+        || host
+            .parse::<std::net::Ipv6Addr>()
+            .is_ok_and(|a| a.is_loopback())
+}
+
+/// Host (with scheme) of `url`, for evidence. Falls back to a truncated raw
+/// string when there is no recognizable authority, so an unparsable URL is
+/// still reported rather than dropped.
+fn url_host_for_evidence(url: &str) -> String {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((s, r)) => (s, r),
+        None => return truncate_for_snippet(url),
+    };
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(rest)
+        // Strip any `user:pass@` — credentials are not evidence we want to log.
+        .rsplit('@')
+        .next()
+        .unwrap_or(rest);
+    if authority.is_empty() {
+        return truncate_for_snippet(url);
+    }
+    truncate_for_snippet(&format!("{}://{}", scheme.to_ascii_lowercase(), authority))
 }
 
 /// Decide whether `cmd` is inline shell, a convention-dir script (we read it),
@@ -343,6 +459,71 @@ pub(crate) fn emit_default_mode_reason(settings: &Value, out: &mut Vec<AiGuardRe
     }
 }
 
+/// #199 — the deny lists of the `autoMode` classifier block. Each is an array
+/// of prose rules; the shipped safety rules are spliced in by the literal
+/// `"$defaults"` entry. A list written without that marker replaces the
+/// defaults instead of extending them, and nothing in the config says so.
+const AUTO_MODE_DENY_LISTS: &[&str] = &["soft_deny", "hard_deny"];
+const AUTO_MODE_DEFAULTS_MARKER: &str = "$defaults";
+
+/// #199 — check the `autoMode` block for deny lists that silently discarded
+/// the built-in rules.
+///
+/// Two conditions, both required, because a finding here claims a live loss of
+/// protection:
+///
+/// * `permissions.defaultMode` is `auto`. The classifier is what consults these
+///   lists, so under any other mode the block is dormant configuration and
+///   reporting it would describe a risk the machine does not have.
+/// * The block comes from the base settings file. Since v2.1.207 the
+///   classifier reads `autoMode` from user settings, managed settings, and
+///   `--settings` only — never a `settings.local.json` overlay or a repo-local
+///   file — so the caller passes the unmerged base, not the overlay result.
+pub(crate) fn emit_auto_mode_reasons(base_settings: &Value, out: &mut Vec<AiGuardReason>) {
+    let in_auto_mode = base_settings
+        .get("permissions")
+        .and_then(|p| p.get("defaultMode"))
+        .and_then(Value::as_str)
+        == Some("auto");
+    if !in_auto_mode {
+        return;
+    }
+    let Some(auto_mode) = base_settings.get("autoMode") else {
+        return;
+    };
+    for list in AUTO_MODE_DENY_LISTS {
+        let Some(entries) = auto_mode.get(list).and_then(Value::as_array) else {
+            continue;
+        };
+        // An explicitly empty list is the strongest form of the same thing:
+        // the defaults are gone and nothing replaced them.
+        let keeps_defaults = entries
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|e| e.trim() == AUTO_MODE_DEFAULTS_MARKER);
+        if !keeps_defaults {
+            out.push(AiGuardReason::AutoModeDefaultsDropped {
+                list: (*list).to_string(),
+            });
+        }
+    }
+}
+
+/// #199 — the default prompt for unattended, session-scoped repeat runs.
+/// `<dir>/loop.md`; `source` distinguishes the user-global copy from a
+/// repo-local one (the project file wins at runtime, so both are worth seeing).
+pub(crate) fn emit_loop_prompt_reason(
+    claude_dir: &Path,
+    source: &str,
+    out: &mut Vec<AiGuardReason>,
+) {
+    if claude_dir.join("loop.md").is_file() {
+        out.push(AiGuardReason::UnattendedLoopPrompt {
+            source: source.to_string(),
+        });
+    }
+}
+
 /// Max number of `UnattendedScheduledTask` reasons emitted per assessment, to
 /// bound output; tasks beyond this are logged and ignored.
 const MAX_SCHEDULED_TASK_REASONS: usize = 20;
@@ -421,7 +602,28 @@ pub(crate) fn emit_scheduled_task_reasons(claude_dir: &Path, out: &mut Vec<AiGua
 /// `tool(restriction)` paren format, not colon format, so a shared predicate
 /// would not fit. Over-flagging is acceptable — Sigil measures, doesn't block.
 fn is_broad_allow(rule: &str) -> bool {
-    rule == "*" || rule == "*:*" || rule.ends_with(":*") || rule.ends_with(":.*")
+    let rule = rule.trim();
+    if rule == "*" || rule == "*:*" || rule.ends_with(":*") || rule.ends_with(":.*") {
+        return true;
+    }
+    // #199 — two rule forms the colon heuristic alone does not reach.
+    //
+    // `Tool(...)` is the current syntax, and its breadth lives inside the
+    // parens: `Bash(*)` allows every shell command. A parameter predicate
+    // (`Bash(run_in_background:true)`) is narrowing, not broadening, so only a
+    // wildcard argument counts.
+    if let Some((tool, arg)) = rule
+        .strip_suffix(')')
+        .and_then(|r| r.split_once('('))
+        .filter(|(tool, _)| !tool.contains(':'))
+    {
+        debug_assert!(!tool.is_empty() || rule.starts_with('('));
+        return matches!(arg.trim(), "*" | ".*" | "*:*");
+    }
+    // A bare tool-name glob (`mcp__*`) has no matcher at all — it admits every
+    // tool whose name shares the prefix. Require a prefix so this stays
+    // distinct from the bare `*` handled above.
+    rule.len() > 1 && rule.ends_with('*') && !rule.contains(':') && !rule.contains('(')
 }
 
 pub(crate) fn emit_mcp_reasons(settings: &Value, out: &mut Vec<AiGuardReason>) {
@@ -530,6 +732,9 @@ impl AiGuardParser for ClaudeCodeProjectParser {
             self.repo_root.join(".mcp.json"),
             self.repo_root.join("CLAUDE.md"),
             self.repo_root.join("AGENTS.md"),
+            // #199 — a committed loop prompt drives unattended repeat runs for
+            // anyone who clones the repo.
+            cd.join("loop.md"),
         ]
     }
 
@@ -578,6 +783,7 @@ impl AiGuardParser for ClaudeCodeProjectParser {
             && mcp_json.is_none()
             && !self.repo_root.join("CLAUDE.md").is_file()
             && !self.repo_root.join("AGENTS.md").is_file()
+            && !cd.join("loop.md").is_file()
         {
             return Ok(Vec::new());
         }
@@ -597,6 +803,10 @@ impl AiGuardParser for ClaudeCodeProjectParser {
                 });
             }
         }
+        // #199 — a committed loop prompt. `autoMode` is deliberately NOT read
+        // here: since v2.1.207 the classifier ignores the repo-local copy, so
+        // flagging one would report a control that is not in force.
+        emit_loop_prompt_reason(&cd, "project", &mut out);
         // #146 — scan committed instruction files (defensive read each).
         super::instruction_scan::scan_file_path(&self.repo_root.join("CLAUDE.md"), &mut out);
         super::instruction_scan::scan_file_path(&self.repo_root.join("AGENTS.md"), &mut out);
@@ -1653,5 +1863,437 @@ mod tests {
             watched.contains(&repo.path().join(".mcp.json")),
             "got {watched:?}"
         );
+    }
+
+    // ---- #199: defaultMode enum ------------------------------------------
+
+    /// `auto` runs a classifier that can still refuse, so it must not be
+    /// scored at the same severity as the unguarded modes — but it is still an
+    /// auto-approval posture, and still a dangerous toggle.
+    #[test]
+    fn classifier_auto_mode_scores_below_bypass() {
+        let r = crate::ai_guard::rubric::Rubric::defaults();
+        let auto = AiGuardReason::AutoApprovalEnabled {
+            mode: "auto".into(),
+        };
+        let bypass = AiGuardReason::AutoApprovalEnabled {
+            mode: "bypassPermissions".into(),
+        };
+        assert!(
+            r.weight_for(&auto) < r.weight_for(&bypass),
+            "auto={} bypass={}",
+            r.weight_for(&auto),
+            r.weight_for(&bypass)
+        );
+        let toggles = crate::ai_guard::rubric::dangerous_toggles(&[auto]);
+        assert!(
+            toggles.contains("auto_approval_enabled_classifier"),
+            "{toggles:?}"
+        );
+    }
+
+    /// `dontAsk` only runs pre-approved tools and `manual`/`plan` prompt, so
+    /// none of them is a blanket auto-approval.
+    #[test]
+    fn restrictive_default_modes_are_not_flagged() {
+        for mode in ["dontAsk", "manual", "default", "plan"] {
+            let dir = tempdir().unwrap();
+            write_settings(
+                dir.path(),
+                &format!(r#"{{"permissions": {{"defaultMode": "{mode}"}}}}"#),
+            );
+            let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+            assert!(
+                !reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })),
+                "{mode} must not be an auto-approval finding; got {reasons:?}"
+            );
+        }
+    }
+
+    // ---- #199: autoMode classifier rules ---------------------------------
+
+    #[test]
+    fn auto_mode_deny_list_without_defaults_marker_is_flagged() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"permissions": {"defaultMode": "auto"},
+                 "autoMode": {"soft_deny": ["never touch prod"], "hard_deny": ["$defaults"]}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        let dropped: Vec<&str> = reasons
+            .iter()
+            .filter_map(|r| match r {
+                AiGuardReason::AutoModeDefaultsDropped { list } => Some(list.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(dropped, vec!["soft_deny"], "got {reasons:?}");
+    }
+
+    #[test]
+    fn auto_mode_empty_deny_list_is_flagged() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"permissions": {"defaultMode": "auto"}, "autoMode": {"hard_deny": []}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::AutoModeDefaultsDropped { list } if list == "hard_deny"
+            )),
+            "an empty deny list discards the defaults too; got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn auto_mode_keeping_defaults_is_silent() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"permissions": {"defaultMode": "auto"},
+                 "autoMode": {"soft_deny": ["$defaults", "extra"], "hard_deny": ["$defaults"]}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::AutoModeDefaultsDropped { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    /// A list the parser never sees must not be invented: absent lists keep
+    /// the defaults, and no `autoMode` block at all means nothing to say.
+    #[test]
+    fn absent_auto_mode_block_or_list_is_silent() {
+        for settings in [
+            r#"{}"#,
+            r#"{"autoMode": {}}"#,
+            r#"{"autoMode": {"allow": ["x"]}}"#,
+        ] {
+            let dir = tempdir().unwrap();
+            write_settings(dir.path(), settings);
+            let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+            assert!(
+                !reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::AutoModeDefaultsDropped { .. })),
+                "{settings} -> {reasons:?}"
+            );
+        }
+    }
+
+    /// The classifier reads `autoMode` from user/managed settings only, so a
+    /// repo-local copy is not in force and must not be reported as if it were.
+    #[test]
+    fn project_scope_does_not_flag_auto_mode() {
+        let repo = tempdir().unwrap();
+        write_file(
+            repo.path(),
+            ".claude/settings.json",
+            r#"{"permissions": {"defaultMode": "auto"}, "autoMode": {"hard_deny": []}}"#,
+        );
+        let reasons = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        }
+        .assess(repo.path())
+        .unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::AutoModeDefaultsDropped { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    // ---- #199: non-command hook types ------------------------------------
+
+    #[test]
+    fn http_hook_is_reported_with_destination_host_only() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+                 {"type": "http", "url": "https://user:secret@collect.example.test/ingest?tok=abc"}
+               ]}]}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        let dest = reasons
+            .iter()
+            .find_map(|r| match r {
+                AiGuardReason::HookForwardsToolCalls {
+                    hook_event,
+                    destination,
+                } if hook_event == "PreToolUse" => Some(destination.as_str()),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no http hook finding in {reasons:?}"));
+        assert_eq!(dest, "https://collect.example.test");
+    }
+
+    /// In-process hook types run no host command. They still count as hooks
+    /// (the `NoSandbox` signal), but there is nothing to classify and nothing
+    /// leaves the machine.
+    #[test]
+    fn in_process_hook_types_are_counted_but_not_flagged_as_forwarding() {
+        for ty in ["prompt", "agent"] {
+            let dir = tempdir().unwrap();
+            write_settings(
+                dir.path(),
+                &format!(r#"{{"hooks": {{"PreToolUse": [{{"hooks": [{{"type": "{ty}"}}]}}]}}}}"#),
+            );
+            let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+            assert!(
+                reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::NoSandbox { .. })),
+                "{ty} is still a configured hook; got {reasons:?}"
+            );
+            assert!(
+                !reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::HookForwardsToolCalls { .. })),
+                "{ty} does not leave the host; got {reasons:?}"
+            );
+        }
+    }
+
+    /// A hook entry with no `type` is the historical command shape and must
+    /// keep being scanned for destructive inline commands.
+    #[test]
+    fn untyped_hook_is_still_treated_as_a_command() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"hooks": {"PreToolUse": [{"hooks": [{"command": "rm -rf /tmp/x"}]}]}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::DestructiveInInlineCommand { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    /// A dormant `autoMode` block is configuration, not exposure: under any
+    /// other default mode the classifier never consults it.
+    #[test]
+    fn auto_mode_block_is_not_flagged_outside_auto_mode() {
+        for mode in ["default", "acceptEdits", "plan", "bypassPermissions"] {
+            let dir = tempdir().unwrap();
+            write_settings(
+                dir.path(),
+                &format!(
+                    r#"{{"permissions": {{"defaultMode": "{mode}"}}, "autoMode": {{"hard_deny": []}}}}"#
+                ),
+            );
+            let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+            assert!(
+                !reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::AutoModeDefaultsDropped { .. })),
+                "{mode} -> {reasons:?}"
+            );
+        }
+    }
+
+    /// The classifier does not read the `settings.local.json` overlay, so an
+    /// `autoMode` block found only there is not in force.
+    #[test]
+    fn auto_mode_from_local_overlay_is_not_flagged() {
+        let dir = tempdir().unwrap();
+        write_settings(dir.path(), r#"{"permissions": {"defaultMode": "auto"}}"#);
+        write_file(
+            dir.path(),
+            ".claude/settings.local.json",
+            r#"{"autoMode": {"hard_deny": []}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::AutoModeDefaultsDropped { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    /// A loopback hook is a local validator — the payload never leaves the
+    /// machine, which is exactly what this finding claims.
+    #[test]
+    fn loopback_http_hook_is_not_forwarding() {
+        for url in [
+            "http://localhost:8080/hooks/pre-tool-use",
+            "http://127.0.0.1:9000/check",
+            "http://[::1]:8080/x",
+            "https://LOCALHOST/x",
+        ] {
+            let dir = tempdir().unwrap();
+            write_settings(
+                dir.path(),
+                &format!(
+                    r#"{{"hooks": {{"PreToolUse": [{{"hooks": [{{"type": "http", "url": "{url}"}}]}}]}}}}"#
+                ),
+            );
+            let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+            assert!(
+                !reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::HookForwardsToolCalls { .. })),
+                "{url} -> {reasons:?}"
+            );
+        }
+    }
+
+    /// An `mcp_tool` hook hands the call to a separate trust domain, unlike
+    /// `prompt`/`agent` which stay with the model the user already uses.
+    #[test]
+    fn mcp_tool_hook_is_reported_as_forwarding() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"hooks": {"PreToolUse": [{"hooks": [{"type": "mcp_tool", "server": "auditor"}]}]}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::HookForwardsToolCalls { destination, .. } if destination == "mcp:auditor"
+            )),
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn http_hook_without_url_is_silent() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"hooks": {"PreToolUse": [{"hooks": [{"type": "http"}]}]}}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::HookForwardsToolCalls { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    // ---- #199: loop.md ----------------------------------------------------
+
+    #[test]
+    fn user_loop_prompt_is_reported_even_without_settings() {
+        let dir = tempdir().unwrap();
+        write_file(dir.path(), ".claude/loop.md", "check the deploy\n");
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::UnattendedLoopPrompt { source } if source == "user"
+            )),
+            "a loop prompt is evidence of use on its own; got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn project_loop_prompt_is_reported() {
+        let repo = tempdir().unwrap();
+        write_file(repo.path(), ".claude/loop.md", "keep running\n");
+        let reasons = ClaudeCodeProjectParser {
+            repo_root: repo.path().to_path_buf(),
+        }
+        .assess(repo.path())
+        .unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::UnattendedLoopPrompt { source } if source == "project"
+            )),
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn no_loop_prompt_no_finding() {
+        let dir = tempdir().unwrap();
+        write_settings(dir.path(), r#"{"permissions": {"deny": ["Bash"]}}"#);
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::UnattendedLoopPrompt { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    // ---- #199: permission rule forms -------------------------------------
+
+    /// Table of realistic permission rules. Over-flagging here is not a free
+    /// choice: a wrongly-broad rule adds weight to a user's score for a
+    /// setting that is actually scoped, so the "not broad" half matters as
+    /// much as the "broad" half.
+    #[test]
+    fn broad_allow_classifies_real_permission_rules() {
+        let cases: &[(&str, bool)] = &[
+            // Genuinely broad.
+            ("*", true),
+            ("*:*", true),
+            ("**", true),
+            ("Bash:*", true),
+            ("Bash:.*", true),
+            ("Bash(*)", true),
+            ("Read(.*)", true),
+            ("mcp__*", true),
+            // Scoped — a matcher, a path, a domain, or a parameter predicate.
+            ("Bash", false),
+            ("Read", false),
+            ("Bash(run_in_background:true)", false),
+            ("Agent(model:opus)", false),
+            ("Bash(npm run test:*)", false),
+            ("Bash(git diff:*)", false),
+            ("Bash(ls*)", false),
+            ("Read(/etc/hosts)", false),
+            ("Write(/tmp/*)", false),
+            ("Edit(src/**)", false),
+            ("WebFetch(domain:example.com)", false),
+            ("mcp__github", false),
+            ("mcp__github__create_issue", false),
+            ("", false),
+        ];
+        let wrong: Vec<&str> = cases
+            .iter()
+            .filter(|(rule, want)| is_broad_allow(rule) != *want)
+            .map(|(rule, _)| *rule)
+            .collect();
+        assert!(wrong.is_empty(), "misclassified: {wrong:?}");
+    }
+
+    /// The new rule forms must parse without disturbing the rest of the
+    /// assessment — the point of #199 gap 7.
+    #[test]
+    fn new_permission_rule_forms_do_not_break_assessment() {
+        let dir = tempdir().unwrap();
+        write_settings(
+            dir.path(),
+            r#"{"permissions": {
+                 "deny": ["Bash(rm:*)"],
+                 "allow": ["Bash(run_in_background:true)", "mcp__*", "Agent(model:opus)"]
+               }}"#,
+        );
+        let reasons = ClaudeCodeParser.assess(dir.path()).unwrap();
+        let broad: Vec<&str> = reasons
+            .iter()
+            .filter_map(|r| match r {
+                AiGuardReason::PermissionsAllowBroad { rule } => Some(rule.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(broad, vec!["mcp__*"], "got {reasons:?}");
     }
 }

--- a/crates/sigil-agent/src/ai_guard/parser/codex.rs
+++ b/crates/sigil-agent/src/ai_guard/parser/codex.rs
@@ -58,16 +58,33 @@ impl AiGuardParser for CodexParser {
     }
 
     fn watched_paths(&self, home_dir: &Path) -> Vec<PathBuf> {
-        vec![home_dir.join(".codex").join("config.toml")]
+        vec![
+            home_dir.join(".codex").join("config.toml"),
+            // #200 — a standing command-approval rule appearing here is an
+            // OFF→ON drift, so the daemon must re-assess when the dir changes.
+            home_dir.join(".codex").join("rules"),
+        ]
     }
 
     fn assess(&self, home_dir: &Path) -> Result<Vec<AiGuardReason>, AssessError> {
-        let path = home_dir.join(".codex").join("config.toml");
+        let codex_dir = home_dir.join(".codex");
+        let path = codex_dir.join("config.toml");
         let text = match std::fs::read_to_string(&path) {
             Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            // #200 — a rules file is evidence of use on its own, so the
+            // absent-config short-circuit must still look there first.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let mut out = Vec::new();
+                emit_rules_reasons(&codex_dir, &mut out);
+                return Ok(out);
+            }
             Err(source) => return Err(AssessError::Io { path, source }),
         };
+        // A corrupt config.toml is surfaced, not degraded to "no findings"
+        // (`corrupt_toml_returns_parse_error` pins this). Codex will not start
+        // against a config it cannot parse, so the standing approvals in
+        // `rules/` are not in force either, and the actionable signal for the
+        // operator is that the config is broken.
         let val: Value = toml::from_str(&text).map_err(|e| AssessError::Parse {
             path: path.clone(),
             message: e.to_string(),
@@ -75,9 +92,13 @@ impl AiGuardParser for CodexParser {
 
         let mut out = Vec::new();
         emit_sandbox_reasons(&val, &mut out);
-        let hooks_dir = home_dir.join(".codex").join("hooks");
+        // #200 — whether a human is asked before a tool runs.
+        emit_approval_policy_reasons(&val, &mut out);
+        let hooks_dir = codex_dir.join("hooks");
         emit_hook_reasons(&val, &hooks_dir, &mut out);
         emit_mcp_reasons(&val, &mut out);
+        // #200 — standing command approvals, which live outside config.toml.
+        emit_rules_reasons(&codex_dir, &mut out);
         Ok(out)
     }
 
@@ -105,6 +126,362 @@ pub(crate) fn emit_sandbox_reasons(val: &Value, out: &mut Vec<AiGuardReason>) {
     if matches!(mode, Some("danger-full-access")) {
         out.push(AiGuardReason::SandboxDisabled);
     }
+}
+
+/// #200 — `approval_policy` decides whether a human is asked before a tool
+/// runs. Two shapes are accepted by Codex:
+///
+/// ```toml,ignore
+/// approval_policy = "never"                     # scalar
+/// approval_policy = { granular = { ... } }      # table, since ~2026-03
+/// ```
+///
+/// `"never"` is the autonomous setting: nothing is escalated to the user.
+/// `"untrusted"` and `"on-request"` still prompt, and the deprecated
+/// `"on-failure"` prompts on error, so none of those is a finding.
+///
+/// The table form must not crash a scalar-shaped read — that is the robustness
+/// half of this — but it is also **not** scored. Its sub-keys
+/// (`sandbox_approval`, `rules`, `mcp_elicitations`, `request_permissions`,
+/// `skill_approval`) each gate a different class of prompt, and a granular
+/// policy can be more restrictive than any scalar. Emitting
+/// `AutoApprovalEnabled` on the shape alone would assert that approvals are off
+/// when they may not be. The accepted values need hardware verification before
+/// this can say anything; until then the honest answer is silence, and the
+/// silence is recorded here rather than left to look like a clean result.
+pub(crate) fn emit_approval_policy_reasons(val: &Value, out: &mut Vec<AiGuardReason>) {
+    let Some(policy) = val.get("approval_policy") else {
+        return;
+    };
+    match policy.as_str() {
+        Some("never") => out.push(AiGuardReason::AutoApprovalEnabled {
+            mode: "never".to_string(),
+        }),
+        // `untrusted` / `on-request` still prompt; the deprecated `on-failure`
+        // prompts on error. None is a blanket auto-approval.
+        Some(_) => {}
+        None => {
+            if policy.get("granular").is_some() {
+                tracing::info!("codex approval_policy: granular form not yet scored (see #200)");
+            }
+        }
+    }
+}
+
+/// #200 — bounds on the `~/.codex/rules/` sweep. These files are
+/// operator-authored, but a scan on the daemon's path must not be steerable
+/// into unbounded work by dropping a large file there.
+const MAX_RULES_FILES: usize = 64;
+const MAX_RULES_FILE_BYTES: u64 = 1024 * 1024;
+const MAX_STANDING_APPROVAL_REASONS: usize = 32;
+
+/// #200 — `~/.codex/rules/*.rules` holds command-approval rules in a small DSL,
+/// verified on a live install (codex-cli 0.137.0):
+///
+/// ```text,ignore
+/// prefix_rule(pattern=["codex", "mcp", "login"], decision="allow")
+/// ```
+///
+/// A `decision="allow"` entry is a *standing* approval: every future command
+/// whose first words match the prefix runs with no prompt. That is the same
+/// class of posture as `approval_policy = "never"`, but scoped to a prefix and
+/// invisible in `config.toml`.
+///
+/// Only `allow` is a finding — a `deny` rule is a control, not a risk. The
+/// parser is deliberately shallow: it extracts the quoted strings from the
+/// `pattern=[...]` list of any rule whose `decision` is `allow`, and ignores
+/// rule forms it does not recognize rather than guessing at their meaning.
+pub(crate) fn emit_rules_reasons(codex_dir: &Path, out: &mut Vec<AiGuardReason>) {
+    let rules_dir = codex_dir.join("rules");
+    let Ok(entries) = std::fs::read_dir(&rules_dir) else {
+        return;
+    };
+    // Sort for deterministic emission order across platforms.
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rules"))
+        .collect();
+    files.sort();
+    files.truncate(MAX_RULES_FILES);
+
+    let mut patterns: Vec<String> = Vec::new();
+    for file in files {
+        match std::fs::metadata(&file) {
+            Ok(m) if m.len() > MAX_RULES_FILE_BYTES => {
+                tracing::warn!(path = %file.display(), bytes = m.len(), "codex rules: file too large, skipped");
+                continue;
+            }
+            Ok(_) => {}
+            Err(_) => continue,
+        }
+        let Ok(text) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        patterns.extend(allow_patterns_in_rules_text(&text));
+    }
+    patterns.sort();
+    patterns.dedup();
+    let total = patterns.len();
+    for pattern in patterns.into_iter().take(MAX_STANDING_APPROVAL_REASONS) {
+        out.push(AiGuardReason::StandingCommandApproval { pattern });
+    }
+    if total > MAX_STANDING_APPROVAL_REASONS {
+        tracing::warn!(
+            dir = %rules_dir.display(),
+            total,
+            cap = MAX_STANDING_APPROVAL_REASONS,
+            "codex rules: capping StandingCommandApproval reasons"
+        );
+    }
+}
+
+/// Strip `#` and `//` comments that are outside string literals. Without this,
+/// `prefix_rule(pattern=["git"])  # decision="allow"` reads as an approval.
+fn strip_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut quote: Option<char> = None;
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(q) => {
+                out.push(c);
+                if c == '\\' {
+                    // Escaped character inside a string: copy it verbatim so a
+                    // `\"` does not look like the closing quote.
+                    if let Some(n) = chars.next() {
+                        out.push(n);
+                    }
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' => {
+                    quote = Some(c);
+                    out.push(c);
+                }
+                '#' => {
+                    for n in chars.by_ref() {
+                        if n == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                }
+                '/' if chars.peek() == Some(&'/') => {
+                    for n in chars.by_ref() {
+                        if n == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                }
+                _ => out.push(c),
+            },
+        }
+    }
+    out
+}
+
+/// One `prefix_rule( ... )` invocation's argument text. Scans the whole file
+/// rather than a line at a time: the documented form spans several lines.
+fn rule_invocations(text: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while let Some(i) = rest.find("prefix_rule") {
+        let after = &rest[i + "prefix_rule".len()..];
+        let trimmed = after.trim_start();
+        let Some(body) = trimmed.strip_prefix('(') else {
+            rest = after;
+            continue;
+        };
+        match balanced_end(body, '(', ')') {
+            Some(end) => {
+                out.push(&body[..end]);
+                rest = &body[end..];
+            }
+            // Unterminated invocation: nothing further to read.
+            None => break,
+        }
+    }
+    out
+}
+
+/// Byte offset of the `close` that balances an already-consumed `open`.
+/// Quote-aware, so a bracket inside a string does not shift the depth.
+fn balanced_end(s: &str, open: char, close: char) -> Option<usize> {
+    let mut depth = 1usize;
+    let mut quote: Option<char> = None;
+    let mut chars = s.char_indices();
+    while let Some((i, c)) = chars.next() {
+        match quote {
+            Some(q) => {
+                if c == '\\' {
+                    chars.next();
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => {
+                if c == '"' || c == '\'' {
+                    quote = Some(c);
+                } else if c == open {
+                    depth += 1;
+                } else if c == close {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Value text of `name = …` at the top level of an argument list — not inside
+/// a nested list and not inside a string, so prose mentioning the keyword
+/// cannot be mistaken for the real argument.
+fn top_level_arg<'a>(args: &'a str, name: &str) -> Option<&'a str> {
+    let bytes = args.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<char> = None;
+    let mut chars = args.char_indices();
+    while let Some((i, c)) = chars.next() {
+        match quote {
+            Some(q) => {
+                if c == '\\' {
+                    chars.next();
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' => quote = Some(c),
+                '[' | '(' | '{' => depth += 1,
+                ']' | ')' | '}' => depth = depth.saturating_sub(1),
+                _ if depth == 0 && args[i..].starts_with(name) => {
+                    // Must be a whole word followed by `=`.
+                    let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+                    let after = &args[i + name.len()..];
+                    let after_trimmed = after.trim_start();
+                    if before_ok && after_trimmed.starts_with('=') {
+                        return Some(after_trimmed[1..].trim_start());
+                    }
+                }
+                _ => {}
+            },
+        }
+    }
+    None
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// The command prefix a `pattern=[...]` list approves.
+///
+/// The list is a **sequence** of argv words, not a set of independent
+/// prefixes: `["codex", "mcp", "login"]` approves the command
+/// `codex mcp login`, not three separate commands. A nested list is a set of
+/// alternatives at that position, rendered `{a|b}`. Emitting one finding per
+/// quoted string would invent approvals that were never granted.
+fn pattern_prefix(list_text: &str) -> Option<String> {
+    let inner = list_text.trim().strip_prefix('[')?;
+    let end = balanced_end(inner, '[', ']')?;
+    let mut words: Vec<String> = Vec::new();
+    for item in split_top_level(&inner[..end]) {
+        let item = item.trim();
+        if let Some(nested) = item.strip_prefix('[') {
+            let n_end = balanced_end(nested, '[', ']')?;
+            let alts: Vec<String> = split_top_level(&nested[..n_end])
+                .into_iter()
+                .filter_map(|a| quoted_string(a.trim()))
+                .collect();
+            if alts.is_empty() {
+                return None;
+            }
+            words.push(format!("{{{}}}", alts.join("|")));
+        } else {
+            words.push(quoted_string(item)?);
+        }
+    }
+    if words.is_empty() {
+        return None;
+    }
+    Some(words.join(" "))
+}
+
+/// Split on commas that are not inside a nested bracket or a string.
+fn split_top_level(s: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut depth = 0usize;
+    let mut quote: Option<char> = None;
+    let mut start = 0usize;
+    let mut chars = s.char_indices();
+    while let Some((i, c)) = chars.next() {
+        match quote {
+            Some(q) => {
+                if c == '\\' {
+                    chars.next();
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' => quote = Some(c),
+                '[' | '(' | '{' => depth += 1,
+                ']' | ')' | '}' => depth = depth.saturating_sub(1),
+                ',' if depth == 0 => {
+                    out.push(&s[start..i]);
+                    start = i + c.len_utf8();
+                }
+                _ => {}
+            },
+        }
+    }
+    let tail = &s[start..];
+    if !tail.trim().is_empty() {
+        out.push(tail);
+    }
+    out
+}
+
+/// The contents of a single quoted string, or None if `s` is not exactly one.
+fn quoted_string(s: &str) -> Option<String> {
+    let s = s.trim();
+    let quote = s.chars().next().filter(|c| *c == '"' || *c == '\'')?;
+    let body = &s[quote.len_utf8()..];
+    let end = body.find(quote)?;
+    // Anything after the closing quote means this was not a lone string.
+    if !body[end + quote.len_utf8()..].trim().is_empty() {
+        return None;
+    }
+    Some(body[..end].to_string())
+}
+
+/// Approved command prefixes in one rules file. Only `decision="allow"` counts:
+/// a deny rule is a control, not a risk. Rule forms this parser does not model
+/// are skipped rather than guessed at.
+fn allow_patterns_in_rules_text(text: &str) -> Vec<String> {
+    let stripped = strip_comments(text);
+    let mut out = Vec::new();
+    for args in rule_invocations(&stripped) {
+        let decides_allow = top_level_arg(args, "decision")
+            .and_then(|v| quoted_string(v.split(',').next().unwrap_or(v)))
+            .is_some_and(|d| d == "allow");
+        if !decides_allow {
+            continue;
+        }
+        if let Some(list) = top_level_arg(args, "pattern") {
+            if let Some(prefix) = pattern_prefix(list) {
+                out.push(prefix);
+            }
+        }
+    }
+    out
 }
 
 /// Verified schema: hooks live under the top-level `[hooks]` table, keyed by
@@ -931,6 +1308,290 @@ command = "echo inline"
         assert_eq!(
             paths,
             vec![std::path::PathBuf::from("/opt/sigil-tools/pre.sh")]
+        );
+    }
+
+    // ─── #200: approval_policy ─────────────────────────────────────────────
+
+    fn write_rules(home: &Path, name: &str, contents: &str) {
+        let dir = home.join(".codex").join("rules");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn approval_policy_never_is_auto_approval() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"approval_policy = "never""#);
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::AutoApprovalEnabled { mode } if mode == "never"
+            )),
+            "got {reasons:?}"
+        );
+    }
+
+    /// These still put a prompt in front of the user, so none is a blanket
+    /// auto-approval.
+    #[test]
+    fn prompting_approval_policies_are_silent() {
+        for policy in ["untrusted", "on-request", "on-failure"] {
+            let dir = tempdir().unwrap();
+            write_config(dir.path(), &format!("approval_policy = \"{policy}\""));
+            let reasons = CodexParser.assess(dir.path()).unwrap();
+            assert!(
+                !reasons
+                    .iter()
+                    .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })),
+                "{policy} -> {reasons:?}"
+            );
+        }
+    }
+
+    /// The table form must parse without error and without inventing a
+    /// posture claim: a granular policy can be stricter than any scalar, so
+    /// asserting auto-approval on its shape alone would be wrong.
+    #[test]
+    fn granular_approval_policy_parses_and_claims_nothing() {
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"
+[approval_policy.granular]
+sandbox_approval = "on-request"
+rules = "never"
+mcp_elicitations = "on-request"
+"#,
+        );
+        let reasons = CodexParser
+            .assess(dir.path())
+            .expect("table form must not error");
+        assert!(
+            !reasons
+                .iter()
+                .any(|r| matches!(r, AiGuardReason::AutoApprovalEnabled { .. })),
+            "got {reasons:?}"
+        );
+    }
+
+    // ─── #200: standing command approvals (~/.codex/rules) ─────────────────
+
+    #[test]
+    fn allow_prefix_rule_emits_standing_approval() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"sandbox_mode = "read-only""#);
+        write_rules(
+            dir.path(),
+            "default.rules",
+            "prefix_rule(pattern=[\"codex\", \"mcp\", \"login\"], decision=\"allow\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        // The list is one argv sequence, not three independent approvals:
+        // this rule approves the command `codex mcp login`.
+        assert_eq!(
+            approvals(&reasons),
+            vec!["codex mcp login"],
+            "got {reasons:?}"
+        );
+    }
+
+    fn approvals(reasons: &[AiGuardReason]) -> Vec<&str> {
+        reasons
+            .iter()
+            .filter_map(|r| match r {
+                AiGuardReason::StandingCommandApproval { pattern } => Some(pattern.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A nested list is a set of alternatives at that position. Flattening it
+    /// would invent approvals for `view` and `list` as standalone commands.
+    #[test]
+    fn nested_alternatives_stay_within_one_prefix() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "n.rules",
+            "prefix_rule(pattern=[\"gh\", \"pr\", [\"view\", \"list\"]], decision=\"allow\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert_eq!(
+            approvals(&reasons),
+            vec!["gh pr {view|list}"],
+            "got {reasons:?}"
+        );
+    }
+
+    /// The keyword appearing in a comment or inside a quoted string is not a
+    /// decision. Reading either as one manufactures an approval.
+    #[test]
+    fn decision_keyword_in_comment_or_prose_is_not_an_approval() {
+        for line in [
+            "prefix_rule(pattern=[\"git\"])  # decision=\"allow\"",
+            "// prefix_rule(pattern=[\"git\"], decision=\"allow\")",
+            "prefix_rule(pattern=[\"git\"], justification=\"old decision=allow\", decision=\"prompt\")",
+            "prefix_rule(pattern=[\"git\"], note=\"decision\", decision=\"deny\")",
+        ] {
+            let dir = tempdir().unwrap();
+            write_rules(dir.path(), "c.rules", line);
+            let reasons = CodexParser.assess(dir.path()).unwrap();
+            assert!(approvals(&reasons).is_empty(), "{line} -> {reasons:?}");
+        }
+    }
+
+    /// The documented form spans several lines, so a line-at-a-time parser
+    /// would see nothing at all.
+    #[test]
+    fn multi_line_rule_is_parsed() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "ml.rules",
+            "prefix_rule(\n    pattern = [\"cargo\", \"test\"],\n    decision = \"allow\",\n)\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert_eq!(approvals(&reasons), vec!["cargo test"], "got {reasons:?}");
+    }
+
+    /// A bracket or comment character inside a string must not shift the
+    /// parser's depth or truncate the rule.
+    #[test]
+    fn brackets_and_hashes_inside_strings_do_not_confuse_the_parser() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "q.rules",
+            "prefix_rule(pattern=[\"sh\", \"-c\", \"echo ]# not a comment\"], decision=\"allow\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert_eq!(
+            approvals(&reasons),
+            vec!["sh -c echo ]# not a comment"],
+            "got {reasons:?}"
+        );
+    }
+
+    /// A deny rule is a control, not a risk.
+    #[test]
+    fn deny_prefix_rule_is_not_a_finding() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "d.rules",
+            "prefix_rule(pattern=[\"rm\"], decision=\"deny\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert!(reasons.is_empty(), "got {reasons:?}");
+    }
+
+    /// A rules file is evidence of use even with no config.toml.
+    #[test]
+    fn rules_file_alone_is_assessed() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "a.rules",
+            "prefix_rule(pattern=[\"git\"], decision=\"allow\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                AiGuardReason::StandingCommandApproval { pattern } if pattern == "git"
+            )),
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn comments_and_unmodeled_rule_forms_are_ignored() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "m.rules",
+            concat!(
+                "# prefix_rule(pattern=[\"commented\"], decision=\"allow\")\n",
+                "// prefix_rule(pattern=[\"also-commented\"], decision=\"allow\")\n",
+                "\n",
+                "some_future_rule(scope=\"x\")\n",
+                "prefix_rule(pattern=[\"real\"], decision=\"allow\")\n",
+            ),
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        let patterns: Vec<&str> = reasons
+            .iter()
+            .filter_map(|r| match r {
+                AiGuardReason::StandingCommandApproval { pattern } => Some(pattern.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(patterns, vec!["real"], "got {reasons:?}");
+    }
+
+    #[test]
+    fn duplicate_patterns_across_files_are_reported_once() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "a.rules",
+            "prefix_rule(pattern=[\"git\"], decision=\"allow\")\n",
+        );
+        write_rules(
+            dir.path(),
+            "b.rules",
+            "prefix_rule(pattern=[\"git\"], decision=\"allow\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert_eq!(
+            reasons
+                .iter()
+                .filter(|r| matches!(r, AiGuardReason::StandingCommandApproval { .. }))
+                .count(),
+            1,
+            "got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn non_rules_extension_is_skipped() {
+        let dir = tempdir().unwrap();
+        write_rules(
+            dir.path(),
+            "notes.txt",
+            "prefix_rule(pattern=[\"x\"], decision=\"allow\")\n",
+        );
+        let reasons = CodexParser.assess(dir.path()).unwrap();
+        assert!(reasons.is_empty(), "got {reasons:?}");
+    }
+
+    #[test]
+    fn malformed_rule_lines_never_panic() {
+        let dir = tempdir().unwrap();
+        for line in [
+            "prefix_rule(",
+            "prefix_rule(pattern=[",
+            "prefix_rule(pattern=[\"unterminated], decision=\"allow\")",
+            "decision=\"allow\"",
+            "prefix_rule(pattern=[], decision=\"allow\")",
+            "prefix_rule(pattern=[\"a\"], decision=)",
+            "\u{0}\u{0}",
+            "🙂 decision=\"allow\" pattern=[\"🙂\"]",
+        ] {
+            write_rules(dir.path(), "x.rules", line);
+            let _ = CodexParser.assess(dir.path()).unwrap();
+        }
+    }
+
+    #[test]
+    fn rules_dir_is_watched() {
+        let dir = tempdir().unwrap();
+        let watched = CodexParser.watched_paths(dir.path());
+        assert!(
+            watched.contains(&dir.path().join(".codex").join("rules")),
+            "got {watched:?}"
         );
     }
 }

--- a/crates/sigil-agent/src/ai_guard/remediation.rs
+++ b/crates/sigil-agent/src/ai_guard/remediation.rs
@@ -72,6 +72,18 @@ pub fn hint_for_reason(reason: &AiGuardReason) -> &'static str {
         McpToolNameShadow { .. } => {
             "The same MCP tool name is offered by multiple servers — a server may be shadowing a trusted tool; disambiguate or remove the untrusted one."
         }
+        AutoModeDefaultsDropped { .. } => {
+            "An auto-approval deny list replaces the built-in safety rules instead of extending them — add the \"$defaults\" entry back to the list."
+        }
+        HookForwardsToolCalls { .. } => {
+            "A hook POSTs every tool call off-box — remove it, or restrict where hooks may send data."
+        }
+        UnattendedLoopPrompt { .. } => {
+            "A default prompt for unattended repeat runs is on disk — review it, or delete the loop prompt if unexpected."
+        }
+        StandingCommandApproval { .. } => {
+            "A standing rule auto-approves a command prefix without prompting — narrow the prefix or remove the rule."
+        }
     }
 }
 

--- a/crates/sigil-agent/src/ai_guard/rubric.rs
+++ b/crates/sigil-agent/src/ai_guard/rubric.rs
@@ -32,6 +32,14 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
         AiGuardReason::McpServerRemote { .. } => "mcp_server_remote",
         AiGuardReason::McpServerLocalCommand { .. } => "mcp_server_local_command",
         AiGuardReason::TrustedMcpServer { .. } => "trusted_mcp_server",
+        // #199 — Claude Code's `auto` runs every tool call past a classifier
+        // that can still refuse. `bypassPermissions` and `acceptEdits` have no
+        // such check, so `auto` is a real auto-approval posture but a weaker
+        // one, and is scored under its own key rather than folded in at the
+        // same severity.
+        AiGuardReason::AutoApprovalEnabled { mode } if mode == "auto" => {
+            "auto_approval_enabled_classifier"
+        }
         AiGuardReason::AutoApprovalEnabled { .. } => "auto_approval_enabled",
         AiGuardReason::McpServerSuspiciousLauncher {
             shape: LauncherShape::Shell,
@@ -62,12 +70,19 @@ fn kind_key(reason: &AiGuardReason) -> &'static str {
         AiGuardReason::McpToolInstructionOverride { .. } => "mcp_tool_instruction_override",
         AiGuardReason::McpToolHiddenText { .. } => "mcp_tool_hidden_text",
         AiGuardReason::McpToolNameShadow { .. } => "mcp_tool_name_shadow",
+        AiGuardReason::AutoModeDefaultsDropped { .. } => "auto_mode_defaults_dropped",
+        AiGuardReason::HookForwardsToolCalls { .. } => "hook_forwards_tool_calls",
+        AiGuardReason::UnattendedLoopPrompt { .. } => "unattended_loop_prompt",
+        AiGuardReason::StandingCommandApproval { .. } => "standing_command_approval",
     }
 }
 
 /// #147 — the dangerous self-escalation toggle kinds tracked for drift.
 pub const DANGEROUS_TOGGLE_KINDS: &[&str] = &[
     "auto_approval_enabled",
+    // #199 — switching into classifier auto-approval is the same OFF→ON
+    // escalation, just a milder one; it still stops the human prompts.
+    "auto_approval_enabled_classifier",
     "sandbox_disabled",
     "permissions_allow_broad",
     "project_mcp_auto_enabled",
@@ -80,6 +95,14 @@ pub const DANGEROUS_TOGGLE_KINDS: &[&str] = &[
     "mcp_tool_instruction_override",
     "mcp_tool_hidden_text",
     "mcp_tool_name_shadow",
+    // #199/#200 — each is a config edit that removes a human from the loop:
+    // the classifier's safety rules replaced, tool calls newly forwarded
+    // off-box, an unattended loop prompt appearing, or a standing approval
+    // that makes a command prefix run without asking from now on.
+    "auto_mode_defaults_dropped",
+    "hook_forwards_tool_calls",
+    "unattended_loop_prompt",
+    "standing_command_approval",
 ];
 
 /// The set of dangerous-toggle kind keys present in a reason set.
@@ -97,7 +120,7 @@ pub fn dangerous_toggles(reasons: &[AiGuardReason]) -> std::collections::BTreeSe
 #[derive(Debug, Clone)]
 pub struct Rubric {
     /// kind_key → weight. Keys are static strings owned by the rubric
-    /// module (returned by `kind_key()`). Defaults populate all 24 known
+    /// module (returned by `kind_key()`). Defaults populate all 29 known
     /// kinds; with_overrides() may replace values but never adds keys.
     pub weights: HashMap<&'static str, f32>,
     /// Subset of `weights` whose value came from an operator override
@@ -112,7 +135,7 @@ pub struct Rubric {
 impl Rubric {
     /// Build the canonical hardcoded weights — single source of truth for
     /// defaults. Must match the historical `weight_for()` match arms for
-    /// all 24 kinds.
+    /// all 29 kinds.
     pub fn defaults() -> Self {
         let mut w: HashMap<&'static str, f32> = HashMap::new();
         w.insert("destructive_in_inline_command", 4.0);
@@ -145,6 +168,18 @@ impl Rubric {
         w.insert("mcp_tool_instruction_override", 3.5);
         w.insert("mcp_tool_hidden_text", 3.5);
         w.insert("mcp_tool_name_shadow", 3.0);
+        // #199 — classifier auto-approval still removes the prompt, but a
+        // check remains in the path, so it sits below the unguarded modes.
+        w.insert("auto_approval_enabled_classifier", 1.5);
+        // #199 — dropping the shipped safety rules re-arms exactly the
+        // commands the defaults were written to stop.
+        w.insert("auto_mode_defaults_dropped", 2.5);
+        // #199 — every tool call and its arguments leave the machine.
+        w.insert("hook_forwards_tool_calls", 3.0);
+        // #199 — an unattended loop prompt, same class as a scheduled task.
+        w.insert("unattended_loop_prompt", 2.5);
+        // #200 — a persistent, unprompted approval for a command prefix.
+        w.insert("standing_command_approval", 2.0);
         Rubric {
             weights: w,
             overridden: HashSet::new(),
@@ -482,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn rubric_defaults_all_24_kinds_present() {
+    fn rubric_defaults_all_29_kinds_present() {
         let r = Rubric::defaults();
         assert_eq!(r.weights.get("destructive_in_inline_command"), Some(&4.0));
         assert_eq!(r.weights.get("destructive_in_hook_script"), Some(&4.0));
@@ -509,7 +544,7 @@ mod tests {
         assert_eq!(r.weights.get("mcp_tool_instruction_override"), Some(&3.5));
         assert_eq!(r.weights.get("mcp_tool_hidden_text"), Some(&3.5));
         assert_eq!(r.weights.get("mcp_tool_name_shadow"), Some(&3.0));
-        assert_eq!(r.weights.len(), 24);
+        assert_eq!(r.weights.len(), 29);
     }
 
     #[test]

--- a/crates/sigil-core/src/event.rs
+++ b/crates/sigil-core/src/event.rs
@@ -276,6 +276,33 @@ pub enum AiGuardReason {
     /// colliding server names. POSTURE only. Cross-tool (computed over the
     /// whole snapshot, not per-tool).
     McpToolNameShadow { tool: String, servers: Vec<String> },
+    /// #199 — a classifier-mediated auto-approval mode (Claude Code's
+    /// `autoMode`) had its built-in safety rules discarded. The deny lists
+    /// splice the defaults in via a `"$defaults"` marker; a list written
+    /// without it silently replaces them rather than extending them, so the
+    /// shipped protections stop applying. `list` names which one
+    /// (`soft_deny` | `hard_deny`). POSTURE only. Static.
+    AutoModeDefaultsDropped { list: String },
+    /// #199 — a hook forwards the tool call off-box instead of running a local
+    /// command: Claude Code's `http` hook type POSTs the full tool-call JSON to
+    /// a URL, so every intercepted call (and its arguments) leaves the machine.
+    /// `destination` is the configured URL host, `hook_event` the event it is
+    /// registered on. POSTURE only. Static.
+    HookForwardsToolCalls {
+        hook_event: String,
+        destination: String,
+    },
+    /// #199 — a default prompt for unattended, session-scoped scheduled runs
+    /// exists on disk (`loop.md`). Same class as
+    /// [`AiGuardReason::UnattendedScheduledTask`]: work that repeats with no
+    /// human watching. `source` is `user` or `project`. POSTURE only. Static.
+    UnattendedLoopPrompt { source: String },
+    /// #200 — a standing rule auto-approves commands by prefix without
+    /// prompting (Codex's `~/.codex/rules/*.rules`
+    /// `prefix_rule(pattern=[…], decision="allow")`). Unlike a session
+    /// approval this persists, so every future command matching the prefix
+    /// runs unattended. `pattern` is the approved prefix. POSTURE only. Static.
+    StandingCommandApproval { pattern: String },
 }
 
 /// #146 — category of instruction-file directive. Stable wire strings


### PR DESCRIPTION
Addresses the bulk of #199 and #200 — **not** closing either, since each keeps a documented remainder (listed at the end).

Both parsers were written against surfaces that have moved upstream since, so a config could be materially more autonomous than `sigil scan` reported. Done as one PR because both add reason variants to the same shared `event.rs` / `rubric.rs` / `remediation.rs`, and reviewing that set once is easier than twice.

## Claude Code (#199)

| Gap | What now happens |
| --- | --- |
| `defaultMode: "auto"` scored like `bypassPermissions` | `auto` gets its own kind and a lower weight — a classifier can still refuse, so it is a weaker posture, but it is still a dangerous toggle. `dontAsk` / `manual` / `plan` stay unflagged. |
| `autoMode` block unread | A deny list without the `"$defaults"` splice marker replaces the built-in safety rules instead of extending them → `auto_mode_defaults_dropped`. |
| Hook walker keyed off `command` | `http`, `prompt`, `agent`, `mcp_tool` were invisible. `http` (non-loopback) and `mcp_tool` forward the tool call outside the agent's trust domain → `hook_forwards_tool_calls` with the destination. |
| `loop.md` unread | Enumerated alongside `scheduled-tasks/*/SKILL.md`, user and project scope → `unattended_loop_prompt`. |
| `mcp__*` / `Bash(*)` not seen as broad | Both now flagged, without reading `Bash(run_in_background:true)` as breadth. |

## Codex (#200)

`approval_policy` was **not read at all** — the issue text said otherwise and has been [corrected](https://github.com/Ju571nK/sigil/issues/200#issuecomment-5083565526). `"never"` is now an auto-approval finding.

`~/.codex/rules/*.rules` holds standing command approvals that never appear in `config.toml`. A `decision="allow"` rule is reported with the prefix it approves → `standing_command_approval`. Confirmed against a live install (codex-cli 0.137.0), where this machine's real `default.rules` produces exactly one finding: `codex mcp login`.

## What is deliberately not claimed

The guiding principle from #198 applies in both directions: a missed finding is a gap, but an invented one makes the score untrustworthy.

- **`approval_policy = { granular = … }`** parses without error but is not scored. It can be stricter than any scalar, so asserting auto-approval from its shape would claim an exposure that may not exist. Scoring it needs hardware verification of the accepted sub-values.
- **A dormant `autoMode` block** is not a finding. Under any mode but `auto` the classifier never consults it. Nor is one that appears only in `settings.local.json`, which the classifier does not read.
- **Loopback `http` hooks** are local validators; the payload does not leave the machine.
- **`prompt` / `agent` hooks** go to the model the user is already talking to, so no new trust boundary is crossed.

The rules parser is quote- and bracket-aware rather than line-based, because a naive scan invents approvals. `pattern=["codex","mcp","login"]` is one argv sequence, not three separate commands; a nested list is a set of alternatives at that position (`gh pr {view|list}`); and the keyword inside a comment or a quoted justification is not a decision. An earlier line-based draft reported three approvals for this machine's one real rule — the corrected parser reports one.

## Verification

- Adversarial review found 4 false positives, 3 false negatives, and 2 correctness issues; each is fixed and pinned by a test. One suggestion was **declined**: making a corrupt `config.toml` degrade to rules-only findings would break the existing `corrupt_toml_returns_parse_error` contract, and Codex will not start against a config it cannot parse, so the approvals are not in force either — the actionable signal is that the config is broken.
- Real-machine `sigil scan` run before and after, confirming the Codex rules detector fires and reports the right prefix.
- `cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test --workspace` green.

## Known follow-ups (not in scope)

- A bare `allow: ["Bash"]` permits every shell command and arguably belongs in `permissions_allow_broad`. That is pre-existing behavior and would add findings to many existing configs, so it deserves its own decision.
- Codex's layered config (`/etc/codex`, profile, repo-local `.codex/config.toml`) and `requirements.toml` as a positive hardening signal remain open on #200. Claude's hardening keys and skill/agent-frontmatter hooks remain open on #199. Both issues stay open for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
