### PR TITLE
feat(hook): Antigravity enforce adapter on the verified agy contract (#208)

### DIFF
--- a/crates/sigil-hook/src/adapters/antigravity.rs
+++ b/crates/sigil-hook/src/adapters/antigravity.rs
@@ -1,17 +1,32 @@
-use super::HookAdapter;
+use super::{allow_tool_deny, DenyOutput, HookAdapter};
 use crate::redact::capture;
 use sigil_core::event::AiTool;
 use sigil_core::hook_proto::*;
 
-/// Antigravity (Google) — successor to Gemini CLI (sunset 2026-06-18). Its
-/// `PreToolUse` hook adopts the Claude Code payload shape
-/// (`session_id` / `cwd` / `tool_name` / `tool_input` / `tool_use_id`,
-/// `hook_event_name: "PreToolUse"`), so this mirrors the Claude adapter — but we
-/// also defensively handle Gemini-carryover tool names
-/// (`run_shell_command` / `write_file` / `replace`) in case Antigravity still
-/// emits any of them. Unknown tools degrade to `Other { label }`.
-/// NOTE (#112): this adapter is not reachable from current agy command-hooks
-/// (they do not fire); it is retained for parser / forced-bundle compatibility.
+/// Antigravity (Google `agy`) `PreToolUse` hook.
+///
+/// Payload shape hardware-verified on agy 1.1.7 (#202) — it is NOT the Claude
+/// shape this adapter previously assumed. The call is nested under `toolCall`
+/// and its arguments use PascalCase keys:
+///
+/// ```json
+/// {"conversationId":"…","modelName":"…","stepIdx":3,
+///  "toolCall":{"name":"run_command","args":{"CommandLine":"echo hi","Cwd":"/x"}},
+///  "transcriptPath":"…","workspacePaths":[]}
+/// ```
+///
+/// There is no `hook_event_name`, no `session_id`, and no top-level `cwd`; the
+/// session is `conversationId` and the working directory rides in the tool's
+/// own arguments.
+///
+/// Deny is `{"allow_tool": false, "deny_reason": "…"}` with exit 0. agy is
+/// **fail-open** — an empty stdout, an explicit allow, and a non-zero exit all
+/// let the call through — so the deny must always be emitted explicitly and
+/// never expressed through the exit code.
+///
+/// The legacy flat Claude-shaped keys are still accepted as a fallback. They
+/// were this adapter's original assumption and cost little to keep, but no
+/// agy version has been observed emitting them.
 pub struct Antigravity;
 
 impl HookAdapter for Antigravity {
@@ -24,14 +39,28 @@ impl HookAdapter for Antigravity {
         p: &serde_json::Value,
         level: CaptureLevel,
     ) -> Result<HookInvocation, CaptureStatus> {
-        let tool = p
-            .get("tool_name")
+        // Verified 1.1.7 shape first; the flat Claude-shaped keys are the
+        // legacy fallback.
+        let call = p.get("toolCall");
+        let tool = call
+            .and_then(|c| c.get("name"))
+            .or_else(|| p.get("tool_name"))
             .and_then(|v| v.as_str())
             .ok_or(CaptureStatus::Malformed)?;
-        let input = p
-            .get("tool_input")
+        let input = call
+            .and_then(|c| c.get("args"))
+            .or_else(|| p.get("tool_input"))
             .cloned()
             .unwrap_or(serde_json::Value::Null);
+        // agy names the command `CommandLine`; the legacy shape used `command`.
+        let command = input
+            .get("CommandLine")
+            .or_else(|| input.get("command"))
+            .and_then(|v| v.as_str());
+        let file_path = input
+            .get("FilePath")
+            .or_else(|| input.get("file_path"))
+            .and_then(|v| v.as_str());
 
         let action = if let Some(rest) = tool.strip_prefix("mcp__") {
             let mut it = rest.splitn(2, "__");
@@ -45,9 +74,12 @@ impl HookAdapter for Antigravity {
                 args_hash: c.hash,
                 args_preview: c.preview,
             }
-        } else if tool == "Bash" || tool == "run_shell_command" || input.get("command").is_some() {
-            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
-            let c = capture(cmd, level);
+        } else if tool == "run_command"
+            || tool == "Bash"
+            || tool == "run_shell_command"
+            || command.is_some()
+        {
+            let c = capture(command.unwrap_or(""), level);
             HookAction::Bash {
                 command_hash: c.hash,
                 command_preview: c.preview,
@@ -55,12 +87,9 @@ impl HookAdapter for Antigravity {
         } else if matches!(
             tool,
             "Edit" | "Write" | "MultiEdit" | "write_file" | "replace"
-        ) || input.get("file_path").is_some()
+        ) || file_path.is_some()
         {
-            let path = input
-                .get("file_path")
-                .and_then(|v| v.as_str())
-                .unwrap_or(tool);
+            let path = file_path.unwrap_or(tool);
             let c = capture(path, level);
             HookAction::FileEdit {
                 path_hash: c.hash,
@@ -80,9 +109,13 @@ impl HookAdapter for Antigravity {
         Ok(HookInvocation {
             agent: AiTool::Antigravity,
             agent_session_id: p
-                .get("session_id")
+                .get("conversationId")
+                .or_else(|| p.get("session_id"))
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            // agy carries no per-call id; `stepIdx` is the only ordinal in the
+            // payload and is not stable across conversations, so it is not
+            // presented as one.
             tool_use_id: p
                 .get("tool_use_id")
                 .and_then(|v| v.as_str())
@@ -90,8 +123,17 @@ impl HookAdapter for Antigravity {
             action,
             capture_level: level,
             capture_status: CaptureStatus::Ok,
-            cwd: p.get("cwd").and_then(|v| v.as_str()).map(String::from),
+            // No top-level `cwd`; the working directory rides in the tool args.
+            cwd: input
+                .get("Cwd")
+                .or_else(|| p.get("cwd"))
+                .and_then(|v| v.as_str())
+                .map(String::from),
         })
+    }
+
+    fn deny_output(&self, rule_id: &str, reason: &str) -> DenyOutput {
+        allow_tool_deny(rule_id, reason)
     }
 }
 
@@ -189,5 +231,85 @@ mod tests {
             HookAction::Other { label, .. } => assert_eq!(label, "Glob"),
             _ => panic!("expected Other"),
         }
+    }
+
+    /// The exact payload agy 1.1.7 wrote to the hook's stdin (#202), captured
+    /// from hardware. The adapter previously read `tool_name`/`tool_input` and
+    /// would have returned `Malformed` for this.
+    #[test]
+    fn verified_agy_117_run_command_payload() {
+        let p = serde_json::json!({
+            "artifactDirectoryPath": "/h/.gemini/antigravity-cli/brain/bcc552c5",
+            "conversationId": "bcc552c5-cac5-4512-97df-fbf89966a516",
+            "modelName": "gemini-3.6-flash-high",
+            "stepIdx": 3,
+            "toolCall": {
+                "name": "run_command",
+                "args": {
+                    "CommandLine": "echo SIGIL_PROBE_MARKER",
+                    "Cwd": "/h/.gemini/antigravity-cli/scratch",
+                    "WaitMsBeforeAsync": 1000
+                }
+            },
+            "transcriptPath": "/h/.../transcript_full.jsonl",
+            "workspacePaths": []
+        });
+        let inv = Antigravity.normalize(&p, CaptureLevel::Redacted).unwrap();
+        assert_eq!(inv.agent, AiTool::Antigravity);
+        assert_eq!(
+            inv.agent_session_id.as_deref(),
+            Some("bcc552c5-cac5-4512-97df-fbf89966a516")
+        );
+        assert_eq!(
+            inv.cwd.as_deref(),
+            Some("/h/.gemini/antigravity-cli/scratch"),
+            "cwd rides in the tool args, not the top level"
+        );
+        match inv.action {
+            HookAction::Bash {
+                command_preview, ..
+            } => assert_eq!(command_preview.unwrap(), "echo SIGIL_PROBE_MARKER"),
+            other => panic!("expected Bash, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unknown_tool_is_other() {
+        let p = serde_json::json!({
+            "toolCall": {"name": "view_file", "args": {"AbsolutePath": "/x"}}
+        });
+        match Antigravity
+            .normalize(&p, CaptureLevel::Redacted)
+            .unwrap()
+            .action
+        {
+            HookAction::Other { label, .. } => assert_eq!(label, "view_file"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn payload_without_a_tool_name_is_malformed() {
+        let p = serde_json::json!({"conversationId": "c", "toolCall": {"args": {}}});
+        assert!(matches!(
+            Antigravity.normalize(&p, CaptureLevel::Redacted),
+            Err(CaptureStatus::Malformed)
+        ));
+    }
+
+    /// agy is fail-open, so the deny must be explicit and must not be
+    /// expressed through the exit code.
+    #[test]
+    fn deny_is_allow_tool_false_with_exit_zero() {
+        let out = Antigravity.deny_output("no-rm", "destructive");
+        assert_eq!(out.exit_code, 0);
+        let v: serde_json::Value =
+            serde_json::from_str(&out.stdout.expect("deny prints stdout")).unwrap();
+        assert_eq!(v["allow_tool"], false);
+        assert_eq!(v["deny_reason"], "Blocked by Sigil rule no-rm: destructive");
+        // Not any of the other agents' spellings.
+        assert!(v["permission"].is_null(), "{v}");
+        assert!(v["decision"].is_null(), "{v}");
+        assert!(v["hookSpecificOutput"].is_null(), "{v}");
     }
 }

--- a/crates/sigil-hook/src/adapters/mod.rs
+++ b/crates/sigil-hook/src/adapters/mod.rs
@@ -10,8 +10,6 @@ pub mod grok;
 /// deny response, if any) and the process exit code. claude-code/codex/
 /// antigravity: the JSON rides stdout with exit 0; the exit_code field lets a
 /// future agent whose deny path needs a non-zero exit express that.
-/// (antigravity: this deny contract is NOT reachable on current agy — its
-/// command-hooks do not fire; #112).
 pub struct DenyOutput {
     pub stdout: Option<String>,
     pub exit_code: i32,
@@ -41,6 +39,24 @@ pub(crate) fn decision_deny(rule_id: &str, reason: &str) -> DenyOutput {
     let v = serde_json::json!({
         "decision": "deny",
         "reason": format!("Blocked by Sigil rule {rule_id}: {reason}"),
+    });
+    DenyOutput {
+        stdout: Some(v.to_string()),
+        exit_code: 0,
+    }
+}
+
+/// Antigravity-shaped deny: `{"allow_tool":false,"deny_reason":"…"}` on stdout,
+/// exit 0 (hardware-verified on agy 1.1.7, #202 — the reason is surfaced to the
+/// model verbatim). A third distinct spelling: Grok keys on `decision`, Cursor
+/// on `permission`, agy on `allow_tool`.
+///
+/// agy is fail-OPEN — empty stdout, an explicit allow, and a non-zero exit all
+/// allow the call — so this must always be emitted and the exit code stays 0.
+pub(crate) fn allow_tool_deny(rule_id: &str, reason: &str) -> DenyOutput {
+    let v = serde_json::json!({
+        "allow_tool": false,
+        "deny_reason": format!("Blocked by Sigil rule {rule_id}: {reason}"),
     });
     DenyOutput {
         stdout: Some(v.to_string()),

--- a/crates/sigil-hook/src/install.rs
+++ b/crates/sigil-hook/src/install.rs
@@ -10,10 +10,14 @@
 //   - Cursor: ~/.cursor/hooks.json with `version:1` + per-event arrays
 //     (`beforeShellExecution`, `beforeMCPExecution`) of `{command}`.
 //
-// Antigravity is deliberately absent here: on-hardware verification (real `agy`
-// 1.0.4) proved its hooks are NOT read from any settings.json — they load only
-// from an imported plugin bundle. That install path lives in
-// `install_antigravity.rs` (a directory bundle handed to `agy plugin install`).
+//   - Antigravity: ~/.gemini/config/hooks.json, same nested `PreToolUse` shape
+//     as claude-code/codex. This is the SHARED hooks file agy's own `/hooks`
+//     TUI writes, so registration merges and uninstall removes only our entry.
+//     Hardware-verified on agy 1.1.7 (#202): the hook fires and an explicit
+//     deny blocks the call. The earlier "hooks are not read from a settings
+//     file" conclusion (#112) held for agy 1.0.4–1.0.8 and was fixed upstream.
+//     The separate plugin-bundle path in `install_antigravity.rs` is a
+//     different mechanism and has not been re-probed.
 
 use serde_json::{json, Value};
 use std::io;
@@ -30,7 +34,10 @@ pub(crate) enum HookFormat {
 
 pub(crate) fn agent_format(agent: &str) -> Option<HookFormat> {
     match agent {
-        "claude-code" | "codex" => Some(HookFormat::NestedPreToolUse),
+        // #208 — agy's shared hooks file uses the same nested shape as
+        // claude-code/codex (hardware-verified on 1.1.7, #202: a bare
+        // `{"PreToolUse":[…]}` at that path does not load).
+        "claude-code" | "codex" | "antigravity" => Some(HookFormat::NestedPreToolUse),
         "cursor" => Some(HookFormat::Cursor),
         _ => None,
     }
@@ -86,6 +93,39 @@ pub(crate) fn claude_entry_is_ours(entry: &Value, exe: &str) -> bool {
 }
 
 /// Get-or-create the nested `hooks.PreToolUse` array.
+/// #208 — describe a shape conflict in an existing settings document, if the
+/// merge would have to overwrite live data to proceed.
+///
+/// `pretooluse_array_mut` coerces: a `hooks` that is not an object, or a
+/// `PreToolUse` that is not an array, is replaced outright. That is silent data
+/// loss, and for antigravity the file is shared with agy's own `/hooks` TUI, so
+/// what would be lost is the user's other hooks. Callers check this first and
+/// refuse rather than coerce. Absent keys are not a conflict — there is nothing
+/// there to lose.
+pub fn conflicting_shape(root: &Value, agent: &str) -> Option<String> {
+    if !root.is_null() && !root.is_object() {
+        return Some("the document root is not a JSON object".to_string());
+    }
+    let hooks = root.get("hooks")?;
+    if !hooks.is_object() {
+        return Some("`hooks` exists but is not an object".to_string());
+    }
+    let events: &[&str] = match agent_format(agent) {
+        Some(HookFormat::NestedPreToolUse) => &["PreToolUse"],
+        Some(HookFormat::Cursor) => &CURSOR_EVENTS,
+        None => return None,
+    };
+    for ev in events {
+        match hooks.get(*ev) {
+            Some(v) if !v.is_array() => {
+                return Some(format!("`hooks.{ev}` exists but is not an array"));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 fn pretooluse_array_mut(root: &mut Value) -> &mut Vec<Value> {
     if !root.is_object() {
         *root = json!({});
@@ -371,6 +411,10 @@ pub fn settings_path(agent: &str) -> Option<PathBuf> {
         "claude-code" => home.join(".claude/settings.json"),
         "codex" => home.join(".codex/hooks.json"),
         "cursor" => home.join(".cursor/hooks.json"),
+        // #208 — the SHARED hooks file, which agy's own `/hooks` TUI also
+        // writes. Not `~/.gemini/antigravity-cli/hooks.json`: agy 1.0.8 fixed
+        // writing there as a bug. Merged into, never overwritten.
+        "antigravity" => home.join(".gemini/config/hooks.json"),
         _ => return None,
     };
     Some(p)
@@ -542,23 +586,60 @@ mod tests {
         assert!(v["hooks"]["PreToolUse"].is_array());
     }
 
-    // Antigravity is NOT a settings-merge agent — it installs as an `agy`
-    // plugin bundle (see install_antigravity.rs). The JSON-merge path must
-    // treat it as unsupported so it can never write a settings.json hook that
-    // `agy` silently ignores.
+    // #208 — Antigravity IS a settings-merge agent now. Its file is shared
+    // with agy's own `/hooks` TUI, so the merge must be additive and uninstall
+    // must take only our entry.
     #[test]
-    fn antigravity_not_in_settings_merge_path() {
-        assert!(settings_path("antigravity").is_none());
-        assert!(!merge_into(
-            &mut json!({}),
+    fn antigravity_registers_in_nested_pretooluse_shape() {
+        let mut v = json!({});
+        assert!(merge_into(
+            &mut v,
             "/abs/sigil-hook",
             "antigravity",
             "redacted"
         ));
-        assert_eq!(
-            count_sigil_entries(&json!({}), "/abs/sigil-hook", "antigravity"),
-            0
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook", "antigravity"), 1);
+        // The nested wrapper is required: a bare top-level `PreToolUse` does
+        // not load on agy (#202).
+        assert!(v["hooks"]["PreToolUse"].is_array(), "got {v}");
+        assert!(
+            v["PreToolUse"].is_null(),
+            "must not write the bare shape: {v}"
         );
+    }
+
+    #[test]
+    fn antigravity_settings_path_is_the_shared_file() {
+        let p = settings_path("antigravity").expect("antigravity has a settings path");
+        assert!(
+            p.ends_with(".gemini/config/hooks.json"),
+            "got {}",
+            p.display()
+        );
+    }
+
+    /// The file belongs to agy too — registering must not drop a hook the user
+    /// or the `/hooks` TUI put there, and uninstall must leave it behind.
+    #[test]
+    fn antigravity_merge_preserves_foreign_hooks_and_uninstall_leaves_them() {
+        let mut v = json!({
+            "hooks": {"PreToolUse": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": "/other/tool --x"}]}
+            ]}
+        });
+        assert!(merge_into(
+            &mut v,
+            "/abs/sigil-hook",
+            "antigravity",
+            "redacted"
+        ));
+        assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 2);
+
+        assert!(remove_from(&mut v, "/abs/sigil-hook", "antigravity"));
+        let left = v["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(left.len(), 1, "foreign hook must survive: {v}");
+        assert_eq!(left[0]["hooks"][0]["command"], "/other/tool --x");
+        assert_eq!(count_sigil_entries(&v, "/abs/sigil-hook", "antigravity"), 0);
     }
 
     // --- Cursor (version + two event arrays) ---

--- a/crates/sigil-hook/src/install_antigravity.rs
+++ b/crates/sigil-hook/src/install_antigravity.rs
@@ -1,15 +1,18 @@
 // Antigravity (Google `agy` CLI) install. Antigravity loads hooks from an
 // imported plugin bundle (`agy plugin install <dir>`), NOT settings.json.
 //
-// VERSION CAVEAT (#112): agy 1.0.4 accepted and loaded this `hooks/hooks.json`
-// bundle (`agy plugin validate` reported "hooks: 1 processed"), but agy
-// 1.0.7/1.0.8 do NOT fire `agy plugin install` PreToolUse command-hooks —
-// `agy plugin validate` reports "hooks: skipped (not found)", `plugin list`
-// shows components: null, and an always-deny probe hook fired 0 times on
-// hardware. So on current agy this registration is a no-op. `sigil-hook install
-// --agent antigravity` therefore does NOT install by default (see
-// cmd_install_antigravity); this module's bundle path is reached only under
-// `--force` (experimental / for a future agy that restores command-hooks).
+// LEGACY MECHANISM (#112, #208). agy 1.0.4 accepted and loaded this
+// `hooks/hooks.json` bundle (`agy plugin validate` reported "hooks: 1
+// processed"), but agy 1.0.7/1.0.8 did NOT fire `agy plugin install` PreToolUse
+// command-hooks — validate reported "hooks: skipped (not found)", `plugin list`
+// showed components: null, and an always-deny probe hook fired 0 times on
+// hardware.
+//
+// #202 later measured agy 1.1.7 firing hooks from the SHARED settings file
+// `~/.gemini/config/hooks.json`, and honouring an explicit deny. That is a
+// different mechanism and is now the default install (see install.rs). This
+// plugin-bundle path has NOT been re-probed on 1.1.x, registers an observe-only
+// command, and is reached only under `--force`.
 //
 // Canonical bundle layout (as accepted by agy 1.0.4; `hooks/` subdir required —
 // root-level hooks.json, inline `hooks` in plugin.json, and hooks.toml were all
@@ -113,9 +116,12 @@ pub fn render_block(exe: &str, capture: &str) -> String {
     let pj = serde_json::to_string_pretty(&plugin_json()).unwrap_or_default();
     let hj = serde_json::to_string_pretty(&hooks_json(exe, capture)).unwrap_or_default();
     format!(
-        "// Antigravity registers hooks via an imported plugin, not a settings file.\n\
-         // NOTE: current agy (>=1.0.7) does NOT fire this command-hook (sigil #112);\n\
-         // `install --agent antigravity` is a no-op unless you pass --force.\n\
+        "// LEGACY path: the `agy plugin install` bundle, selected by --force.\n\
+         // agy 1.0.7-1.0.8 did not fire this command-hook (sigil #112) and it has\n\
+         // not been re-probed since; it is observe-only and cannot enforce.\n\
+         // The SUPPORTED path is `install --agent antigravity` without --force,\n\
+         // which merges into ~/.gemini/config/hooks.json — verified to fire and\n\
+         // to honour a deny on agy 1.1.7 (sigil #202).\n\
          // Under --force, --write writes this bundle to\n\
          //   {dir_s}\n\
          // then runs: agy plugin install {dir_s}\n\

--- a/crates/sigil-hook/src/main.rs
+++ b/crates/sigil-hook/src/main.rs
@@ -190,10 +190,18 @@ enum Cmd {
         on_failure: OnFailureArg,
     },
 
-    /// Antigravity PreToolUse entrypoint: read stdin, emit, exit 0.
+    /// Antigravity PreToolUse entrypoint: observe (emit, exit 0), or --enforce
+    /// (deny-decision path). #208 — enforce became reachable once #202 measured
+    /// agy 1.1.7 firing the hook and honouring an explicit deny.
     Antigravity {
         #[arg(long, value_enum, default_value_t = CaptureArg::Redacted)]
         capture: CaptureArg,
+        /// Stage 2: run the synchronous deny-decision path instead of observe.
+        #[arg(long)]
+        enforce: bool,
+        /// Behavior when no verdict is obtainable. Default open (fail-open).
+        #[arg(long, value_enum, default_value_t = OnFailureArg::Open)]
+        on_failure: OnFailureArg,
     },
 
     /// Grok Build PreToolUse entrypoint: observe (emit, exit 0), or --enforce (deny-decision path).
@@ -210,9 +218,12 @@ enum Cmd {
 
     /// Print (or write) the sigil-hook registration for an agent.
     ///
-    /// claude-code | codex | cursor merge into a settings JSON file; antigravity
-    /// is registered as an `agy` plugin bundle (`agy plugin install`); grok
-    /// writes a dedicated ~/.grok/hooks/sigil-hook.json file.
+    /// claude-code | codex | cursor | antigravity merge into a settings JSON
+    /// file (antigravity's is ~/.gemini/config/hooks.json, shared with agy's own
+    /// `/hooks` TUI, so the merge is additive); grok writes a dedicated
+    /// ~/.grok/hooks/sigil-hook.json file. `--force` selects antigravity's
+    /// legacy `agy plugin install` bundle instead, which is a different and
+    /// unverified mechanism.
     Install {
         /// Agent to register with: claude-code | codex | cursor | antigravity | grok.
         #[arg(long, default_value = INSTALL_AGENT_DEFAULT)]
@@ -399,7 +410,17 @@ fn main() {
                 run_hook("cursor", capture.into())
             }
         }
-        Cmd::Antigravity { capture } => run_hook("antigravity", capture.into()),
+        Cmd::Antigravity {
+            capture,
+            enforce,
+            on_failure,
+        } => {
+            if enforce {
+                run_enforce("antigravity", capture.into(), on_failure)
+            } else {
+                run_hook("antigravity", capture.into())
+            }
+        }
         Cmd::Grok {
             capture,
             enforce,
@@ -451,19 +472,24 @@ fn cmd_install(
     };
     let exe = exe_path();
 
-    // Antigravity is not a settings-merge agent: it installs as an `agy` plugin
-    // bundle. Route it through the dedicated path.
-    if agent == "antigravity" {
-        // #112 (C1) — Antigravity enforce is not available: current agy does not
-        // fire plugin command-hooks, so there is no deny path to register.
+    // #208 — Antigravity now installs through the ordinary settings-merge path
+    // (`~/.gemini/config/hooks.json`), which is the mechanism #202 verified on
+    // hardware. `--force` still selects the legacy `agy plugin install` bundle:
+    // that is a DIFFERENT mechanism which has not been re-probed, so it stays
+    // opt-in rather than becoming the default or being deleted outright.
+    if agent == "antigravity" && force {
+        // The legacy bundle registers an observe-only command
+        // (`install_antigravity::command_string`). Honouring `--enforce` here
+        // would hand back a hook that never denies while reporting success.
         if enforce {
             eprintln!(
-                "error: Antigravity enforce is not available — current agy does not fire \
-                 plugin command-hooks (sigil #112). Use static posture scanning; omit --enforce."
+                "error: --force selects the legacy Antigravity plugin bundle, which registers \
+                 an observe-only hook and cannot enforce. Drop --force to install the \
+                 verified enforce hook in ~/.gemini/config/hooks.json."
             );
             std::process::exit(2);
         }
-        return cmd_install_antigravity(&exe, write, capture_str, force);
+        return cmd_install_antigravity(&exe, write, capture_str);
     }
 
     // Grok is not a settings-merge agent: it writes a dedicated
@@ -485,14 +511,19 @@ fn cmd_install(
     }
 
     // Enforce-mode --write is supported for the NestedPreToolUse agents
-    // (claude-code, codex), for cursor (beforeShellExecution/beforeMCPExecution),
-    // and for grok (native ~/.grok/hooks). Guard any other agent so we never
-    // write a misleading settings file. (antigravity routes to its own plugin
-    // path above; grok routes to cmd_install_grok above — so by here the only
-    // enforce-capable agents reaching the generic path are claude-code/codex/cursor.)
-    if enforce && !matches!(agent, "claude-code" | "codex" | "grok" | "cursor") {
+    // (claude-code, codex, antigravity), for cursor
+    // (beforeShellExecution/beforeMCPExecution), and for grok (native
+    // ~/.grok/hooks). Guard any other agent so we never write a misleading
+    // settings file. #208 added antigravity, whose deny path #202 measured
+    // working on agy 1.1.7. (grok routes to cmd_install_grok above.)
+    if enforce
+        && !matches!(
+            agent,
+            "claude-code" | "codex" | "grok" | "cursor" | "antigravity"
+        )
+    {
         eprintln!(
-            "error: enforce-mode install is only supported for claude-code/codex/grok/cursor in this slice (agent '{agent}' not registered)"
+            "error: enforce-mode install is only supported for claude-code/codex/grok/cursor/antigravity (agent '{agent}' not registered)"
         );
         std::process::exit(1);
     }
@@ -507,6 +538,12 @@ fn cmd_install(
     };
 
     // Read existing settings or start from an empty object.
+    //
+    // A file we cannot parse is NOT treated as empty. Registration rewrites the
+    // whole document, so starting from `{}` would silently delete whatever the
+    // file held — and for antigravity that file is shared with agy's own
+    // `/hooks` TUI (#208), so the loss would be the user's other hooks. Refuse
+    // and say which file, so a typo is fixed rather than erased.
     let mut root: serde_json::Value = if sp.exists() {
         let raw = match std::fs::read(&sp) {
             Ok(r) => r,
@@ -515,10 +552,36 @@ fn cmd_install(
                 std::process::exit(1);
             }
         };
-        serde_json::from_slice(&raw).unwrap_or(serde_json::json!({}))
+        if raw.iter().all(|b| b.is_ascii_whitespace()) {
+            serde_json::json!({})
+        } else {
+            match serde_json::from_slice(&raw) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "error: {} is not valid JSON ({e}); refusing to overwrite it. \
+                         Fix or move the file, then re-run.",
+                        sp.display()
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
     } else {
         serde_json::json!({})
     };
+
+    // #208 — refuse rather than coerce a conflicting shape. `merge_*` would
+    // replace a non-array `PreToolUse` (or a non-object `hooks`) outright, which
+    // for antigravity's shared file means deleting the user's own hooks.
+    if let Some(conflict) = install::conflicting_shape(&root, agent) {
+        eprintln!(
+            "error: {} has an unexpected shape — {conflict}. Registering would \
+             overwrite it, so nothing was written. Fix or move the file, then re-run.",
+            sp.display()
+        );
+        std::process::exit(1);
+    }
 
     let changed = if enforce {
         install::merge_into_enforce(&mut root, &exe, agent, capture_str, on_failure_str)
@@ -550,9 +613,9 @@ fn cmd_install(
     // Write baseline / update discovery index. For agents whose `verify`
     // path is implemented. Cursor gained format-aware verify in #120 (per-agent
     // baseline file hook-registration-cursor.json), so the #119 D6 exclusion
-    // is removed. (grok and antigravity never reach here; they return to their
-    // own install fns above.)
-    if matches!(agent, "claude-code" | "codex" | "cursor") {
+    // is removed. #208 added antigravity, which now uses this same path.
+    // (grok never reaches here; it returns to its own install fn above.)
+    if matches!(agent, "claude-code" | "codex" | "cursor" | "antigravity") {
         if let Err(e) = install::write_baseline(
             agent,
             &sp,
@@ -577,8 +640,11 @@ fn cmd_install(
 fn cmd_uninstall(agent: &str, write: bool) {
     let exe = exe_path();
 
+    // #208 — remove the plugin bundle too, so an operator who installed the
+    // legacy way before this change is still cleaned up. The settings-file
+    // entry is then removed by the shared path below.
     if agent == "antigravity" {
-        return cmd_uninstall_antigravity(write);
+        cmd_uninstall_antigravity(write);
     }
 
     if agent == "grok" {
@@ -608,7 +674,19 @@ fn cmd_uninstall(agent: &str, write: bool) {
             std::process::exit(1);
         }
     };
-    let mut root: serde_json::Value = serde_json::from_slice(&raw).unwrap_or(serde_json::json!({}));
+    // Same reasoning as install: an unparsable file must not be reported as
+    // "nothing to remove", which reads as "already clean" when in fact we could
+    // not look.
+    let mut root: serde_json::Value = match serde_json::from_slice(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "error: {} is not valid JSON ({e}); cannot tell what is registered there.",
+                sp.display()
+            );
+            std::process::exit(1);
+        }
+    };
 
     let count = install::count_sigil_entries(&root, &exe, agent);
     if count == 0 {
@@ -693,45 +771,18 @@ fn cmd_uninstall_grok(write: bool) {
     }
 }
 
-/// #112 — current agy (>=1.0.7) does not fire `agy plugin install` PreToolUse
-/// command-hooks; installing one is a no-op that gives false assurance. Skip by
-/// default; only proceed under `--force` (preserves the path for a future agy
-/// that restores command-hooks).
-#[derive(Debug, PartialEq, Eq)]
-enum AntigravityInstallDisposition {
-    NotSupported,
-    Proceed,
-}
-
-fn antigravity_install_disposition(force: bool) -> AntigravityInstallDisposition {
-    if force {
-        AntigravityInstallDisposition::Proceed
-    } else {
-        AntigravityInstallDisposition::NotSupported
-    }
-}
-
-// C6 — must begin with "NOT installed" + "no files written, agy not invoked"
-// so the message never drifts into "installed" language; asserted by tests.
-const ANTIGRAVITY_NOT_SUPPORTED_MSG: &str =
-    "sigil-hook: Antigravity runtime hooks NOT installed (no files written, agy not invoked).\n\
-     Current Antigravity (agy >=1.0.7) does not fire `agy plugin install` PreToolUse \
-     command-hooks (verified — sigil #112), so installing one would be a no-op that \
-     falsely implies runtime protection.\n\
-     Sigil covers Antigravity via STATIC configuration posture scanning \
-     (sandbox / permission settings) instead.\n\
-     If a future agy restores command-hooks, re-run with --force to install anyway.";
-
 /// Antigravity install: materialize the plugin bundle, then register it with
 /// `agy plugin install`. Without `--write`, print the bundle + command preview.
-fn cmd_install_antigravity(exe: &str, write: bool, capture: &str, force: bool) {
-    if antigravity_install_disposition(force) == AntigravityInstallDisposition::NotSupported {
-        // Both preview (!write) and apply (--write) paths: do nothing but explain.
-        eprintln!("{ANTIGRAVITY_NOT_SUPPORTED_MSG}");
-        return;
-    }
-    // --force: legacy bundle path preserved (may still be a no-op on current agy).
-    eprintln!("sigil-hook: --force set; installing Antigravity command-hook anyway (may not fire on current agy — #112).");
+fn cmd_install_antigravity(exe: &str, write: bool, capture: &str) {
+    // Reached only under `--force`. This is the legacy `agy plugin install`
+    // bundle, a different mechanism from the verified `~/.gemini/config/hooks.json`
+    // registration and one that agy 1.0.7-1.0.8 did not fire (#112). It has not
+    // been re-probed since, so say so rather than implying protection.
+    eprintln!(
+        "sigil-hook: --force set; installing the legacy Antigravity plugin bundle. \
+         This mechanism did not fire on agy 1.0.7-1.0.8 (#112) and has not been \
+         re-verified; the supported path is `install --agent antigravity` without --force."
+    );
     if !write {
         print!("{}", install_antigravity::render_block(exe, capture));
         return;
@@ -821,13 +872,17 @@ fn cmd_verify(agent: &str) -> i32 {
     use sigil_core::event::AiTool;
 
     // TODO(#120 follow-on): consolidate this agent→AiTool table with install::agent_format
-    // when more agents (grok/antigravity) gain verify support — keep the two in sync until then.
+    // when grok gains verify support — keep the two in sync until then.
+    // #208 added antigravity, which now writes a baseline like the others; verify
+    // must accept every agent install writes one for, or the baseline is
+    // unreadable by the command meant to read it.
     let aitool = match agent {
         "claude-code" => AiTool::ClaudeCode,
         "codex" => AiTool::Codex,
         "cursor" => AiTool::Cursor,
+        "antigravity" => AiTool::Antigravity,
         other => {
-            eprintln!("sigil-hook verify: unsupported --agent '{other}' (expected: claude-code, codex, cursor)");
+            eprintln!("sigil-hook verify: unsupported --agent '{other}' (expected: claude-code, codex, cursor, antigravity)");
             return 1; // usage error — distinct from drift (2) / baseline_absent (3) / clean (0)
         }
     };
@@ -898,27 +953,5 @@ mod tests {
         assert_eq!(drift_exit_code(CommandDrift), 2);
         assert_eq!(drift_exit_code(MatcherDrift), 2);
         assert_eq!(drift_exit_code(FailModeDrift), 2);
-    }
-
-    #[test]
-    fn antigravity_disposition_gates_on_force() {
-        assert_eq!(
-            antigravity_install_disposition(false),
-            AntigravityInstallDisposition::NotSupported
-        );
-        assert_eq!(
-            antigravity_install_disposition(true),
-            AntigravityInstallDisposition::Proceed
-        );
-    }
-
-    #[test]
-    fn antigravity_not_supported_msg_is_honest() {
-        let m = ANTIGRAVITY_NOT_SUPPORTED_MSG;
-        assert!(m.contains("NOT installed"));
-        assert!(m.contains("no files written"));
-        assert!(m.contains("#112"));
-        assert!(m.contains("--force"));
-        assert!(m.to_lowercase().contains("static"));
     }
 }

--- a/crates/sigil-hook/tests/install_antigravity_static.rs
+++ b/crates/sigil-hook/tests/install_antigravity_static.rs
@@ -1,6 +1,11 @@
-//! CLI side-effect tests (#112): `install --agent antigravity` is static-posture-only
-//! by default (no bundle written, agy never invoked) and rejects --enforce; only
-//! --force performs the (legacy / no-op-on-current-agy) bundle install.
+//! CLI side-effect tests for `install --agent antigravity`.
+//!
+//! #112 made this static-posture-only because agy 1.0.7/1.0.8 did not fire
+//! command hooks. #202 re-verified on agy 1.1.7: the hook at the shared
+//! `~/.gemini/config/hooks.json` fires and an explicit deny blocks the call, so
+//! the default install now registers there. The legacy `agy plugin install`
+//! bundle is a *different* mechanism that has not been re-probed, and stays
+//! behind `--force`.
 #![cfg(unix)]
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -26,35 +31,109 @@ fn staging(home: &Path) -> PathBuf {
     home.join(".local/state/sigil/antigravity-plugin/sigil-hook")
 }
 
-#[test]
-fn antigravity_install_no_force_is_static_only_noop() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
-    let marker = write_fake_agy(home);
-    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
-        .args(["install", "--agent", "antigravity", "--write"])
+fn hooks_file(home: &Path) -> PathBuf {
+    home.join(".gemini/config/hooks.json")
+}
+
+fn run(home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
+        .args(args)
         .env("HOME", home)
         .env_remove("XDG_STATE_HOME")
         .output()
-        .unwrap();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(out.status.success(), "stderr: {stderr}");
-    assert!(stderr.contains("NOT installed"), "stderr: {stderr}");
-    assert!(!staging(home).exists(), "no bundle should be written");
-    assert!(!marker.exists(), "agy must not be invoked");
+        .unwrap()
 }
 
 #[test]
-fn antigravity_install_force_writes_bundle_and_calls_agy() {
+fn install_registers_in_the_shared_hooks_file_not_the_plugin_bundle() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
     let marker = write_fake_agy(home);
-    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
-        .args(["install", "--agent", "antigravity", "--write", "--force"])
-        .env("HOME", home)
-        .env_remove("XDG_STATE_HOME")
-        .output()
-        .unwrap();
+
+    let out = run(home, &["install", "--agent", "antigravity", "--write"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr: {stderr}");
+
+    let v: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(hooks_file(home)).unwrap()).unwrap();
+    // The nested wrapper is required — a bare top-level `PreToolUse` does not
+    // load on agy (#202).
+    let arr = v["hooks"]["PreToolUse"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected nested hooks.PreToolUse, got {v}"));
+    assert_eq!(arr.len(), 1, "{v}");
+    assert!(
+        v["PreToolUse"].is_null(),
+        "must not write the bare shape: {v}"
+    );
+
+    assert!(!staging(home).exists(), "default install writes no bundle");
+    assert!(!marker.exists(), "default install must not invoke agy");
+}
+
+/// The file is shared with agy's own `/hooks` TUI, so registration is additive
+/// and uninstall takes only Sigil's entry.
+#[test]
+fn install_and_uninstall_leave_foreign_hooks_alone() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_fake_agy(home);
+    fs::create_dir_all(hooks_file(home).parent().unwrap()).unwrap();
+    fs::write(
+        hooks_file(home),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"/other/tool"}]}]}}"#,
+    )
+    .unwrap();
+
+    assert!(run(home, &["install", "--agent", "antigravity", "--write"])
+        .status
+        .success());
+    let v: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(hooks_file(home)).unwrap()).unwrap();
+    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 2, "{v}");
+
+    assert!(
+        run(home, &["uninstall", "--agent", "antigravity", "--write"])
+            .status
+            .success()
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(hooks_file(home)).unwrap()).unwrap();
+    let left = v["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(left.len(), 1, "foreign hook must survive: {v}");
+    assert_eq!(left[0]["hooks"][0]["command"], "/other/tool");
+}
+
+/// #202 measured the deny path working, so enforce is no longer refused.
+#[test]
+fn enforce_registers_the_deny_command() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_fake_agy(home);
+
+    let out = run(
+        home,
+        &["install", "--agent", "antigravity", "--enforce", "--write"],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr: {stderr}");
+
+    let text = fs::read_to_string(hooks_file(home)).unwrap();
+    assert!(text.contains("--enforce"), "{text}");
+    // agy is fail-open, so the registered command must carry an explicit
+    // on-failure mode rather than relying on the exit code.
+    assert!(text.contains("--on-failure"), "{text}");
+}
+
+#[test]
+fn force_still_writes_the_legacy_plugin_bundle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let marker = write_fake_agy(home);
+    let out = run(
+        home,
+        &["install", "--agent", "antigravity", "--write", "--force"],
+    );
     assert!(
         out.status.success(),
         "stderr: {}",
@@ -65,23 +144,126 @@ fn antigravity_install_force_writes_bundle_and_calls_agy() {
         "bundle written under --force"
     );
     assert!(marker.exists(), "agy invoked under --force");
+    // And it says plainly that this path is unverified rather than implying
+    // protection.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("legacy"), "stderr: {stderr}");
 }
 
+/// The hooks file is shared with agy. If it does not parse, registration must
+/// refuse rather than start from `{}` and silently delete the user's hooks.
 #[test]
-fn antigravity_enforce_is_rejected() {
+fn malformed_shared_file_is_not_overwritten() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
     write_fake_agy(home);
-    let out = Command::new(env!("CARGO_BIN_EXE_sigil-hook"))
-        .args(["install", "--agent", "antigravity", "--enforce"])
-        .env("HOME", home)
-        .env_remove("XDG_STATE_HOME")
-        .output()
-        .unwrap();
+    fs::create_dir_all(hooks_file(home).parent().unwrap()).unwrap();
+    let original = r#"{"hooks":{"PreToolUse":[{"matcher":"*",]}}"#; // trailing comma / bad
+    fs::write(hooks_file(home), original).unwrap();
+
+    let out = run(home, &["install", "--agent", "antigravity", "--write"]);
+    assert!(!out.status.success(), "must not claim success");
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert_eq!(out.status.code(), Some(2), "stderr: {stderr}");
+    assert!(stderr.contains("not valid JSON"), "stderr: {stderr}");
+    assert_eq!(
+        fs::read_to_string(hooks_file(home)).unwrap(),
+        original,
+        "the file must be left exactly as it was"
+    );
+}
+
+/// An empty file holds nothing to lose, so it is treated as an empty document
+/// rather than an error.
+#[test]
+fn empty_shared_file_registers_normally() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_fake_agy(home);
+    fs::create_dir_all(hooks_file(home).parent().unwrap()).unwrap();
+    fs::write(hooks_file(home), "  \n").unwrap();
+
+    let out = run(home, &["install", "--agent", "antigravity", "--write"]);
     assert!(
-        stderr.contains("enforce is not available"),
-        "stderr: {stderr}"
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(hooks_file(home)).unwrap()).unwrap();
+    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 1, "{v}");
+}
+
+/// Valid JSON in an unexpected shape is still live data. Coercing it — which is
+/// what the merge helper does on its own — would delete the user's hooks.
+#[test]
+fn wrong_shaped_but_valid_json_is_refused_not_coerced() {
+    for original in [
+        // PreToolUse as an object rather than an array
+        r#"{"hooks":{"PreToolUse":{"matcher":"*","hooks":[{"type":"command","command":"/other"}]}}}"#,
+        // hooks as a string
+        r#"{"hooks":"user data"}"#,
+        // root as an array
+        r#"[1,2,3]"#,
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        write_fake_agy(home);
+        fs::create_dir_all(hooks_file(home).parent().unwrap()).unwrap();
+        fs::write(hooks_file(home), original).unwrap();
+
+        let out = run(home, &["install", "--agent", "antigravity", "--write"]);
+        assert!(!out.status.success(), "must refuse: {original}");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("unexpected shape"), "stderr: {stderr}");
+        assert_eq!(
+            fs::read_to_string(hooks_file(home)).unwrap(),
+            original,
+            "file must be untouched"
+        );
+    }
+}
+
+/// The legacy bundle registers an observe-only command, so asking for enforce
+/// through it must fail loudly rather than return a hook that never denies.
+#[test]
+fn force_plus_enforce_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let marker = write_fake_agy(home);
+    let out = run(
+        home,
+        &[
+            "install",
+            "--agent",
+            "antigravity",
+            "--enforce",
+            "--write",
+            "--force",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("cannot enforce"), "stderr: {stderr}");
+    assert!(!marker.exists(), "agy must not be invoked");
+    assert!(!staging(home).exists(), "no bundle written");
+}
+
+/// Install writes a baseline for antigravity, so verify has to be able to read
+/// it — otherwise the command that checks registrations rejects the agent whose
+/// registration it just recorded.
+#[test]
+fn verify_accepts_antigravity_after_install() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_fake_agy(home);
+    assert!(run(home, &["install", "--agent", "antigravity", "--write"])
+        .status
+        .success());
+
+    let out = run(home, &["verify", "--agent", "antigravity"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("unsupported --agent"),
+        "verify must know this agent: {stderr}"
     );
 }


### PR DESCRIPTION
Fixes #208.

#202 hardware-verified that agy 1.1.7 fires `PreToolUse` command hooks and honours an explicit deny, overturning #112. Sigil's Antigravity support was built on the older premise and was wrong in three ways.

| | Before | Now |
| --- | --- | --- |
| **Payload** | read `tool_name` / `tool_input` (the Claude shape it was assumed to copy) — against a real invocation it failed at the first lookup and returned `Malformed` | `toolCall.name` / `toolCall.args.CommandLine`; session from `conversationId`, cwd from `args.Cwd` (there is no top-level `cwd`). Flat keys kept as a fallback. |
| **Deny** | fell through to Claude's `permissionDecision` JSON | `{"allow_tool": false, "deny_reason": "…"}` with exit 0 — a third distinct spelling next to Cursor's `permission` and Grok's `decision` |
| **Install** | `agy plugin install` bundle | merges into the shared `~/.gemini/config/hooks.json` with the nested schema (a bare `{"PreToolUse":[…]}` there does not load) |

**agy is fail-open** — empty stdout, an explicit allow, and a non-zero exit all allow the call — so the deny is always emitted explicitly and never expressed through the exit code.

## End-to-end against real agy

Unit tests passed while the chain was still broken, so this was tested against the actual CLI:

- fail-closed → `tool call denied with reason: Blocked by Sigil rule fail_closed: decision unavailable; on_failure=closed`, surfaced to the model
- fail-open default, no daemon → the command ran, i.e. no spurious blocking

That test is what caught the real bug: the `antigravity` subcommand did not accept `--enforce`, so the registered hook exited 2 with no stdout and agy — being fail-open — ran the command anyway. Every unit test was green at that point.

## Two safety fixes found along the way

Both are about not destroying a file Sigil does not own. `~/.gemini/config/hooks.json` is shared with agy's own `/hooks` TUI, so the blast radius is a user's other hooks.

- **Unparsable file was read as `{}` and then rewritten**, silently deleting the contents. Registration now refuses and names the file. An empty file still registers normally — there is nothing to lose.
- **Valid JSON in an unexpected shape was coerced** by the merge helper: a `PreToolUse` object, a `hooks` string, or a non-object root got replaced outright. Registration refuses that too.

Both applied to the other settings-merge agents as well, so the fix is general rather than Antigravity-only.

## Also

- `--force --enforce` is rejected. `--force` selects the legacy plugin bundle, which registers an observe-only command, so honouring `--enforce` there would return a hook that never denies while reporting success.
- `verify --agent antigravity` is accepted. Install writes a baseline for it, and rejecting the agent whose registration was just recorded made the two commands disagree.
- The legacy bundle's preview text and module header said hooks do not fire and that the default install is a no-op. Both now describe it as the unverified legacy path and point at the supported one.

## Not in scope / gate

- **Linux re-verification before enforce is recommended for fleets.** #202 and this PR were measured on macOS only.
- The plugin-bundle mechanism was **not** re-probed on 1.1.x. The 1.1.7 changelog implies plugin hooks run again, but that is inference, not a measurement, so it stays behind `--force` rather than being trusted or deleted.
- Reading agy's `permissions.allow` is #209.

## Verification

Adversarial review found one P1 (shape coercion), two P2 (verify mismatch, `--force --enforce`), and one P4 (stale text); each is fixed and pinned by a test. `cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test --workspace` green. The test machine was restored afterwards — no `hooks.json` left behind, and only the state files this work created were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
